### PR TITLE
Add types to define graph structures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ edition = "2018"
 test = false
 
 [dependencies]
+either = "1.6"
 fxhash = "0.2"
+smallvec = { version="1.6", features=["union"] }
 
 [dev-dependencies]
 maplit = "1.0"

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -140,6 +140,12 @@ impl<T> Arena<T> {
     pub fn get(&self, handle: Handle<T>) -> &T {
         &self.items[handle.as_usize() - 1]
     }
+    ///
+    /// Dereferences a handle to an instance owned by this arena, returning a mutable reference to
+    /// it.
+    pub fn get_mut(&mut self, handle: Handle<T>) -> &mut T {
+        &mut self.items[handle.as_usize() - 1]
+    }
 
     /// Returns an iterator of all of the handles in this arena.  (Note that this iterator does not
     /// retain a reference to the arena!)

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -361,6 +361,12 @@ impl StackGraph {
         self.node_id_handles.unused_id(file)
     }
 
+    /// Returns an iterator of all of the nodes in the graph.  (Note that because we're only
+    /// returning _handles_, this iterator does not retain a reference to the `StackGraph`.)
+    pub fn iter_nodes(&self) -> impl Iterator<Item = Handle<Node>> {
+        self.nodes.iter_handles()
+    }
+
     fn add_node(&mut self, node_id: NodeID, node: Node) -> Option<Handle<Node>> {
         if let Some(_) = self.node_id_handles.handle_for_id(node_id) {
             return None;

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -377,6 +377,11 @@ impl StackGraph {
         self.nodes.iter_handles()
     }
 
+    /// Returns the handle to the node with a particular ID, if it exists.
+    pub fn node_for_id(&self, node_id: NodeID) -> Option<Handle<Node>> {
+        self.node_id_handles.try_handle_for_id(node_id)
+    }
+
     fn add_node(&mut self, node_id: NodeID, node: Node) -> Option<Handle<Node>> {
         if let Some(_) = self.node_id_handles.handle_for_id(node_id) {
             return None;
@@ -902,6 +907,15 @@ impl NodeIDHandles {
         NodeIDHandles {
             files: SupplementalArena::new(),
         }
+    }
+
+    fn try_handle_for_id(&self, node_id: NodeID) -> Option<Handle<Node>> {
+        let file_entry = self.files.get(node_id.file)?;
+        let node_index = node_id.local_id as usize;
+        if node_index >= file_entry.len() {
+            return None;
+        }
+        file_entry[node_index]
     }
 
     fn handle_for_id(&mut self, node_id: NodeID) -> Option<Handle<Node>> {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -200,6 +200,15 @@ impl StackGraph {
     }
 }
 
+impl StackGraph {
+    /// Returns an iterator over all of the handles of all of the files in this stack graph.  (Note
+    /// that because we're only returning _handles_, this iterator does not retain a reference to
+    /// the `StackGraph`.)
+    pub fn iter_files(&self) -> impl Iterator<Item = Handle<File>> + '_ {
+        self.files.iter_handles()
+    }
+}
+
 impl Display for File {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.name)

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -54,6 +54,7 @@
 use std::fmt::Display;
 use std::ops::Deref;
 use std::ops::Index;
+use std::ops::IndexMut;
 
 use either::Either;
 use fxhash::FxHashMap;
@@ -413,7 +414,14 @@ impl Index<Handle<Node>> for StackGraph {
     type Output = Node;
     #[inline(always)]
     fn index(&self, handle: Handle<Node>) -> &Node {
-        &self.nodes.get(handle)
+        self.nodes.get(handle)
+    }
+}
+
+impl IndexMut<Handle<Node>> for StackGraph {
+    #[inline(always)]
+    fn index_mut(&mut self, handle: Handle<Node>) -> &mut Node {
+        self.nodes.get_mut(handle)
     }
 }
 
@@ -867,7 +875,7 @@ impl StackGraph {
     pub fn resolve_unknown_node(&mut self, node: Node) -> Result<(), &Node> {
         let id = node.id().unwrap();
         let handle = self.node_id_handles.handle_for_id(id).unwrap();
-        let arena_node = self.nodes.get_mut(handle);
+        let arena_node = &mut self[handle];
         if !matches!(arena_node, Node::Unknown(_)) {
             return Err(arena_node);
         }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -328,6 +328,23 @@ impl Node {
         matches!(self, Node::Root(_))
     }
 
+    /// Returns this node's symbol, if it has one.  (_Pop symbol_, _pop scoped symbol_, _push
+    /// symbol_, and _push scoped symbol_ nodes have symbols.)
+    pub fn symbol(&self) -> Option<Handle<Symbol>> {
+        match self {
+            Node::DropScopes(_) => None,
+            Node::ExportedScope(_) => None,
+            Node::InternalScope(_) => None,
+            Node::JumpTo(_) => None,
+            Node::PushScopedSymbol(node) => Some(node.symbol),
+            Node::PushSymbol(node) => Some(node.symbol),
+            Node::PopScopedSymbol(node) => Some(node.symbol),
+            Node::PopSymbol(node) => Some(node.symbol),
+            Node::Root(_) => None,
+            Node::Unknown(_) => None,
+        }
+    }
+
     /// Returns the ID of this node.  Returns `None` for the singleton _root_ and _jump to scope_
     /// nodes, which don't have IDs.
     pub fn id(&self) -> Option<NodeID> {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -17,15 +17,51 @@
 //!
 //! [`Arena`]: ../arena/struct.Arena.html
 //! [`StackGraph`]: struct.StackGraph.html
+//!
+//! There are several different kinds of node that can appear in a stack graph.  As we search for a
+//! path representing a name binding, each kind of node has different rules for how it interacts
+//! with the symbol and scope stacks:
+//!
+//!   - the singleton [_root node_][`RootNode`], which allows name binding paths to cross between
+//!     files
+//!   - [_exported_][`ExportedScopeNode`] and [_internal_][`InternalScopeNode`] _scopes_, which
+//!     define the name binding structure within a single file
+//!   - [_push symbol_][`PushSymbolNode`] and [_push scoped symbol_][`PushScopedSymbolNode`] nodes,
+//!     which push onto the symbol stack new things for us to look for
+//!   - [_pop symbol_][`PopSymbolNode`] and [_pop scoped symbol_][`PopScopedSymbolNode`] nodes,
+//!     which pop things off the symbol stack once they've been found
+//!   - [_drop scopes_][`DropScopesNode`] and [_jump to scope_][`JumpToNode`] nodes, which
+//!     manipulate the scope stack
+//!
+//! [`DropScopesNode`]: struct.DropScopesNode.html
+//! [`ExportedScopeNode`]: struct.ExportedScopeNode.html
+//! [`InternalScopeNode`]: struct.InternalScopeNode.html
+//! [`JumpToNode`]: struct.JumpToNode.html
+//! [`PushScopedSymbolNode`]: struct.PushScopedSymbolNode.html
+//! [`PushSymbolNode`]: struct.PushSymbolNode.html
+//! [`PopScopedSymbolNode`]: struct.PopScopedSymbolNode.html
+//! [`PopSymbolNode`]: struct.PopSymbolNode.html
+//! [`RootNode`]: struct.RootNode.html
+//!
+//! All nodes except for the singleton _root node_ and _jump to scope_ node belong to
+//! [files][`File`].
+//!
+//! Nodes are connected via [edges][`Edge`].
+//!
+//! [`Edge`]: struct.Edge.html
+//! [`File`]: struct.File.html
 
 use std::fmt::Display;
 use std::ops::Deref;
 use std::ops::Index;
 
+use either::Either;
 use fxhash::FxHashMap;
+use smallvec::SmallVec;
 
 use crate::arena::Arena;
 use crate::arena::Handle;
+use crate::arena::SupplementalArena;
 
 //-------------------------------------------------------------------------------------------------
 // Symbols
@@ -131,6 +167,389 @@ impl Handle<Symbol> {
 }
 
 //-------------------------------------------------------------------------------------------------
+// Files
+
+/// A source file that we have extracted stack graph data from.
+///
+/// It's up to you to choose what names to use for your files, but they must be unique within a
+/// stack graph.  If you are analyzing files from the local filesystem, the file's path is a good
+/// choice.  If your files belong to packages or repositories, they should include the package or
+/// repository IDs to make sure that files in different packages or repositories don't clash with
+/// each other.
+pub struct File {
+    /// The name of this source file.
+    pub name: String,
+}
+
+impl StackGraph {
+    /// Adds a file to the stack graph, ensuring that there's only ever one file with a particular
+    /// name in the graph.
+    pub fn add_file<S: AsRef<str> + ?Sized>(&mut self, name: &S) -> Handle<File> {
+        let name = name.as_ref();
+        if let Some(handle) = self.file_handles.get(name) {
+            return *handle;
+        }
+        let name_value = name.to_string();
+        let file = File {
+            name: name_value.clone(),
+        };
+        let handle = self.files.add(file);
+        self.file_handles.insert(name_value, handle);
+        handle
+    }
+}
+
+impl Index<Handle<File>> for StackGraph {
+    type Output = File;
+    #[inline(always)]
+    fn index(&self, handle: Handle<File>) -> &File {
+        &self.files.get(handle)
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Nodes
+
+/// Uniquely identifies a node in a stack graph.
+///
+/// Each node (except for the _root node_ and _jump to scope_ node) lives in a file, and has a
+/// _local ID_ that must be unique within its file.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NodeID {
+    /// The file that the node comes from.
+    pub file: Handle<File>,
+    /// The unique identity of the node within its file.
+    pub local_id: u32,
+}
+
+/// A node in a stack graph.
+pub enum Node {
+    DropScopes(DropScopesNode),
+    ExportedScope(ExportedScopeNode),
+    InternalScope(InternalScopeNode),
+    JumpTo(JumpToNode),
+    PushScopedSymbol(PushScopedSymbolNode),
+    PushSymbol(PushSymbolNode),
+    PopScopedSymbol(PopScopedSymbolNode),
+    PopSymbol(PopSymbolNode),
+    Root(RootNode),
+}
+
+impl Node {
+    #[inline(always)]
+    pub fn is_definition(&self) -> bool {
+        match self {
+            Node::PopScopedSymbol(node) => node.is_definition,
+            Node::PopSymbol(node) => node.is_definition,
+            _ => false,
+        }
+    }
+
+    #[inline(always)]
+    pub fn is_reference(&self) -> bool {
+        match self {
+            Node::PushScopedSymbol(node) => node.is_reference,
+            Node::PushSymbol(node) => node.is_reference,
+            _ => false,
+        }
+    }
+
+    #[inline(always)]
+    pub fn is_jump_to(&self) -> bool {
+        matches!(self, Node::JumpTo(_))
+    }
+
+    #[inline(always)]
+    pub fn is_root(&self) -> bool {
+        matches!(self, Node::Root(_))
+    }
+}
+
+impl StackGraph {
+    /// Returns a handle to the stack graph's singleton _jump to scope_ node.
+    #[inline(always)]
+    pub fn jump_to_node(&self) -> Handle<Node> {
+        self.jump_to_node
+    }
+
+    /// Returns a handle to the stack graph's singleton _root node_.
+    #[inline(always)]
+    pub fn root_node(&self) -> Handle<Node> {
+        self.root_node
+    }
+
+    /// Returns an unused _local node ID_ for the given file.
+    pub fn new_node_id(&mut self, file: Handle<File>) -> NodeID {
+        self.node_id_handles.unused_id(file)
+    }
+
+    fn add_node(&mut self, node_id: NodeID, node: Node) -> Option<Handle<Node>> {
+        if let Some(_) = self.node_id_handles.handle_for_id(node_id) {
+            return None;
+        }
+        let handle = self.nodes.add(node);
+        self.node_id_handles.set_handle_for_id(node_id, handle);
+        Some(handle)
+    }
+}
+
+impl Index<Handle<Node>> for StackGraph {
+    type Output = Node;
+    #[inline(always)]
+    fn index(&self, handle: Handle<Node>) -> &Node {
+        &self.nodes.get(handle)
+    }
+}
+
+/// Removes everything from the current scope stack.
+pub struct DropScopesNode {
+    /// The unique identifier for this node.
+    pub id: NodeID,
+}
+
+impl From<DropScopesNode> for Node {
+    fn from(node: DropScopesNode) -> Node {
+        Node::DropScopes(node)
+    }
+}
+
+impl DropScopesNode {
+    /// Adds the node to a stack graph.
+    pub fn add_to_graph(self, graph: &mut StackGraph) -> Option<Handle<Node>> {
+        graph.add_node(self.id, self.into())
+    }
+}
+
+/// A node that can be referred to on the scope stack, which allows "jump to" nodes in any other
+/// part of the graph can jump back here.
+pub struct ExportedScopeNode {
+    /// The unique identifier for this node.
+    pub id: NodeID,
+}
+
+impl From<ExportedScopeNode> for Node {
+    fn from(node: ExportedScopeNode) -> Node {
+        Node::ExportedScope(node)
+    }
+}
+
+impl ExportedScopeNode {
+    /// Adds the node to a stack graph.
+    pub fn add_to_graph(self, graph: &mut StackGraph) -> Option<Handle<Node>> {
+        graph.add_node(self.id, self.into())
+    }
+}
+
+/// A node internal to a single file.  This node has no effect on the symbol or scope stacks;
+/// it's just used to add structure to the graph.
+pub struct InternalScopeNode {
+    /// The unique identifier for this node.
+    pub id: NodeID,
+}
+
+impl From<InternalScopeNode> for Node {
+    fn from(node: InternalScopeNode) -> Node {
+        Node::InternalScope(node)
+    }
+}
+
+impl InternalScopeNode {
+    /// Adds the node to a stack graph.
+    pub fn add_to_graph(self, graph: &mut StackGraph) -> Option<Handle<Node>> {
+        graph.add_node(self.id, self.into())
+    }
+}
+
+/// The singleton "jump to" node, which allows a name binding path to jump back to another part of
+/// the graph.
+pub struct JumpToNode;
+
+impl From<JumpToNode> for Node {
+    fn from(node: JumpToNode) -> Node {
+        Node::JumpTo(node)
+    }
+}
+
+/// Pops a scoped symbol from the symbol stack.  If the top of the symbol stack doesn't match the
+/// requested symbol, or if the top of the symbol stack doesn't have an attached scope list, then
+/// the path is not allowed to enter this node.
+pub struct PopScopedSymbolNode {
+    /// The unique identifier for this node.
+    pub id: NodeID,
+    /// The symbol to pop off the symbol stack.
+    pub symbol: Handle<Symbol>,
+    /// Whether this node represents a reference in the source language.
+    pub is_definition: bool,
+}
+
+impl From<PopScopedSymbolNode> for Node {
+    fn from(node: PopScopedSymbolNode) -> Node {
+        Node::PopScopedSymbol(node)
+    }
+}
+
+impl PopScopedSymbolNode {
+    /// Adds the node to a stack graph.
+    pub fn add_to_graph(self, graph: &mut StackGraph) -> Option<Handle<Node>> {
+        graph.add_node(self.id, self.into())
+    }
+}
+
+/// Pops a symbol from the symbol stack.  If the top of the symbol stack doesn't match the
+/// requested symbol, then the path is not allowed to enter this node.
+pub struct PopSymbolNode {
+    /// The unique identifier for this node.
+    pub id: NodeID,
+    /// The symbol to pop off the symbol stack.
+    pub symbol: Handle<Symbol>,
+    /// Whether this node represents a reference in the source language.
+    pub is_definition: bool,
+}
+
+impl From<PopSymbolNode> for Node {
+    fn from(node: PopSymbolNode) -> Node {
+        Node::PopSymbol(node)
+    }
+}
+
+impl PopSymbolNode {
+    /// Adds the node to a stack graph.
+    pub fn add_to_graph(self, graph: &mut StackGraph) -> Option<Handle<Node>> {
+        graph.add_node(self.id, self.into())
+    }
+}
+
+/// Pushes a scoped symbol onto the symbol stack.
+pub struct PushScopedSymbolNode {
+    /// The unique identifier for this node.
+    pub id: NodeID,
+    /// The symbol to push onto the symbol stack.
+    pub symbol: Handle<Symbol>,
+    /// The exported scope node that should be attached to the scoped symbol.  The Handle<Node> must
+    /// refer to an exported scope node.
+    pub scope: Handle<Node>,
+    /// Whether this node represents a reference in the source language.
+    pub is_reference: bool,
+}
+
+impl From<PushScopedSymbolNode> for Node {
+    fn from(node: PushScopedSymbolNode) -> Node {
+        Node::PushScopedSymbol(node)
+    }
+}
+
+impl PushScopedSymbolNode {
+    /// Adds the node to a stack graph.
+    pub fn add_to_graph(self, graph: &mut StackGraph) -> Option<Handle<Node>> {
+        graph.add_node(self.id, self.into())
+    }
+}
+
+/// Pushes a symbol onto the symbol stack.
+pub struct PushSymbolNode {
+    /// The unique identifier for this node.
+    pub id: NodeID,
+    /// The symbol to push onto the symbol stack.
+    pub symbol: Handle<Symbol>,
+    /// Whether this node represents a reference in the source language.
+    pub is_reference: bool,
+}
+
+impl From<PushSymbolNode> for Node {
+    fn from(node: PushSymbolNode) -> Node {
+        Node::PushSymbol(node)
+    }
+}
+
+impl PushSymbolNode {
+    /// Adds the node to a stack graph.
+    pub fn add_to_graph(self, graph: &mut StackGraph) -> Option<Handle<Node>> {
+        graph.add_node(self.id, self.into())
+    }
+}
+
+/// The singleton root node, which allows a name binding path to cross between files.
+pub struct RootNode;
+
+impl From<RootNode> for Node {
+    fn from(node: RootNode) -> Node {
+        Node::Root(node)
+    }
+}
+
+struct NodeIDHandles {
+    files: SupplementalArena<File, Vec<Option<Handle<Node>>>>,
+}
+
+impl NodeIDHandles {
+    fn new() -> NodeIDHandles {
+        NodeIDHandles {
+            files: SupplementalArena::new(),
+        }
+    }
+
+    fn handle_for_id(&mut self, node_id: NodeID) -> Option<Handle<Node>> {
+        let file_entry = &mut self.files[node_id.file];
+        let node_index = node_id.local_id as usize;
+        if node_index >= file_entry.len() {
+            file_entry.resize(node_index + 1, None);
+        }
+        file_entry[node_index]
+    }
+
+    fn set_handle_for_id(&mut self, node_id: NodeID, handle: Handle<Node>) {
+        let file_entry = &mut self.files[node_id.file];
+        let node_index = node_id.local_id as usize;
+        file_entry[node_index] = Some(handle);
+    }
+
+    fn unused_id(&mut self, file: Handle<File>) -> NodeID {
+        let local_id = self
+            .files
+            .get(file)
+            .map(|file_entry| file_entry.len() as u32)
+            .unwrap_or(0);
+        NodeID { file, local_id }
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Edges
+
+/// Connects two nodes in a stack graph.
+///
+/// These edges provide the basic graph connectivity that allow us to search for name binding paths
+/// in a stack graph.  (Though not all sequence of edges is a well-formed name binding: the nodes
+/// that you encounter along the path must also satisfy all of the rules for maintaining correct
+/// symbol and scope stacks.)
+#[derive(Clone, Copy, Debug)]
+pub struct Edge {
+    pub source: Handle<Node>,
+    pub sink: Handle<Node>,
+}
+
+impl StackGraph {
+    /// Adds a new edge to the stack graph.
+    pub fn add_edge(&mut self, edge: Edge) {
+        let edges = &mut self.outgoing_edges[edge.source];
+        if let Err(index) = edges.binary_search(&edge.sink) {
+            edges.insert(index, edge.sink);
+        }
+    }
+
+    /// Returns an iterator of all of the edges that begin at a particular source node.
+    pub fn outgoing_edges(&self, source: Handle<Node>) -> impl Iterator<Item = Edge> + '_ {
+        match self.outgoing_edges.get(source) {
+            Some(edges) => Either::Right(edges.iter().map(move |sink| Edge {
+                source,
+                sink: *sink,
+            })),
+            None => Either::Left(std::iter::empty()),
+        }
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
 // Stack graphs
 
 /// Contains all of the nodes and edges that make up a stack graph.
@@ -140,14 +559,32 @@ pub struct StackGraph {
     // https://matklad.github.io/2020/03/22/fast-simple-rust-interner.html
     symbols: Arena<Symbol>,
     symbol_handles: FxHashMap<String, Handle<Symbol>>,
+    files: Arena<File>,
+    file_handles: FxHashMap<String, Handle<File>>,
+    nodes: Arena<Node>,
+    node_id_handles: NodeIDHandles,
+    jump_to_node: Handle<Node>,
+    root_node: Handle<Node>,
+    outgoing_edges: SupplementalArena<Node, SmallVec<[Handle<Node>; 8]>>,
 }
 
 impl StackGraph {
     /// Creates a new, initially empty stack graph.
     pub fn new() -> StackGraph {
+        let mut nodes = Arena::new();
+        let root_node = nodes.add(RootNode.into());
+        let jump_to_node = nodes.add(JumpToNode.into());
+
         StackGraph {
             symbols: Arena::new(),
             symbol_handles: FxHashMap::default(),
+            files: Arena::new(),
+            file_handles: FxHashMap::default(),
+            nodes,
+            node_id_handles: NodeIDHandles::new(),
+            jump_to_node,
+            root_node,
+            outgoing_edges: SupplementalArena::new(),
         }
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -921,7 +921,7 @@ impl NodeIDHandles {
 /// in a stack graph.  (Though not all sequence of edges is a well-formed name binding: the nodes
 /// that you encounter along the path must also satisfy all of the rules for maintaining correct
 /// symbol and scope stacks.)
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Edge {
     pub source: Handle<Node>,
     pub sink: Handle<Node>,
@@ -933,6 +933,14 @@ impl StackGraph {
         let edges = &mut self.outgoing_edges[edge.source];
         if let Err(index) = edges.binary_search(&edge.sink) {
             edges.insert(index, edge.sink);
+        }
+    }
+
+    /// Removes an edge from the stack graph.
+    pub fn remove_edge(&mut self, edge: Edge) {
+        let edges = &mut self.outgoing_edges[edge.source];
+        if let Ok(index) = edges.binary_search(&edge.sink) {
+            edges.remove(index);
         }
     }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -345,16 +345,11 @@ impl Node {
     /// symbol_, and _push scoped symbol_ nodes have symbols.)
     pub fn symbol(&self) -> Option<Handle<Symbol>> {
         match self {
-            Node::DropScopes(_) => None,
-            Node::ExportedScope(_) => None,
-            Node::InternalScope(_) => None,
-            Node::JumpTo(_) => None,
             Node::PushScopedSymbol(node) => Some(node.symbol),
             Node::PushSymbol(node) => Some(node.symbol),
             Node::PopScopedSymbol(node) => Some(node.symbol),
             Node::PopSymbol(node) => Some(node.symbol),
-            Node::Root(_) => None,
-            Node::Unknown(_) => None,
+            _ => None,
         }
     }
 
@@ -365,13 +360,12 @@ impl Node {
             Node::DropScopes(node) => Some(node.id),
             Node::ExportedScope(node) => Some(node.id),
             Node::InternalScope(node) => Some(node.id),
-            Node::JumpTo(_) => None,
             Node::PushScopedSymbol(node) => Some(node.id),
             Node::PushSymbol(node) => Some(node.id),
             Node::PopScopedSymbol(node) => Some(node.id),
             Node::PopSymbol(node) => Some(node.id),
-            Node::Root(_) => None,
             Node::Unknown(node) => Some(node.id),
+            _ => None,
         }
     }
 

--- a/tests/it/can_create_graph.rs
+++ b/tests/it/can_create_graph.rs
@@ -5,8 +5,14 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-pub mod test_graphs;
+use crate::test_graphs;
 
-mod arena;
-mod can_create_graph;
-mod graph;
+#[test]
+fn class_field_through_function_parameter() {
+    let _ = test_graphs::class_field_through_function_parameter::new();
+}
+
+#[test]
+fn sequenced_import_star() {
+    let _ = test_graphs::sequenced_import_star::new();
+}

--- a/tests/it/graph.rs
+++ b/tests/it/graph.rs
@@ -72,7 +72,7 @@ fn can_display_symbols() {
 #[test]
 fn can_iterate_nodes() {
     let mut graph = StackGraph::new();
-    let file = graph.add_file("test.py");
+    let file = graph.get_or_create_file("test.py");
     let h1 = graph.internal_scope(file, 0);
     let h2 = graph.internal_scope(file, 1);
     let h3 = graph.internal_scope(file, 2);
@@ -86,7 +86,7 @@ fn can_iterate_nodes() {
 #[test]
 fn can_create_and_resolve_unknown_nodes() {
     let mut graph = StackGraph::new();
-    let file = graph.add_file("test.py");
+    let file = graph.get_or_create_file("test.py");
     let id = graph.new_node_id(file);
     let unknown = UnknownNode { id };
     let _handle = unknown.add_to_graph(&mut graph);
@@ -102,7 +102,7 @@ fn can_create_and_resolve_unknown_nodes() {
 #[test]
 fn can_add_and_remove_edges() {
     let mut graph = StackGraph::new();
-    let file = graph.add_file("test.py");
+    let file = graph.get_or_create_file("test.py");
     let h1 = graph.internal_scope(file, 0);
     let h2 = graph.internal_scope(file, 1);
     let h3 = graph.internal_scope(file, 2);

--- a/tests/it/graph.rs
+++ b/tests/it/graph.rs
@@ -8,6 +8,7 @@
 use std::collections::HashSet;
 
 use maplit::hashset;
+use stack_graphs::graph::Edge;
 use stack_graphs::graph::ExportedScopeNode;
 use stack_graphs::graph::InternalScopeNode;
 use stack_graphs::graph::Node;
@@ -96,4 +97,44 @@ fn can_create_and_resolve_unknown_nodes() {
         graph.resolve_unknown_node(conflict.into()),
         Err(Node::InternalScope(_))
     ));
+}
+
+#[test]
+fn can_add_and_remove_edges() {
+    let mut graph = StackGraph::new();
+    let file = graph.add_file("test.py");
+    let h1 = graph.internal_scope(file, 0);
+    let h2 = graph.internal_scope(file, 1);
+    let h3 = graph.internal_scope(file, 2);
+    let h4 = graph.internal_scope(file, 3);
+    graph.add_edge(Edge {
+        source: h1,
+        sink: h2,
+    });
+    graph.add_edge(Edge {
+        source: h1,
+        sink: h3,
+    });
+    graph.add_edge(Edge {
+        source: h1,
+        sink: h4,
+    });
+    assert_eq!(
+        graph
+            .outgoing_edges(h1)
+            .map(|edge| edge.sink)
+            .collect::<HashSet<_>>(),
+        hashset! { h2, h3, h4 }
+    );
+    graph.remove_edge(Edge {
+        source: h1,
+        sink: h3,
+    });
+    assert_eq!(
+        graph
+            .outgoing_edges(h1)
+            .map(|edge| edge.sink)
+            .collect::<HashSet<_>>(),
+        hashset! { h2, h4 }
+    );
 }

--- a/tests/it/graph.rs
+++ b/tests/it/graph.rs
@@ -14,6 +14,8 @@ use stack_graphs::graph::Node;
 use stack_graphs::graph::StackGraph;
 use stack_graphs::graph::UnknownNode;
 
+use crate::test_graphs::CreateStackGraph;
+
 #[test]
 fn can_create_symbols() {
     let mut graph = StackGraph::new();
@@ -64,6 +66,20 @@ fn can_display_symbols() {
         .collect::<Vec<_>>();
     symbols.sort();
     assert_eq!(symbols, vec!["a", "b", "c"]);
+}
+
+#[test]
+fn can_iterate_nodes() {
+    let mut graph = StackGraph::new();
+    let file = graph.add_file("test.py");
+    let h1 = graph.internal_scope(file, 0);
+    let h2 = graph.internal_scope(file, 1);
+    let h3 = graph.internal_scope(file, 2);
+    let handles = graph.iter_nodes().collect::<HashSet<_>>();
+    assert_eq!(
+        handles,
+        hashset! {graph.root_node(), graph.jump_to_node(), h1, h2, h3}
+    );
 }
 
 #[test]

--- a/tests/it/graph.rs
+++ b/tests/it/graph.rs
@@ -8,7 +8,11 @@
 use std::collections::HashSet;
 
 use maplit::hashset;
+use stack_graphs::graph::ExportedScopeNode;
+use stack_graphs::graph::InternalScopeNode;
+use stack_graphs::graph::Node;
 use stack_graphs::graph::StackGraph;
+use stack_graphs::graph::UnknownNode;
 
 #[test]
 fn can_create_symbols() {
@@ -60,4 +64,20 @@ fn can_display_symbols() {
         .collect::<Vec<_>>();
     symbols.sort();
     assert_eq!(symbols, vec!["a", "b", "c"]);
+}
+
+#[test]
+fn can_create_and_resolve_unknown_nodes() {
+    let mut graph = StackGraph::new();
+    let file = graph.add_file("test.py");
+    let id = graph.new_node_id(file);
+    let unknown = UnknownNode { id };
+    let _handle = unknown.add_to_graph(&mut graph);
+    let resolved = InternalScopeNode { id };
+    assert!(graph.resolve_unknown_node(resolved.into()).is_ok());
+    let conflict = ExportedScopeNode { id };
+    assert!(matches!(
+        graph.resolve_unknown_node(conflict.into()),
+        Err(Node::InternalScope(_))
+    ));
 }

--- a/tests/it/test_graphs/class_field_through_function_parameter.rs
+++ b/tests/it/test_graphs/class_field_through_function_parameter.rs
@@ -67,7 +67,7 @@ pub fn new() -> ClassFieldThroughFunctionParameter {
     let sym_foo = graph.add_symbol("foo");
     let sym_bar = graph.add_symbol("bar");
 
-    let main_file = graph.add_file("main.py");
+    let main_file = graph.get_or_create_file("main.py");
     let main = graph.definition(main_file, 0, sym_main);
     let main_dot_1 = graph.pop_symbol(main_file, 1, sym_dot);
     let main_bottom_2 = graph.internal_scope(main_file, 2);
@@ -107,7 +107,7 @@ pub fn new() -> ClassFieldThroughFunctionParameter {
     graph.edge(main_a, root);
     graph.edge(main_5, main_top_6);
 
-    let a_file = graph.add_file("a.py");
+    let a_file = graph.get_or_create_file("a.py");
     let a = graph.definition(a_file, 0, sym_a);
     let a_dot_1 = graph.pop_symbol(a_file, 1, sym_dot);
     let a_bottom_2 = graph.internal_scope(a_file, 2);
@@ -148,7 +148,7 @@ pub fn new() -> ClassFieldThroughFunctionParameter {
     graph.edge(a_x_17, jump_to);
     graph.edge(a_3, a_top_4);
 
-    let b_file = graph.add_file("b.py");
+    let b_file = graph.get_or_create_file("b.py");
     let b = graph.definition(b_file, 0, sym_b);
     let b_dot_1 = graph.pop_symbol(b_file, 1, sym_dot);
     let b_bottom_2 = graph.internal_scope(b_file, 2);

--- a/tests/it/test_graphs/class_field_through_function_parameter.rs
+++ b/tests/it/test_graphs/class_field_through_function_parameter.rs
@@ -1,0 +1,196 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use stack_graphs::arena::Handle;
+use stack_graphs::graph::*;
+
+use crate::test_graphs::CreateStackGraph;
+
+/// A stack graph containing:
+///
+/// ``` python
+/// # main.py
+/// from a import *
+/// from b import *
+/// print(foo(A).bar)
+/// ```
+///
+/// ``` python
+/// # a.py
+/// def foo(x):
+///   return x
+/// ```
+///
+/// ``` python
+/// # b.py
+/// class A:
+///   bar = 1
+/// ```
+#[allow(non_snake_case)]
+pub struct ClassFieldThroughFunctionParameter {
+    pub graph: StackGraph,
+    // Interesting nodes in main.py
+    pub main: Handle<Node>,
+    pub main_A: Handle<Node>,
+    pub main_a: Handle<Node>,
+    pub main_b: Handle<Node>,
+    pub main_bar: Handle<Node>,
+    pub main_foo: Handle<Node>,
+    // Interesting nodes in a.py
+    pub a: Handle<Node>,
+    pub a_x_def: Handle<Node>,
+    pub a_x_ref: Handle<Node>,
+    pub a_foo: Handle<Node>,
+    // Interesting nodes in b.py
+    pub b: Handle<Node>,
+    pub b_A: Handle<Node>,
+    pub b_bar: Handle<Node>,
+}
+
+#[allow(non_snake_case)]
+pub fn new() -> ClassFieldThroughFunctionParameter {
+    let mut graph = StackGraph::new();
+    let root = graph.root_node();
+    let jump_to = graph.jump_to_node();
+    let sym_call = graph.add_symbol("()");
+    let sym_dot = graph.add_symbol(".");
+    let sym_zero = graph.add_symbol("0");
+    let sym_main = graph.add_symbol("__main__");
+    let sym_A = graph.add_symbol("A");
+    let sym_a = graph.add_symbol("a");
+    let sym_b = graph.add_symbol("b");
+    let sym_x = graph.add_symbol("x");
+    let sym_foo = graph.add_symbol("foo");
+    let sym_bar = graph.add_symbol("bar");
+
+    let main_file = graph.add_file("main.py");
+    let main = graph.definition(main_file, 0, sym_main);
+    let main_dot_1 = graph.pop_symbol(main_file, 1, sym_dot);
+    let main_bottom_2 = graph.internal_scope(main_file, 2);
+    let main_3 = graph.internal_scope(main_file, 3);
+    let main_4 = graph.internal_scope(main_file, 4);
+    let main_5 = graph.internal_scope(main_file, 5);
+    let main_top_6 = graph.internal_scope(main_file, 6);
+    let main_exported = graph.exported_scope(main_file, 7);
+    let main_zero_8 = graph.pop_symbol(main_file, 8, sym_zero);
+    let main_A = graph.reference(main_file, 9, sym_A);
+    let main_bar = graph.reference(main_file, 10, sym_bar);
+    let main_dot_11 = graph.push_symbol(main_file, 11, sym_dot);
+    let main_call_12 = graph.push_scoped_symbol(main_file, 12, sym_call, main_exported);
+    let main_foo = graph.reference(main_file, 13, sym_foo);
+    let main_dot_14 = graph.push_symbol(main_file, 14, sym_dot);
+    let main_b = graph.reference(main_file, 15, sym_b);
+    let main_dot_16 = graph.push_symbol(main_file, 16, sym_dot);
+    let main_a = graph.reference(main_file, 17, sym_a);
+    graph.edge(root, main);
+    graph.edge(main, main_dot_1);
+    graph.edge(main_dot_1, main_bottom_2);
+    graph.edge(main_bottom_2, main_3);
+    graph.edge(main_exported, main_zero_8);
+    graph.edge(main_zero_8, main_A);
+    graph.edge(main_A, main_3);
+    graph.edge(main_bar, main_dot_11);
+    graph.edge(main_dot_11, main_call_12);
+    graph.edge(main_call_12, main_foo);
+    graph.edge(main_foo, main_3);
+    graph.edge(main_3, main_4);
+    graph.edge(main_4, main_dot_14);
+    graph.edge(main_dot_14, main_b);
+    graph.edge(main_b, root);
+    graph.edge(main_4, main_5);
+    graph.edge(main_5, main_dot_16);
+    graph.edge(main_dot_16, main_a);
+    graph.edge(main_a, root);
+    graph.edge(main_5, main_top_6);
+
+    let a_file = graph.add_file("a.py");
+    let a = graph.definition(a_file, 0, sym_a);
+    let a_dot_1 = graph.pop_symbol(a_file, 1, sym_dot);
+    let a_bottom_2 = graph.internal_scope(a_file, 2);
+    let a_3 = graph.internal_scope(a_file, 3);
+    let a_top_4 = graph.internal_scope(a_file, 4);
+    let a_foo = graph.definition(a_file, 5, sym_foo);
+    let a_call_6 = graph.pop_scoped_symbol(a_file, 6, sym_call);
+    let a_return_7 = graph.internal_scope(a_file, 7);
+    let a_x_ref = graph.reference(a_file, 8, sym_x);
+    let a_params_9 = graph.internal_scope(a_file, 9);
+    let a_drop_10 = graph.drop_scopes(a_file, 10);
+    let a_lexical_11 = graph.internal_scope(a_file, 11);
+    let a_formals_12 = graph.internal_scope(a_file, 12);
+    let a_drop_13 = graph.drop_scopes(a_file, 13);
+    let a_x_def = graph.definition(a_file, 14, sym_x);
+    let a_x_15 = graph.pop_symbol(a_file, 15, sym_x);
+    let a_zero_16 = graph.push_symbol(a_file, 16, sym_zero);
+    let a_x_17 = graph.push_symbol(a_file, 17, sym_x);
+    graph.edge(root, a);
+    graph.edge(a, a_dot_1);
+    graph.edge(a_dot_1, a_bottom_2);
+    graph.edge(a_bottom_2, a_3);
+    graph.edge(a_3, a_foo);
+    graph.edge(a_foo, a_call_6);
+    graph.edge(a_call_6, a_return_7);
+    graph.edge(a_return_7, a_x_ref);
+    graph.edge(a_x_ref, a_params_9);
+    graph.edge(a_params_9, a_drop_10);
+    graph.edge(a_drop_10, a_lexical_11);
+    graph.edge(a_lexical_11, a_bottom_2);
+    graph.edge(a_params_9, a_formals_12);
+    graph.edge(a_formals_12, a_drop_13);
+    graph.edge(a_drop_13, a_x_def);
+    graph.edge(a_formals_12, a_x_15);
+    graph.edge(a_x_15, a_zero_16);
+    graph.edge(a_zero_16, jump_to);
+    graph.edge(a_x_15, a_x_17);
+    graph.edge(a_x_17, jump_to);
+    graph.edge(a_3, a_top_4);
+
+    let b_file = graph.add_file("b.py");
+    let b = graph.definition(b_file, 0, sym_b);
+    let b_dot_1 = graph.pop_symbol(b_file, 1, sym_dot);
+    let b_bottom_2 = graph.internal_scope(b_file, 2);
+    let b_3 = graph.internal_scope(b_file, 3);
+    let b_top_4 = graph.internal_scope(b_file, 4);
+    let b_A = graph.definition(b_file, 5, sym_A);
+    let b_dot_6 = graph.pop_symbol(b_file, 6, sym_dot);
+    let b_class_members_7 = graph.internal_scope(b_file, 7);
+    let b_bar = graph.definition(b_file, 8, sym_bar);
+    let b_call_9 = graph.pop_scoped_symbol(b_file, 9, sym_call);
+    let b_self_10 = graph.internal_scope(b_file, 10);
+    let b_dot_11 = graph.pop_symbol(b_file, 11, sym_dot);
+    let b_instance_members_12 = graph.internal_scope(b_file, 12);
+    graph.edge(root, b);
+    graph.edge(b, b_dot_1);
+    graph.edge(b_dot_1, b_bottom_2);
+    graph.edge(b_bottom_2, b_3);
+    graph.edge(b_3, b_A);
+    graph.edge(b_A, b_dot_6);
+    graph.edge(b_dot_6, b_class_members_7);
+    graph.edge(b_class_members_7, b_bar);
+    graph.edge(b_A, b_call_9);
+    graph.edge(b_call_9, b_self_10);
+    graph.edge(b_self_10, b_dot_11);
+    graph.edge(b_dot_11, b_instance_members_12);
+    graph.edge(b_instance_members_12, b_class_members_7);
+    graph.edge(b_3, b_top_4);
+
+    ClassFieldThroughFunctionParameter {
+        graph,
+        main,
+        main_A,
+        main_a,
+        main_b,
+        main_bar,
+        main_foo,
+        a,
+        a_x_def,
+        a_x_ref,
+        a_foo,
+        b,
+        b_A,
+        b_bar,
+    }
+}

--- a/tests/it/test_graphs/mod.rs
+++ b/tests/it/test_graphs/mod.rs
@@ -14,7 +14,7 @@ pub mod class_field_through_function_parameter;
 pub mod sequenced_import_star;
 
 /// An extension trait that makes it a bit easier to add stuff to our test stack graphs.
-trait CreateStackGraph {
+pub trait CreateStackGraph {
     fn definition(
         &mut self,
         file: Handle<File>,

--- a/tests/it/test_graphs/mod.rs
+++ b/tests/it/test_graphs/mod.rs
@@ -1,0 +1,182 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! Contains several useful stack graphs that can be used in test cases.
+
+use stack_graphs::arena::Handle;
+use stack_graphs::graph::*;
+
+pub mod class_field_through_function_parameter;
+pub mod sequenced_import_star;
+
+/// An extension trait that makes it a bit easier to add stuff to our test stack graphs.
+trait CreateStackGraph {
+    fn definition(
+        &mut self,
+        file: Handle<File>,
+        local_id: u32,
+        symbol: Handle<Symbol>,
+    ) -> Handle<Node>;
+
+    fn drop_scopes(&mut self, file: Handle<File>, local_id: u32) -> Handle<Node>;
+
+    fn edge(&mut self, source: Handle<Node>, sink: Handle<Node>);
+
+    fn exported_scope(&mut self, file: Handle<File>, local_id: u32) -> Handle<Node>;
+
+    fn internal_scope(&mut self, file: Handle<File>, local_id: u32) -> Handle<Node>;
+
+    fn pop_scoped_symbol(
+        &mut self,
+        file: Handle<File>,
+        local_id: u32,
+        symbol: Handle<Symbol>,
+    ) -> Handle<Node>;
+
+    fn pop_symbol(
+        &mut self,
+        file: Handle<File>,
+        local_id: u32,
+        symbol: Handle<Symbol>,
+    ) -> Handle<Node>;
+
+    fn push_scoped_symbol(
+        &mut self,
+        file: Handle<File>,
+        local_id: u32,
+        symbol: Handle<Symbol>,
+        scope: Handle<Node>,
+    ) -> Handle<Node>;
+
+    fn push_symbol(
+        &mut self,
+        file: Handle<File>,
+        local_id: u32,
+        symbol: Handle<Symbol>,
+    ) -> Handle<Node>;
+
+    fn reference(
+        &mut self,
+        file: Handle<File>,
+        local_id: u32,
+        symbol: Handle<Symbol>,
+    ) -> Handle<Node>;
+}
+
+impl CreateStackGraph for StackGraph {
+    fn definition(
+        &mut self,
+        file: Handle<File>,
+        local_id: u32,
+        symbol: Handle<Symbol>,
+    ) -> Handle<Node> {
+        let node = PopSymbolNode {
+            id: NodeID { file, local_id },
+            symbol,
+            is_definition: true,
+        };
+        node.add_to_graph(self).expect("Duplicate node ID")
+    }
+
+    fn drop_scopes(&mut self, file: Handle<File>, local_id: u32) -> Handle<Node> {
+        let node = DropScopesNode {
+            id: NodeID { file, local_id },
+        };
+        node.add_to_graph(self).expect("Duplicate node ID")
+    }
+
+    fn edge(&mut self, source: Handle<Node>, sink: Handle<Node>) {
+        let edge = Edge { source, sink };
+        self.add_edge(edge);
+    }
+
+    fn exported_scope(&mut self, file: Handle<File>, local_id: u32) -> Handle<Node> {
+        let node = ExportedScopeNode {
+            id: NodeID { file, local_id },
+        };
+        node.add_to_graph(self).expect("Duplicate node ID")
+    }
+
+    fn internal_scope(&mut self, file: Handle<File>, local_id: u32) -> Handle<Node> {
+        let node = InternalScopeNode {
+            id: NodeID { file, local_id },
+        };
+        node.add_to_graph(self).expect("Duplicate node ID")
+    }
+
+    fn pop_scoped_symbol(
+        &mut self,
+        file: Handle<File>,
+        local_id: u32,
+        symbol: Handle<Symbol>,
+    ) -> Handle<Node> {
+        let node = PopScopedSymbolNode {
+            id: NodeID { file, local_id },
+            symbol,
+            is_definition: false,
+        };
+        node.add_to_graph(self).expect("Duplicate node ID")
+    }
+
+    fn pop_symbol(
+        &mut self,
+        file: Handle<File>,
+        local_id: u32,
+        symbol: Handle<Symbol>,
+    ) -> Handle<Node> {
+        let node = PopSymbolNode {
+            id: NodeID { file, local_id },
+            symbol,
+            is_definition: false,
+        };
+        node.add_to_graph(self).expect("Duplicate node ID")
+    }
+
+    fn push_scoped_symbol(
+        &mut self,
+        file: Handle<File>,
+        local_id: u32,
+        symbol: Handle<Symbol>,
+        scope: Handle<Node>,
+    ) -> Handle<Node> {
+        let node = PushScopedSymbolNode {
+            id: NodeID { file, local_id },
+            symbol,
+            scope,
+            is_reference: false,
+        };
+        node.add_to_graph(self).expect("Duplicate node ID")
+    }
+
+    fn push_symbol(
+        &mut self,
+        file: Handle<File>,
+        local_id: u32,
+        symbol: Handle<Symbol>,
+    ) -> Handle<Node> {
+        let node = PushSymbolNode {
+            id: NodeID { file, local_id },
+            symbol,
+            is_reference: false,
+        };
+        node.add_to_graph(self).expect("Duplicate node ID")
+    }
+
+    fn reference(
+        &mut self,
+        file: Handle<File>,
+        local_id: u32,
+        symbol: Handle<Symbol>,
+    ) -> Handle<Node> {
+        let node = PushSymbolNode {
+            id: NodeID { file, local_id },
+            symbol,
+            is_reference: true,
+        };
+        node.add_to_graph(self).expect("Duplicate node ID")
+    }
+}

--- a/tests/it/test_graphs/sequenced_import_star.rs
+++ b/tests/it/test_graphs/sequenced_import_star.rs
@@ -50,7 +50,7 @@ pub fn new() -> SequencedImportStar {
     let sym_b = graph.add_symbol("b");
     let sym_foo = graph.add_symbol("foo");
 
-    let main_file = graph.add_file("main.py");
+    let main_file = graph.get_or_create_file("main.py");
     let main = graph.definition(main_file, 0, sym_main);
     let main_dot_1 = graph.pop_symbol(main_file, 1, sym_dot);
     let main_bottom_2 = graph.internal_scope(main_file, 2);
@@ -71,7 +71,7 @@ pub fn new() -> SequencedImportStar {
     graph.edge(main_a, root);
     graph.edge(main_4, main_top_5);
 
-    let a_file = graph.add_file("a.py");
+    let a_file = graph.get_or_create_file("a.py");
     let a = graph.definition(a_file, 0, sym_a);
     let a_dot_1 = graph.pop_symbol(a_file, 1, sym_dot);
     let a_bottom_2 = graph.internal_scope(a_file, 2);
@@ -88,7 +88,7 @@ pub fn new() -> SequencedImportStar {
     graph.edge(a_b, root);
     graph.edge(a_3, a_top_4);
 
-    let b_file = graph.add_file("b.py");
+    let b_file = graph.get_or_create_file("b.py");
     let b = graph.definition(b_file, 0, sym_b);
     let b_dot_1 = graph.pop_symbol(b_file, 1, sym_dot);
     let b_bottom_2 = graph.internal_scope(b_file, 2);

--- a/tests/it/test_graphs/sequenced_import_star.rs
+++ b/tests/it/test_graphs/sequenced_import_star.rs
@@ -1,0 +1,115 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use stack_graphs::arena::Handle;
+use stack_graphs::graph::*;
+
+use crate::test_graphs::CreateStackGraph;
+
+/// A stack graph containing:
+///
+/// ``` python
+/// # main.py
+/// from a import *
+/// print(foo)
+/// ```
+///
+/// ``` python
+/// # a.py
+/// from b import *
+/// ```
+///
+/// ``` python
+/// # b.py
+/// foo = 2
+/// ```
+pub struct SequencedImportStar {
+    pub graph: StackGraph,
+    // Interesting nodes in main.py
+    pub main: Handle<Node>,
+    pub main_a: Handle<Node>,
+    pub main_foo: Handle<Node>,
+    // Interesting nodes in a.py
+    pub a: Handle<Node>,
+    pub a_b: Handle<Node>,
+    // Interesting nodes in b.py
+    pub b: Handle<Node>,
+    pub b_foo: Handle<Node>,
+}
+
+pub fn new() -> SequencedImportStar {
+    let mut graph = StackGraph::new();
+    let root = graph.root_node();
+    let sym_dot = graph.add_symbol(".");
+    let sym_main = graph.add_symbol("__main__");
+    let sym_a = graph.add_symbol("a");
+    let sym_b = graph.add_symbol("b");
+    let sym_foo = graph.add_symbol("foo");
+
+    let main_file = graph.add_file("main.py");
+    let main = graph.definition(main_file, 0, sym_main);
+    let main_dot_1 = graph.pop_symbol(main_file, 1, sym_dot);
+    let main_bottom_2 = graph.internal_scope(main_file, 2);
+    let main_3 = graph.internal_scope(main_file, 3);
+    let main_4 = graph.internal_scope(main_file, 4);
+    let main_top_5 = graph.internal_scope(main_file, 5);
+    let main_foo = graph.reference(main_file, 6, sym_foo);
+    let main_dot_7 = graph.push_symbol(main_file, 7, sym_dot);
+    let main_a = graph.reference(main_file, 8, sym_a);
+    graph.edge(root, main);
+    graph.edge(main, main_dot_1);
+    graph.edge(main_dot_1, main_bottom_2);
+    graph.edge(main_bottom_2, main_3);
+    graph.edge(main_foo, main_3);
+    graph.edge(main_3, main_4);
+    graph.edge(main_4, main_dot_7);
+    graph.edge(main_dot_7, main_a);
+    graph.edge(main_a, root);
+    graph.edge(main_4, main_top_5);
+
+    let a_file = graph.add_file("a.py");
+    let a = graph.definition(a_file, 0, sym_a);
+    let a_dot_1 = graph.pop_symbol(a_file, 1, sym_dot);
+    let a_bottom_2 = graph.internal_scope(a_file, 2);
+    let a_3 = graph.internal_scope(a_file, 3);
+    let a_top_4 = graph.internal_scope(a_file, 4);
+    let a_dot_5 = graph.push_symbol(a_file, 5, sym_dot);
+    let a_b = graph.reference(a_file, 6, sym_b);
+    graph.edge(root, a);
+    graph.edge(a, a_dot_1);
+    graph.edge(a_dot_1, a_bottom_2);
+    graph.edge(a_bottom_2, a_3);
+    graph.edge(a_3, a_dot_5);
+    graph.edge(a_dot_5, a_b);
+    graph.edge(a_b, root);
+    graph.edge(a_3, a_top_4);
+
+    let b_file = graph.add_file("b.py");
+    let b = graph.definition(b_file, 0, sym_b);
+    let b_dot_1 = graph.pop_symbol(b_file, 1, sym_dot);
+    let b_bottom_2 = graph.internal_scope(b_file, 2);
+    let b_3 = graph.internal_scope(b_file, 3);
+    let b_top_4 = graph.internal_scope(b_file, 4);
+    let b_foo = graph.definition(b_file, 5, sym_foo);
+    graph.edge(root, b);
+    graph.edge(b, b_dot_1);
+    graph.edge(b_dot_1, b_bottom_2);
+    graph.edge(b_bottom_2, b_3);
+    graph.edge(b_3, b_foo);
+    graph.edge(b_3, b_top_4);
+
+    SequencedImportStar {
+        graph,
+        main,
+        main_a,
+        main_foo,
+        a,
+        a_b,
+        b,
+        b_foo,
+    }
+}


### PR DESCRIPTION
This is a slew of types for each of the possible kinds of node that a stack graph can hold, as well as files and edges.