### PR TITLE
Add cycle detection

### DIFF
--- a/src/cycles.rs
+++ b/src/cycles.rs
@@ -1,0 +1,122 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! Detect and avoid cycles in our path-finding algorithm.
+//!
+//! Cycles in a stack graph can indicate many things.  Your language might allow mutually recursive
+//! imports.  If you are modeling dataflow through function calls, then any recursion in your
+//! function calls will lead to cycles in your stack graph.  And if you have any control-flow paths
+//! that lead to infinite loops at runtime, we'll probably discover those as stack graph paths
+//! during the path-finding algorithm.
+//!
+//! (Note that we're only considering cycles in well-formed paths.  For instance, _pop symbol_
+//! nodes are "guards" that don't allow you to progress into a node if the top of the symbol stack
+//! doesn't match.  We don't consider that a valid path, and so we don't have to worry about
+//! whether it contains any cycles.)
+//!
+//! This module implements a cycle detector that lets us detect these situations and "cut off"
+//! these paths, not trying to extend them any further.  Note that any cycle detection logic we
+//! implement will be a heuristic.  In particular, since our path-finding algorithm will mimic any
+//! runtime recursion, a "complete" cycle detection logic would be equivalent to the Halting
+//! Problem.
+//!
+//! Right now, we implement a simple heuristic where we limit the number of distinct paths that we
+//! process that have the same start and end nodes.  We do not make any guarantees that we will
+//! always use this particular heuristic, however!  We reserve the right to change the heuristic at
+//! any time.
+
+use std::collections::HashMap;
+
+use smallvec::SmallVec;
+
+use crate::arena::Handle;
+use crate::graph::Node;
+use crate::partial::PartialPath;
+use crate::paths::Path;
+
+/// Helps detect cycles in the path-finding algorithm.
+pub struct CycleDetector<P> {
+    paths: HashMap<PathKey, SmallVec<[P; 8]>>,
+}
+
+#[doc(hidden)]
+#[derive(Clone, Eq, Hash, PartialEq)]
+pub struct PathKey {
+    start_node: Handle<Node>,
+    end_node: Handle<Node>,
+}
+
+#[doc(hidden)]
+pub trait HasPathKey: Clone {
+    fn key(&self) -> PathKey;
+    fn is_shorter_than(&self, other: &Self) -> bool;
+}
+
+impl HasPathKey for Path {
+    fn key(&self) -> PathKey {
+        PathKey {
+            start_node: self.start_node,
+            end_node: self.end_node,
+        }
+    }
+
+    fn is_shorter_than(&self, other: &Self) -> bool {
+        self.edge_count < other.edge_count && self.symbol_stack.len() <= other.symbol_stack.len()
+    }
+}
+
+impl HasPathKey for PartialPath {
+    fn key(&self) -> PathKey {
+        PathKey {
+            start_node: self.start_node,
+            end_node: self.end_node,
+        }
+    }
+
+    fn is_shorter_than(&self, other: &Self) -> bool {
+        self.edge_count < other.edge_count
+    }
+}
+
+const MAX_SIMILAR_PATH_COUNT: usize = 4;
+
+impl<P> CycleDetector<P>
+where
+    P: HasPathKey,
+{
+    /// Creates a new, empty cycle detector.
+    pub fn new() -> CycleDetector<P> {
+        CycleDetector {
+            paths: HashMap::new(),
+        }
+    }
+
+    /// Determines whether we should process this path during the path-finding algorithm.  If our
+    /// heuristics decide that this path is a duplicate, or is "non-productive", then we return
+    /// `false`, and the path-finding algorithm will skip this path.
+    pub fn should_process_path<F>(&mut self, path: &P, cmp: F) -> bool
+    where
+        F: FnMut(&P) -> std::cmp::Ordering,
+    {
+        let key = path.key();
+        let paths_with_same_nodes = self.paths.entry(key).or_default();
+        match paths_with_same_nodes.binary_search_by(cmp) {
+            // We've already seen this exact path before; no need to process it again.
+            Ok(_) => return false,
+            // Otherwise add it to the list.
+            Err(index) => paths_with_same_nodes.insert(index, path.clone()),
+        }
+
+        // Count how many paths we've already processed that have the same endpoints and are
+        // "shorter".
+        let similar_path_count = paths_with_same_nodes
+            .iter()
+            .filter(|similar_path| similar_path.is_shorter_than(path))
+            .count();
+        return similar_path_count <= MAX_SIMILAR_PATH_COUNT;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,3 +59,4 @@ pub mod arena;
 pub mod graph;
 pub mod partial;
 pub mod paths;
+pub(crate) mod utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@
 //! original source file.  (a.k.a., it’s incremental!)
 
 pub mod arena;
+pub mod cycles;
 pub mod graph;
 pub mod partial;
 pub mod paths;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,39 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+pub(crate) fn equals_option<T, F>(a: Option<T>, b: Option<T>, mut eq: F) -> bool
+where
+    F: FnMut(T, T) -> bool,
+{
+    match a {
+        Some(a) => match b {
+            Some(b) => eq(a, b),
+            None => false,
+        },
+        None => match b {
+            Some(_) => false,
+            None => true,
+        },
+    }
+}
+
+pub(crate) fn cmp_option<T, F>(a: Option<T>, b: Option<T>, mut cmp: F) -> std::cmp::Ordering
+where
+    F: FnMut(T, T) -> std::cmp::Ordering,
+{
+    use std::cmp::Ordering;
+    match a {
+        Some(a) => match b {
+            Some(b) => cmp(a, b),
+            None => Ordering::Greater,
+        },
+        None => match b {
+            Some(_) => Ordering::Less,
+            None => Ordering::Equal,
+        },
+    }
+}

--- a/tests/it/arena.rs
+++ b/tests/it/arena.rs
@@ -60,6 +60,34 @@ fn can_create_lists() {
 }
 
 #[test]
+fn can_compare_lists() {
+    use std::cmp::Ordering;
+    let mut arena = List::new_arena();
+    let mut from_slice = |slice: &[u32]| {
+        let mut list = List::empty();
+        for element in slice.iter().rev() {
+            list.push_front(&mut arena, *element);
+        }
+        list
+    };
+    let list0 = from_slice(&[]);
+    let list1 = from_slice(&[1]);
+    let list2 = from_slice(&[2]);
+    let list12 = from_slice(&[1, 2]);
+    assert!(list0.equals(&arena, list0));
+    assert_eq!(list0.cmp(&arena, list0), Ordering::Equal);
+    assert!(!list0.equals(&arena, list1));
+    assert_eq!(list0.cmp(&arena, list1), Ordering::Less);
+    assert!(list1.equals(&arena, list1));
+    assert_eq!(list1.cmp(&arena, list1), Ordering::Equal);
+    assert!(!list1.equals(&arena, list2));
+    assert_eq!(list1.cmp(&arena, list2), Ordering::Less);
+    assert!(list2.equals(&arena, list2));
+    assert_eq!(list2.cmp(&arena, list12), Ordering::Greater);
+    assert_eq!(list1.cmp(&arena, list12), Ordering::Less);
+}
+
+#[test]
 fn can_create_reversible_lists() {
     fn collect(list: &ReversibleList<u32>, arena: &ReversibleListArena<u32>) -> Vec<u32> {
         list.iter(arena).copied().collect()
@@ -82,6 +110,38 @@ fn can_create_reversible_lists() {
     assert_eq!(collect(&list, &arena), vec![3, 2, 1, 4, 5]);
     // Verify that we stash away the re-reversal so that we don't have to recompute it.
     assert!(list.have_reversal(&arena));
+}
+
+#[test]
+fn can_compare_reversible_lists() {
+    use std::cmp::Ordering;
+    let mut arena = ReversibleList::new_arena();
+    let mut from_slice = |slice: &[u32]| {
+        let mut list = ReversibleList::empty();
+        for element in slice.iter().rev() {
+            list.push_front(&mut arena, *element);
+        }
+        list
+    };
+    let list0 = from_slice(&[]);
+    let list1 = from_slice(&[1]);
+    let list2 = from_slice(&[2]);
+    let list12 = from_slice(&[1, 2]);
+    assert!(list0.equals(&arena, list0));
+    assert_eq!(list0.cmp(&arena, list0), Ordering::Equal);
+    assert!(!list0.equals(&arena, list1));
+    assert_eq!(list0.cmp(&arena, list1), Ordering::Less);
+    assert!(list1.equals(&arena, list1));
+    assert_eq!(list1.cmp(&arena, list1), Ordering::Equal);
+    assert!(!list1.equals(&arena, list2));
+    assert_eq!(list1.cmp(&arena, list2), Ordering::Less);
+    assert!(list2.equals(&arena, list2));
+    assert_eq!(list2.cmp(&arena, list12), Ordering::Greater);
+    assert_eq!(list1.cmp(&arena, list12), Ordering::Less);
+    let mut list21 = list12;
+    list21.reverse(&mut arena);
+    assert_eq!(list2.cmp(&arena, list21), Ordering::Less);
+    assert_eq!(list1.cmp(&arena, list21), Ordering::Less);
 }
 
 #[test]
@@ -122,4 +182,50 @@ fn can_create_deques() {
         collect_rev(&deque, &mut arena),
         vec![6, 5, 4, 1, 2, 3, 7, 8]
     );
+}
+
+#[test]
+fn can_compare_deques() {
+    use std::cmp::Ordering;
+    let mut arena = Deque::new_arena();
+    // Build up deques in both directions so that our comparisons have to test the "reverse if
+    // needed" logic.
+    let from_slice_forwards = |slice: &[u32], arena: &mut DequeArena<u32>| {
+        let mut deque = Deque::empty();
+        for element in slice.iter() {
+            deque.push_back(arena, *element);
+        }
+        deque
+    };
+    let from_slice_backwards = |slice: &[u32], arena: &mut DequeArena<u32>| {
+        let mut deque = Deque::empty();
+        for element in slice.iter().rev() {
+            deque.push_front(arena, *element);
+        }
+        deque
+    };
+    let deque0 = from_slice_forwards(&[], &mut arena);
+    let mut deque1 = from_slice_backwards(&[1], &mut arena);
+    let deque2 = from_slice_forwards(&[2], &mut arena);
+    let mut deque10 = from_slice_backwards(&[1, 0], &mut arena);
+    let deque12 = from_slice_backwards(&[1, 2], &mut arena);
+    assert!(deque0.equals(&mut arena, deque0));
+    assert_eq!(deque0.cmp(&mut arena, deque0), Ordering::Equal);
+    assert!(!deque0.equals(&mut arena, deque1));
+    assert_eq!(deque0.cmp(&mut arena, deque1), Ordering::Less);
+    assert!(deque1.equals(&mut arena, deque1));
+    assert_eq!(deque1.cmp(&mut arena, deque1), Ordering::Equal);
+    assert!(!deque1.equals(&mut arena, deque2));
+    assert_eq!(deque1.cmp(&mut arena, deque2), Ordering::Less);
+    assert!(deque2.equals(&mut arena, deque2));
+    assert_eq!(deque2.cmp(&mut arena, deque12), Ordering::Greater);
+    assert_eq!(deque1.cmp(&mut arena, deque12), Ordering::Less);
+
+    // We should get the same result regardless of which direction the deques are pointing.
+    deque1.ensure_forwards(&mut arena);
+    deque10.ensure_forwards(&mut arena);
+    assert_eq!(deque1.cmp(&mut arena, deque10), Ordering::Less);
+    deque1.ensure_backwards(&mut arena);
+    deque10.ensure_backwards(&mut arena);
+    assert_eq!(deque1.cmp(&mut arena, deque10), Ordering::Less);
 }

--- a/tests/it/can_create_graph.rs
+++ b/tests/it/can_create_graph.rs
@@ -13,6 +13,16 @@ fn class_field_through_function_parameter() {
 }
 
 #[test]
+fn cyclic_imports_python() {
+    let _ = test_graphs::cyclic_imports_python::new();
+}
+
+#[test]
+fn cyclic_imports_rust() {
+    let _ = test_graphs::cyclic_imports_rust::new();
+}
+
+#[test]
 fn sequenced_import_star() {
     let _ = test_graphs::sequenced_import_star::new();
 }

--- a/tests/it/test_graphs/cyclic_imports_python.rs
+++ b/tests/it/test_graphs/cyclic_imports_python.rs
@@ -1,0 +1,125 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use stack_graphs::arena::Handle;
+use stack_graphs::graph::*;
+
+use crate::test_graphs::CreateStackGraph;
+
+/// A stack graph containing:
+///
+/// ``` python
+/// # main.py
+/// from a import *
+/// print(foo)
+/// ```
+///
+/// ``` python
+/// # a.py
+/// from b import *
+/// ```
+///
+/// ``` python
+/// # b.py
+/// from a import *
+/// foo = 1
+/// ```
+pub struct CyclicImportsPython {
+    pub graph: StackGraph,
+    // Interesting nodes in main.py
+    pub main: Handle<Node>,
+    pub main_a: Handle<Node>,
+    pub main_foo: Handle<Node>,
+    // Interesting nodes in a.py
+    pub a: Handle<Node>,
+    pub a_b: Handle<Node>,
+    // Interesting nodes in b.py
+    pub b: Handle<Node>,
+    pub b_a: Handle<Node>,
+    pub b_foo: Handle<Node>,
+}
+
+pub fn new() -> CyclicImportsPython {
+    let mut graph = StackGraph::new();
+    let root = graph.root_node();
+    let sym_dot = graph.add_symbol(".");
+    let sym_main = graph.add_symbol("__main__");
+    let sym_a = graph.add_symbol("a");
+    let sym_b = graph.add_symbol("b");
+    let sym_foo = graph.add_symbol("foo");
+
+    let main_file = graph.get_or_create_file("main.py");
+    let main = graph.definition(main_file, 0, sym_main);
+    let main_dot_1 = graph.pop_symbol(main_file, 1, sym_dot);
+    let main_bottom_2 = graph.internal_scope(main_file, 2);
+    let main_3 = graph.internal_scope(main_file, 3);
+    let main_4 = graph.internal_scope(main_file, 4);
+    let main_top_5 = graph.internal_scope(main_file, 5);
+    let main_foo = graph.reference(main_file, 6, sym_foo);
+    let main_dot_7 = graph.push_symbol(main_file, 7, sym_dot);
+    let main_a = graph.reference(main_file, 8, sym_a);
+    graph.edge(root, main);
+    graph.edge(main, main_dot_1);
+    graph.edge(main_dot_1, main_bottom_2);
+    graph.edge(main_bottom_2, main_3);
+    graph.edge(main_foo, main_3);
+    graph.edge(main_3, main_4);
+    graph.edge(main_4, main_dot_7);
+    graph.edge(main_dot_7, main_a);
+    graph.edge(main_a, root);
+    graph.edge(main_4, main_top_5);
+
+    let a_file = graph.get_or_create_file("a.py");
+    let a = graph.definition(a_file, 0, sym_a);
+    let a_dot_1 = graph.pop_symbol(a_file, 1, sym_dot);
+    let a_bottom_2 = graph.internal_scope(a_file, 2);
+    let a_3 = graph.internal_scope(a_file, 3);
+    let a_top_4 = graph.internal_scope(a_file, 4);
+    let a_dot_5 = graph.push_symbol(a_file, 5, sym_dot);
+    let a_b = graph.reference(a_file, 6, sym_b);
+    graph.edge(root, a);
+    graph.edge(a, a_dot_1);
+    graph.edge(a_dot_1, a_bottom_2);
+    graph.edge(a_bottom_2, a_3);
+    graph.edge(a_3, a_dot_5);
+    graph.edge(a_dot_5, a_b);
+    graph.edge(a_b, root);
+    graph.edge(a_3, a_top_4);
+
+    let b_file = graph.get_or_create_file("b.py");
+    let b = graph.definition(b_file, 0, sym_b);
+    let b_dot_1 = graph.pop_symbol(b_file, 1, sym_dot);
+    let b_bottom_2 = graph.internal_scope(b_file, 2);
+    let b_3 = graph.internal_scope(b_file, 3);
+    let b_4 = graph.internal_scope(b_file, 4);
+    let b_top_5 = graph.internal_scope(b_file, 5);
+    let b_foo = graph.definition(b_file, 6, sym_foo);
+    let b_dot_7 = graph.push_symbol(b_file, 7, sym_dot);
+    let b_a = graph.reference(b_file, 8, sym_a);
+    graph.edge(root, b);
+    graph.edge(b, b_dot_1);
+    graph.edge(b_dot_1, b_bottom_2);
+    graph.edge(b_bottom_2, b_3);
+    graph.edge(b_3, b_foo);
+    graph.edge(b_3, b_4);
+    graph.edge(b_4, b_dot_7);
+    graph.edge(b_dot_7, b_a);
+    graph.edge(b_a, root);
+    graph.edge(b_4, b_top_5);
+
+    CyclicImportsPython {
+        graph,
+        main,
+        main_a,
+        main_foo,
+        a,
+        a_b,
+        b,
+        b_a,
+        b_foo,
+    }
+}

--- a/tests/it/test_graphs/cyclic_imports_rust.rs
+++ b/tests/it/test_graphs/cyclic_imports_rust.rs
@@ -1,0 +1,111 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use stack_graphs::arena::Handle;
+use stack_graphs::graph::*;
+
+use crate::test_graphs::CreateStackGraph;
+
+/// A stack graph containing:
+///
+/// ``` ignore
+/// mod a {
+///   pub use crate::b::*;
+///   pub const BAR: i32 = 1;
+/// }
+///
+/// mod b {
+///   pub use crate::a::*;
+///   pub const FOO: i32 = BAR;
+/// }
+///
+/// fn main() {
+///   println!("FOO is {}", a::FOO);
+/// }
+/// ```
+#[allow(non_snake_case)]
+pub struct CyclicImportsRust {
+    pub graph: StackGraph,
+    pub file_root: Handle<Node>,
+    // Interesting nodes in crate root
+    pub main_a: Handle<Node>,
+    pub main_FOO: Handle<Node>,
+    // Interesting nodes in mod a
+    pub a: Handle<Node>,
+    pub a_b: Handle<Node>,
+    pub a_BAR: Handle<Node>,
+    // Interesting nodes in mod b
+    pub b: Handle<Node>,
+    pub b_a: Handle<Node>,
+    pub b_BAR: Handle<Node>,
+    pub b_FOO: Handle<Node>,
+}
+
+#[allow(non_snake_case)]
+pub fn new() -> CyclicImportsRust {
+    let mut graph = StackGraph::new();
+    let sym_colons = graph.add_symbol("::");
+    let sym_a = graph.add_symbol("a");
+    let sym_b = graph.add_symbol("b");
+    let sym_BAR = graph.add_symbol("BAR");
+    let sym_FOO = graph.add_symbol("FOO");
+
+    let file = graph.get_or_create_file("test.rs");
+    let file_root = graph.internal_scope(file, 0);
+
+    let main_FOO = graph.reference(file, 101, sym_FOO);
+    let main_colons_2 = graph.push_symbol(file, 102, sym_colons);
+    let main_a = graph.reference(file, 103, sym_a);
+    graph.edge(main_FOO, main_colons_2);
+    graph.edge(main_colons_2, main_a);
+    graph.edge(main_a, file_root);
+
+    let a = graph.definition(file, 201, sym_a);
+    let a_colons_2 = graph.pop_symbol(file, 202, sym_colons);
+    let a_mod_3 = graph.internal_scope(file, 203);
+    let a_BAR = graph.definition(file, 204, sym_BAR);
+    let a_colons_5 = graph.push_symbol(file, 205, sym_colons);
+    let a_b = graph.reference(file, 206, sym_b);
+    graph.edge(file_root, a);
+    graph.edge(a, a_colons_2);
+    graph.edge(a_colons_2, a_mod_3);
+    graph.edge(a_mod_3, a_BAR);
+    graph.edge(a_mod_3, a_colons_5);
+    graph.edge(a_colons_5, a_b);
+    graph.edge(a_b, file_root);
+
+    let b = graph.definition(file, 301, sym_b);
+    let b_colons_2 = graph.pop_symbol(file, 302, sym_colons);
+    let b_mod_3 = graph.internal_scope(file, 303);
+    let b_FOO = graph.definition(file, 304, sym_FOO);
+    let b_BAR = graph.reference(file, 305, sym_BAR);
+    let b_colons_6 = graph.push_symbol(file, 306, sym_colons);
+    let b_a = graph.reference(file, 307, sym_a);
+    graph.edge(file_root, b);
+    graph.edge(b, b_colons_2);
+    graph.edge(b_colons_2, b_mod_3);
+    graph.edge(b_mod_3, b_FOO);
+    graph.edge(b_FOO, b_BAR);
+    graph.edge(b_BAR, b_mod_3);
+    graph.edge(b_mod_3, b_colons_6);
+    graph.edge(b_colons_6, b_a);
+    graph.edge(b_a, file_root);
+
+    CyclicImportsRust {
+        graph,
+        file_root,
+        main_a,
+        main_FOO,
+        a,
+        a_b,
+        a_BAR,
+        b,
+        b_a,
+        b_BAR,
+        b_FOO,
+    }
+}

--- a/tests/it/test_graphs/mod.rs
+++ b/tests/it/test_graphs/mod.rs
@@ -11,6 +11,8 @@ use stack_graphs::arena::Handle;
 use stack_graphs::graph::*;
 
 pub mod class_field_through_function_parameter;
+pub mod cyclic_imports_python;
+pub mod cyclic_imports_rust;
 pub mod sequenced_import_star;
 
 /// An extension trait that makes it a bit easier to add stuff to our test stack graphs.


### PR DESCRIPTION
This is a simple heuristic that limits the number of paths we process with the same start and end nodes.  Given all of the paths that we encounter with the same start and end nodes, we try to "keep" the ones that are shorter.  Our current threshold is 4 paths.  That said, all of the specifics about this heuristic are subject to change in the future. The only API that we guarantee is that our `CycleDetector` is a black box that says "yes" or "no" to individual paths.