### PR TITLE
Add the path-stitching algorithm

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -314,6 +314,15 @@ impl<T> List<T> {
         }
     }
 
+    pub fn from_handle(handle: Handle<ListCell<T>>) -> List<T> {
+        List { cells: handle }
+    }
+
+    /// Returns a handle to the head of the list.
+    pub fn handle(&self) -> Handle<ListCell<T>> {
+        self.cells
+    }
+
     /// Pushes a new element onto the front of this list.
     pub fn push_front(&mut self, arena: &mut ListArena<T>, head: T) {
         self.cells = arena.add(ListCell::Nonempty {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,4 +60,5 @@ pub mod cycles;
 pub mod graph;
 pub mod partial;
 pub mod paths;
+pub mod stitching;
 pub(crate) mod utils;

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -38,6 +38,8 @@ use std::convert::TryFrom;
 use std::fmt::Display;
 use std::num::NonZeroU32;
 
+use smallvec::SmallVec;
+
 use crate::arena::Deque;
 use crate::arena::DequeArena;
 use crate::arena::Handle;
@@ -49,6 +51,10 @@ use crate::graph::StackGraph;
 use crate::graph::Symbol;
 use crate::paths::Extend;
 use crate::paths::PathResolutionError;
+use crate::paths::Paths;
+use crate::paths::ScopeStack;
+use crate::paths::ScopedSymbol;
+use crate::paths::SymbolStack;
 use crate::utils::cmp_option;
 use crate::utils::equals_option;
 
@@ -165,6 +171,10 @@ impl ScopeStackVariable {
     fn as_u32(self) -> u32 {
         self.0.get()
     }
+
+    fn as_usize(self) -> usize {
+        self.0.get() as usize
+    }
 }
 
 impl Display for ScopeStackVariable {
@@ -188,6 +198,97 @@ impl TryFrom<u32> for ScopeStackVariable {
 }
 
 //-------------------------------------------------------------------------------------------------
+// Symbol stack bindings
+
+/// The portion of the symbol stack that was not consumed by a partial path's precondition.
+///
+/// For scope stacks, we have actual variables, since there are many places in a partial path's
+/// precondition where we need to match against scope stacks.  So [`ScopeStackBindings`][] is an
+/// actual map from variables to the scope stacks that they match against.
+///
+/// The story is different for the symbol stack.  In theory, a partial path's symbol stack
+/// precondition does have an implicit variable at the end, which matches against whatever portion
+/// of the symbol stack is not consumed by the list of symbols in the precondition.  However,
+/// because there is only ever one symbol stack variable, we don't currently reify that in our data
+/// model anywhere.  Instead the "bindings" just keeps track of that unmatched portion of the
+/// symbol stack.
+///
+/// [`ScopeStackBindings`]: struct.ScopeStackBindings.html
+pub struct SymbolStackBindings {
+    binding: Option<SymbolStack>,
+}
+
+impl SymbolStackBindings {
+    /// Creates a new, empty set of symbol stack bindings.
+    pub fn new() -> SymbolStackBindings {
+        SymbolStackBindings { binding: None }
+    }
+
+    /// Returns the symbol stack that the (unnamed) symbol stack variable matched.  Returns an
+    /// error if that variable didn't match anything.
+    pub fn get(&self) -> Result<SymbolStack, PathResolutionError> {
+        self.binding
+            .ok_or(PathResolutionError::UnboundSymbolStackVariable)
+    }
+
+    /// Adds a new binding from the (unnamed) symbol stack variable to the symbol stack that it
+    /// matched.  Returns an error if you try to bind the (unnamed) symbol stack variable more than
+    /// once.
+    pub fn add(&mut self, symbols: SymbolStack) -> Result<(), PathResolutionError> {
+        if self.binding.is_some() {
+            return Err(PathResolutionError::IncompatibleSymbolStackVariables);
+        }
+        self.binding = Some(symbols);
+        Ok(())
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Scope stack bindings
+
+/// A mapping from scope stack variables to scope stacks.
+pub struct ScopeStackBindings {
+    bindings: SmallVec<[Option<ScopeStack>; 4]>,
+}
+
+impl ScopeStackBindings {
+    /// Creates a new, empty set of scope stack bindings.
+    pub fn new() -> ScopeStackBindings {
+        ScopeStackBindings {
+            bindings: SmallVec::new(),
+        }
+    }
+
+    /// Returns the scope stack that a particular scope stack variable matched.  Returns an error
+    /// if that variable didn't match anything.
+    pub fn get(&self, variable: ScopeStackVariable) -> Result<ScopeStack, PathResolutionError> {
+        let index = variable.as_usize();
+        if self.bindings.len() < index {
+            return Err(PathResolutionError::UnboundScopeStackVariable);
+        }
+        self.bindings[index - 1].ok_or(PathResolutionError::UnboundScopeStackVariable)
+    }
+
+    /// Adds a new binding from a scope stack variable to the scope stack that it matched.  Returns
+    /// an error if you try to bind a particular variable more than once.
+    pub fn add(
+        &mut self,
+        variable: ScopeStackVariable,
+        scopes: ScopeStack,
+    ) -> Result<(), PathResolutionError> {
+        let index = variable.as_usize();
+        if self.bindings.len() < index {
+            self.bindings.resize_with(index, || None);
+        }
+        if self.bindings[index - 1].is_some() {
+            return Err(PathResolutionError::IncompatibleScopeStackVariables);
+        }
+        self.bindings[index - 1] = Some(scopes);
+        Ok(())
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
 // Partial symbol stacks
 
 /// A symbol with an unknown, but possibly empty, list of exported scopes attached to it.
@@ -200,6 +301,25 @@ pub struct PartialScopedSymbol {
 }
 
 impl PartialScopedSymbol {
+    /// Matches this precondition symbol against a scoped symbol, unifying its contents with an
+    /// existing set of bindings.
+    pub fn match_symbol(
+        self,
+        graph: &StackGraph,
+        symbol: ScopedSymbol,
+        scope_bindings: &mut ScopeStackBindings,
+    ) -> Result<(), PathResolutionError> {
+        if graph[self.symbol] != graph[symbol.symbol] {
+            return Err(PathResolutionError::SymbolStackUnsatisfied);
+        }
+        if !equals_option(self.scopes, symbol.scopes, |pre, sym| {
+            pre.match_stack(sym, scope_bindings).is_ok()
+        }) {
+            return Err(PathResolutionError::SymbolStackUnsatisfied);
+        }
+        Ok(())
+    }
+
     /// Returns whether two partial scoped symbols "match".  The symbols must be identical, and any
     /// attached scopes must also match.
     pub fn matches(self, partials: &mut PartialPaths, postcondition: PartialScopedSymbol) -> bool {
@@ -221,6 +341,23 @@ impl PartialScopedSymbol {
         }
 
         true
+    }
+
+    /// Applies a set of bindings to this partial scoped symbol, producing a new scoped symbol.
+    pub fn apply_bindings(
+        self,
+        paths: &mut Paths,
+        partials: &mut PartialPaths,
+        scope_bindings: &ScopeStackBindings,
+    ) -> Result<ScopedSymbol, PathResolutionError> {
+        let scopes = match self.scopes {
+            Some(scopes) => Some(scopes.apply_bindings(paths, partials, scope_bindings)?),
+            None => None,
+        };
+        Ok(ScopedSymbol {
+            symbol: self.symbol,
+            scopes,
+        })
     }
 
     pub fn equals(&self, partials: &mut PartialPaths, other: &PartialScopedSymbol) -> bool {
@@ -337,6 +474,34 @@ impl PartialSymbolStack {
         display_with(self, graph, partials)
     }
 
+    /// Matches this precondition against a symbol stack, stashing away the unmatched portion of
+    /// the stack in the bindings.
+    pub fn match_stack(
+        mut self,
+        graph: &StackGraph,
+        paths: &Paths,
+        partial_paths: &mut PartialPaths,
+        mut stack: SymbolStack,
+        symbol_bindings: &mut SymbolStackBindings,
+        scope_bindings: &mut ScopeStackBindings,
+    ) -> Result<(), PathResolutionError> {
+        // First verify that every symbol in the precondition has a corresponding matching symbol
+        // in the symbol stack.
+        while let Some(precondition_symbol) = self.pop_front(partial_paths) {
+            match stack.pop_front(paths) {
+                // This will update scope_bindings if the precondition symbol has an attached scope
+                // stack variable.
+                Some(symbol) => precondition_symbol.match_symbol(graph, symbol, scope_bindings)?,
+                // The precondition is longer than the symbol stack, which is an error.
+                None => return Err(PathResolutionError::SymbolStackUnsatisfied),
+            }
+        }
+
+        // Anything remaining on the symbol stack is stashed away as the binding of the implicit
+        // symbol stack variable.
+        symbol_bindings.add(stack)
+    }
+
     /// Returns whether two partial symbol stacks "match".  They must be the same length, and each
     /// respective partial scoped symbol must match.
     pub fn matches(mut self, partials: &mut PartialPaths, mut other: PartialSymbolStack) -> bool {
@@ -355,6 +520,22 @@ impl PartialSymbolStack {
             return false;
         }
         true
+    }
+
+    /// Applies a set of bindings to this partial symbol stack, producing a new symbol stack.
+    pub fn apply_bindings(
+        mut self,
+        paths: &mut Paths,
+        partials: &mut PartialPaths,
+        symbol_bindings: &SymbolStackBindings,
+        scope_bindings: &ScopeStackBindings,
+    ) -> Result<SymbolStack, PathResolutionError> {
+        let mut result = symbol_bindings.get()?;
+        while let Some(partial_symbol) = self.pop_back(partials) {
+            let symbol = partial_symbol.apply_bindings(paths, partials, scope_bindings)?;
+            result.push_front(paths, symbol);
+        }
+        Ok(result)
     }
 
     pub fn equals(mut self, partials: &mut PartialPaths, mut other: PartialSymbolStack) -> bool {
@@ -485,6 +666,24 @@ impl PartialScopeStack {
         }
     }
 
+    /// Matches this partial scope stack against a scope stack, unifying any scope stack variables
+    /// with an existing set of bindings.
+    pub fn match_stack(
+        &self,
+        stack: ScopeStack,
+        bindings: &mut ScopeStackBindings,
+    ) -> Result<(), PathResolutionError> {
+        match self.variable {
+            Some(variable) => return bindings.add(variable, stack),
+            None => {
+                if !stack.is_empty() {
+                    return Err(PathResolutionError::ScopeStackUnsatisfied);
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Returns whether two partial scope stacks match exactly the same set of scope stacks.
     pub fn matches(mut self, partials: &mut PartialPaths, mut other: PartialScopeStack) -> bool {
         while let Some(self_element) = self.pop_front(partials) {
@@ -502,6 +701,24 @@ impl PartialScopeStack {
             return false;
         }
         self.variable == other.variable
+    }
+
+    /// Applies a set of scope stack bindings to this partial scope stack, producing a new scope
+    /// stack.
+    pub fn apply_bindings(
+        mut self,
+        paths: &mut Paths,
+        partials: &mut PartialPaths,
+        bindings: &ScopeStackBindings,
+    ) -> Result<ScopeStack, PathResolutionError> {
+        let mut result = match self.variable {
+            Some(variable) => bindings.get(variable)?,
+            None => ScopeStack::empty(),
+        };
+        while let Some(scope) = self.pop_back(partials) {
+            result.push_front(paths, scope);
+        }
+        Ok(result)
     }
 
     /// Pushes a new [`Node`][] onto the front of this partial scope stack.  The node must be an

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -454,6 +454,12 @@ pub enum PathResolutionError {
     /// The path contains a _pop symbol_ or _pop scoped symbol_ node, but there are no symbols on
     /// the symbol stack to pop off.
     EmptySymbolStack,
+    /// The partial path contains multiple references to a scope stack variable, and those
+    /// references can't unify on a single scope stack.
+    IncompatibleScopeStackVariables,
+    /// The partial path contains multiple references to a symbol stack variable, and those
+    /// references can't unify on a single symbol stack.
+    IncompatibleSymbolStackVariables,
     /// The partial path contains edges from multiple files.
     IncorrectFile,
     /// The path contains a _pop symbol_ or _pop scoped symbol_ node, but the symbol at the top of
@@ -465,6 +471,16 @@ pub enum PathResolutionError {
     /// The path contains a _pop scoped symbol_ node, but the symbol at the top of the symbol stack
     /// does not have an attached scope list to pop off.
     MissingAttachedScopeList,
+    /// The path's scope stack does not satisfy the partial path's scope stack precondition.
+    ScopeStackUnsatisfied,
+    /// The path's symbol stack does not satisfy the partial path's symbol stack precondition.
+    SymbolStackUnsatisfied,
+    /// The partial path's postcondition references a symbol stack variable that isn't present in
+    /// the precondition.
+    UnboundSymbolStackVariable,
+    /// The partial path's postcondition references a scope stack variable that isn't present in
+    /// the precondition.
+    UnboundScopeStackVariable,
     /// The path contains a _pop symbol_ node, but the symbol at the top of the symbol stack has an
     /// attached scope list that we weren't expecting.
     UnexpectedAttachedScopeList,

--- a/src/stitching.rs
+++ b/src/stitching.rs
@@ -1,0 +1,219 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! Partial paths can be "stitched together" to produce name-binding paths.
+
+use std::collections::HashMap;
+use std::ops::Index;
+
+use crate::arena::Arena;
+use crate::arena::Handle;
+use crate::arena::List;
+use crate::arena::ListArena;
+use crate::arena::ListCell;
+use crate::arena::SupplementalArena;
+use crate::graph::Node;
+use crate::graph::StackGraph;
+use crate::graph::Symbol;
+use crate::partial::PartialPath;
+use crate::partial::PartialPaths;
+use crate::partial::PartialSymbolStack;
+use crate::paths::Paths;
+use crate::paths::SymbolStack;
+
+//-------------------------------------------------------------------------------------------------
+// Databases
+
+/// Contains a "database" of partial paths.
+///
+/// This type is meant to be a lazily loaded "view" into a proper storage layer.  During the
+/// path-stitching algorithm, we repeatedly try to extend a currently incomplete path with any
+/// partial paths that are compatible with it.  For large codebases, or projects with a large
+/// number of dependencies, it can be prohibitive to load in _all_ of the partial paths up-front.
+/// We've written the path-stitching algorithm so that you have a chance to only load in the
+/// partial paths that are actually needed, placing them into a `Database` instance as they're
+/// needed.
+pub struct Database {
+    partial_paths: Arena<PartialPath>,
+    symbol_stack_keys: ListArena<Handle<Symbol>>,
+    symbol_stack_key_cache: HashMap<SymbolStackCacheKey, SymbolStackKeyHandle>,
+    paths_by_start_node: SupplementalArena<Node, Vec<Handle<PartialPath>>>,
+    root_paths_by_precondition: SupplementalArena<SymbolStackKeyCell, Vec<Handle<PartialPath>>>,
+}
+
+impl Database {
+    /// Creates a new, empty data.
+    pub fn new() -> Database {
+        Database {
+            partial_paths: Arena::new(),
+            symbol_stack_keys: List::new_arena(),
+            symbol_stack_key_cache: HashMap::new(),
+            paths_by_start_node: SupplementalArena::new(),
+            root_paths_by_precondition: SupplementalArena::new(),
+        }
+    }
+
+    /// Adds a partial path to this database.  We do not deduplicate partial paths in any way; it's
+    /// your responsibility to only add each partial path once.
+    pub fn add_partial_path(
+        &mut self,
+        graph: &StackGraph,
+        partials: &mut PartialPaths,
+        path: PartialPath,
+    ) -> Handle<PartialPath> {
+        let start_node = path.start_node;
+        let symbol_stack_precondition = path.symbol_stack_precondition;
+        let handle = self.partial_paths.add(path);
+
+        // If the partial path starts at the root node, index it by its symbol stack precondition.
+        if graph[start_node].is_root() {
+            let key = SymbolStackKey::from_partial_symbol_stack(
+                partials,
+                self,
+                symbol_stack_precondition,
+            );
+            let key_handle = key.back_handle();
+            self.root_paths_by_precondition[key_handle].push(handle);
+        } else {
+            // Otherwise index it by its source node.
+            self.paths_by_start_node[start_node].push(handle);
+        }
+
+        handle
+    }
+
+    /// Find all partial paths in this database that start at the root node, and have a symbol
+    /// stack precondition that is compatible with a given symbol stack.
+    pub fn find_candidate_partial_paths_from_root<R>(
+        &mut self,
+        paths: &mut Paths,
+        symbol_stack: SymbolStack,
+        result: &mut R,
+    ) where
+        R: std::iter::Extend<Handle<PartialPath>>,
+    {
+        // If the path currently ends at the root node, then we need to look up partial paths whose
+        // symbol stack precondition is compatible with the path.
+        let mut symbol_stack = SymbolStackKey::from_symbol_stack(paths, self, symbol_stack);
+        loop {
+            let key_handle = symbol_stack.back_handle();
+            if let Some(paths) = self.root_paths_by_precondition.get(key_handle) {
+                result.extend(paths.iter().copied());
+            }
+            if symbol_stack.pop_back(self).is_none() {
+                break;
+            }
+        }
+    }
+
+    /// Find all partial paths in the database that start at the given node.  We don't filter the
+    /// results any further than that, since we have to check each partial path for compatibility
+    /// as we try to append it to the current incomplete path anyway, and non-root nodes will
+    /// typically have a small number of outgoing edges.
+    pub fn find_candidate_partial_paths_from_node<R>(
+        &self,
+        start_node: Handle<Node>,
+        result: &mut R,
+    ) where
+        R: std::iter::Extend<Handle<PartialPath>>,
+    {
+        // Return all of the partial paths that start at the requested node.
+        if let Some(paths) = self.paths_by_start_node.get(start_node) {
+            result.extend(paths.iter().copied());
+        }
+    }
+}
+
+impl Index<Handle<PartialPath>> for Database {
+    type Output = PartialPath;
+    #[inline(always)]
+    fn index(&self, handle: Handle<PartialPath>) -> &PartialPath {
+        self.partial_paths.get(handle)
+    }
+}
+
+#[derive(Clone, Copy)]
+struct SymbolStackKey {
+    // Note: the symbols are stored in reverse order, with the "front" of the List being the "back"
+    // of the symbol stack.  That lets us easily get a handle to the back of the symbol stack, and
+    // also lets us easily pops items off the back of key, which we need to do to search for all
+    // prefixes of a particular symbol stack down in `find_candidate_partial_paths_from_root`.
+    symbols: List<Handle<Symbol>>,
+}
+
+#[derive(Clone, Eq, Hash, PartialEq)]
+struct SymbolStackCacheKey {
+    head: Handle<Symbol>,
+    tail: SymbolStackKeyHandle,
+}
+
+type SymbolStackKeyCell = ListCell<Handle<Symbol>>;
+type SymbolStackKeyHandle = Handle<SymbolStackKeyCell>;
+
+impl SymbolStackKey {
+    /// Returns an empty symbol stack key.
+    fn empty() -> SymbolStackKey {
+        SymbolStackKey {
+            symbols: List::empty(),
+        }
+    }
+
+    /// Pushes a new symbol onto the back of this symbol stack key.
+    fn push_back(&mut self, db: &mut Database, symbol: Handle<Symbol>) {
+        let cache_key = SymbolStackCacheKey {
+            head: symbol,
+            tail: self.back_handle(),
+        };
+        if let Some(handle) = db.symbol_stack_key_cache.get(&cache_key) {
+            self.symbols = List::from_handle(*handle);
+            return;
+        }
+        // push_front because we store the key's symbols in reverse order.
+        self.symbols.push_front(&mut db.symbol_stack_keys, symbol);
+        let handle = self.back_handle();
+        db.symbol_stack_key_cache.insert(cache_key, handle);
+    }
+
+    /// Pops a symbol from the back of this symbol stack key.
+    fn pop_back(&mut self, db: &Database) -> Option<Handle<Symbol>> {
+        // pop_front because we store the key's symbols in reverse order.
+        self.symbols.pop_front(&db.symbol_stack_keys).copied()
+    }
+
+    /// Extracts a new symbol stack key from a symbol stack.
+    fn from_symbol_stack(
+        paths: &mut Paths,
+        db: &mut Database,
+        mut stack: SymbolStack,
+    ) -> SymbolStackKey {
+        let mut result = SymbolStackKey::empty();
+        while let Some(symbol) = stack.pop_front(paths) {
+            result.push_back(db, symbol.symbol);
+        }
+        result
+    }
+
+    /// Extracts a new symbol stack key from a partial symbol stack.
+    fn from_partial_symbol_stack(
+        partials: &mut PartialPaths,
+        db: &mut Database,
+        mut stack: PartialSymbolStack,
+    ) -> SymbolStackKey {
+        let mut result = SymbolStackKey::empty();
+        while let Some(symbol) = stack.pop_front(partials) {
+            result.push_back(db, symbol.symbol);
+        }
+        result
+    }
+
+    /// Returns a handle to the back of the symbol stack key.
+    fn back_handle(self) -> SymbolStackKeyHandle {
+        // Because the symbols are stored in reverse order, the handle to the "front" of the list
+        // is a handle to the "back" of the key.
+        self.symbols.handle()
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,9 +5,9 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-pub(crate) fn equals_option<T, F>(a: Option<T>, b: Option<T>, mut eq: F) -> bool
+pub(crate) fn equals_option<A, B, F>(a: Option<A>, b: Option<B>, mut eq: F) -> bool
 where
-    F: FnMut(T, T) -> bool,
+    F: FnMut(A, B) -> bool,
 {
     match a {
         Some(a) => match b {

--- a/tests/it/can_find_node_partial_paths_in_database.rs
+++ b/tests/it/can_find_node_partial_paths_in_database.rs
@@ -1,0 +1,122 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use std::collections::HashSet;
+
+use stack_graphs::arena::Handle;
+use stack_graphs::graph::Node;
+use stack_graphs::graph::StackGraph;
+use stack_graphs::partial::PartialPath;
+use stack_graphs::partial::PartialPaths;
+use stack_graphs::stitching::Database;
+
+use crate::test_graphs;
+
+fn check_node_partial_paths(
+    graph: &mut StackGraph,
+    node: Handle<Node>,
+    expected_partial_paths: &[&str],
+) {
+    let file = graph[node].id().unwrap().file;
+    let mut partials = PartialPaths::new();
+    let mut database = Database::new();
+    partials.find_all_partial_paths_in_file(graph, file, |graph, partials, path| {
+        if !path.is_complete_as_possible(graph) {
+            return;
+        }
+        if !path.is_productive(partials) {
+            return;
+        }
+        database.add_partial_path(graph, partials, path);
+    });
+
+    let mut results = Vec::<Handle<PartialPath>>::new();
+    database.find_candidate_partial_paths_from_node(node, &mut results);
+
+    let actual_partial_paths = results
+        .into_iter()
+        .map(|path| database[path].display(graph, &mut partials).to_string())
+        .collect::<HashSet<_>>();
+    let expected_partial_paths = expected_partial_paths
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<HashSet<_>>();
+    assert_eq!(actual_partial_paths, expected_partial_paths);
+}
+
+#[test]
+fn class_field_through_function_parameter() {
+    let mut fixture = test_graphs::class_field_through_function_parameter::new();
+    check_node_partial_paths(
+        &mut fixture.graph,
+        fixture.main_bar,
+        &[
+            "<> () [main.py(10) reference bar] -> [root] <a.foo()/[main.py(7)].bar> ()",
+            "<> () [main.py(10) reference bar] -> [root] <b.foo()/[main.py(7)].bar> ()",
+        ],
+    );
+    check_node_partial_paths(
+        &mut fixture.graph,
+        fixture.a_x_ref,
+        &["<> () [a.py(8) reference x] -> [a.py(14) definition x] <> ()"],
+    );
+    // no references in b.py
+}
+
+#[test]
+fn cyclic_imports_python() {
+    let mut fixture = test_graphs::cyclic_imports_python::new();
+    check_node_partial_paths(
+        &mut fixture.graph,
+        fixture.main_foo,
+        &["<> () [main.py(6) reference foo] -> [root] <a.foo> ()"],
+    );
+    check_node_partial_paths(
+        &mut fixture.graph,
+        fixture.a_b,
+        &["<> () [a.py(6) reference b] -> [root] <b> ()"],
+    );
+    check_node_partial_paths(
+        &mut fixture.graph,
+        fixture.b_a,
+        &["<> () [b.py(8) reference a] -> [root] <a> ()"],
+    );
+}
+
+#[test]
+fn cyclic_imports_rust() {
+    let mut fixture = test_graphs::cyclic_imports_rust::new();
+    check_node_partial_paths(
+        &mut fixture.graph,
+        fixture.main_FOO,
+        &[
+            "<> () [test.rs(101) reference FOO] -> [test.rs(204) definition BAR] <> ()",
+            "<> () [test.rs(101) reference FOO] -> [test.rs(304) definition FOO] <> ()",
+        ],
+    );
+    check_node_partial_paths(
+        &mut fixture.graph,
+        fixture.b_BAR,
+        &["<> () [test.rs(305) reference BAR] -> [test.rs(204) definition BAR] <> ()"],
+    );
+}
+
+#[test]
+fn sequenced_import_star() {
+    let mut fixture = test_graphs::sequenced_import_star::new();
+    check_node_partial_paths(
+        &mut fixture.graph,
+        fixture.main_foo,
+        &["<> () [main.py(6) reference foo] -> [root] <a.foo> ()"],
+    );
+    check_node_partial_paths(
+        &mut fixture.graph,
+        fixture.a_b,
+        &["<> () [a.py(6) reference b] -> [root] <b> ()"],
+    );
+    // no references in b.py
+}

--- a/tests/it/can_find_root_partial_paths_in_database.rs
+++ b/tests/it/can_find_root_partial_paths_in_database.rs
@@ -1,0 +1,164 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use std::collections::HashSet;
+
+use stack_graphs::arena::Handle;
+use stack_graphs::graph::StackGraph;
+use stack_graphs::partial::PartialPath;
+use stack_graphs::partial::PartialPaths;
+use stack_graphs::paths::Paths;
+use stack_graphs::paths::ScopedSymbol;
+use stack_graphs::paths::SymbolStack;
+use stack_graphs::stitching::Database;
+
+use crate::test_graphs;
+
+fn check_root_partial_paths(
+    graph: &mut StackGraph,
+    file: &str,
+    precondition: &[&str],
+    expected_partial_paths: &[&str],
+) {
+    let file = graph.get_file_unchecked(file);
+    let mut paths = Paths::new();
+    let mut partials = PartialPaths::new();
+    let mut database = Database::new();
+    partials.find_all_partial_paths_in_file(graph, file, |graph, partials, path| {
+        if !path.is_complete_as_possible(graph) {
+            return;
+        }
+        if !path.is_productive(partials) {
+            return;
+        }
+        database.add_partial_path(graph, partials, path);
+    });
+
+    let mut symbol_stack = SymbolStack::empty();
+    for symbol in precondition.iter().rev() {
+        let symbol = graph.add_symbol(symbol);
+        let scoped_symbol = ScopedSymbol {
+            symbol,
+            scopes: None,
+        };
+        symbol_stack.push_front(&mut paths, scoped_symbol);
+    }
+
+    let mut results = Vec::<Handle<PartialPath>>::new();
+    database.find_candidate_partial_paths_from_root(&mut paths, symbol_stack, &mut results);
+
+    let actual_partial_paths = results
+        .into_iter()
+        .map(|path| database[path].display(graph, &mut partials).to_string())
+        .collect::<HashSet<_>>();
+    let expected_partial_paths = expected_partial_paths
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<HashSet<_>>();
+    assert_eq!(actual_partial_paths, expected_partial_paths);
+}
+
+#[test]
+fn class_field_through_function_parameter() {
+    let mut fixture = test_graphs::class_field_through_function_parameter::new();
+    check_root_partial_paths(
+        &mut fixture.graph,
+        "main.py",
+        &["__main__", ".", "baz"],
+        &[
+            "<__main__.> ($1) [root] -> [root] <a.> ($1)",
+            "<__main__.> ($1) [root] -> [root] <b.> ($1)",
+            "<__main__> ($1) [root] -> [main.py(0) definition __main__] <> ($1)",
+        ],
+    );
+    check_root_partial_paths(
+        &mut fixture.graph,
+        "a.py",
+        &["a", ".", "baz"],
+        &["<a> ($1) [root] -> [a.py(0) definition a] <> ($1)"],
+    );
+    check_root_partial_paths(
+        &mut fixture.graph,
+        "b.py",
+        &["b", ".", "baz"],
+        &["<b> ($1) [root] -> [b.py(0) definition b] <> ($1)"],
+    );
+}
+
+#[test]
+fn cyclic_imports_python() {
+    let mut fixture = test_graphs::cyclic_imports_python::new();
+    check_root_partial_paths(
+        &mut fixture.graph,
+        "main.py",
+        &["__main__", ".", "baz"],
+        &[
+            "<__main__> ($1) [root] -> [main.py(0) definition __main__] <> ($1)",
+            "<__main__.> ($1) [root] -> [root] <a.> ($1)",
+        ],
+    );
+    check_root_partial_paths(
+        &mut fixture.graph,
+        "a.py",
+        &["a", ".", "baz"],
+        &[
+            "<a> ($1) [root] -> [a.py(0) definition a] <> ($1)",
+            "<a.> ($1) [root] -> [root] <b.> ($1)",
+        ],
+    );
+    check_root_partial_paths(
+        &mut fixture.graph,
+        "b.py",
+        &["b", ".", "baz"],
+        &[
+            "<b> ($1) [root] -> [b.py(0) definition b] <> ($1)",
+            "<b.> ($1) [root] -> [root] <a.> ($1)",
+        ],
+    );
+}
+
+#[test]
+fn cyclic_imports_rust() {
+    let mut fixture = test_graphs::cyclic_imports_rust::new();
+    check_root_partial_paths(
+        &mut fixture.graph,
+        "test.rs",
+        &[],
+        // NOTE: Because everything in this example is local to one file, there aren't any partial
+        // paths involving the root node.
+        &[],
+    );
+}
+
+#[test]
+fn sequenced_import_star() {
+    let mut fixture = test_graphs::sequenced_import_star::new();
+    check_root_partial_paths(
+        &mut fixture.graph,
+        "main.py",
+        &["__main__", ".", "baz"],
+        &[
+            "<__main__> ($1) [root] -> [main.py(0) definition __main__] <> ($1)",
+            "<__main__.> ($1) [root] -> [root] <a.> ($1)",
+        ],
+    );
+    check_root_partial_paths(
+        &mut fixture.graph,
+        "a.py",
+        &["a", ".", "baz"],
+        &[
+            "<a> ($1) [root] -> [a.py(0) definition a] <> ($1)",
+            "<a.> ($1) [root] -> [root] <b.> ($1)",
+        ],
+    );
+    check_root_partial_paths(
+        &mut fixture.graph,
+        "b.py",
+        &["b", ".", "baz"],
+        &["<b> ($1) [root] -> [b.py(0) definition b] <> ($1)"],
+    );
+}

--- a/tests/it/can_jump_to_definition_with_partial_paths.rs
+++ b/tests/it/can_jump_to_definition_with_partial_paths.rs
@@ -1,0 +1,133 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use std::collections::HashSet;
+
+use stack_graphs::graph::StackGraph;
+use stack_graphs::partial::PartialPaths;
+use stack_graphs::paths::Paths;
+use stack_graphs::stitching::Database;
+use stack_graphs::stitching::PathStitcher;
+
+use crate::test_graphs;
+
+fn check_jump_to_definition(graph: &StackGraph, expected_paths: &[&str]) {
+    let mut paths = Paths::new();
+    let mut partials = PartialPaths::new();
+    let mut db = Database::new();
+
+    // Generate partial paths for everything in the database.
+    for file in graph.iter_files() {
+        partials.find_all_partial_paths_in_file(graph, file, |graph, partials, path| {
+            if !path.is_complete_as_possible(graph) {
+                return;
+            }
+            if !path.is_productive(partials) {
+                return;
+            }
+            db.add_partial_path(graph, partials, path);
+        });
+    }
+
+    let references = graph
+        .iter_nodes()
+        .filter(|handle| graph[*handle].is_reference());
+    let complete_paths = PathStitcher::find_all_complete_paths(
+        graph,
+        &mut paths,
+        &mut partials,
+        &mut db,
+        references,
+    );
+    let results = complete_paths
+        .into_iter()
+        .map(|path| path.display(graph, &mut paths).to_string())
+        .collect::<HashSet<_>>();
+
+    let expected_paths = expected_paths
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<HashSet<_>>();
+    assert_eq!(results, expected_paths);
+}
+
+#[test]
+fn class_field_through_function_parameter() {
+    let fixture = test_graphs::class_field_through_function_parameter::new();
+    check_jump_to_definition(
+        &fixture.graph,
+        &[
+            // reference to `a` in import statement
+            "[main.py(17) reference a] -> [a.py(0) definition a]",
+            // reference to `b` in import statement
+            "[main.py(15) reference b] -> [b.py(0) definition b]",
+            // reference to `foo` in function call resolves to function definition
+            "[main.py(13) reference foo] -> [a.py(5) definition foo]",
+            // reference to `A` as function parameter resolves to class definition
+            "[main.py(9) reference A] -> [b.py(5) definition A]",
+            // reference to `bar` on result flows through body of `foo` to find `A.bar`
+            "[main.py(10) reference bar] -> [b.py(8) definition bar]",
+            // reference to `x` in function body resolves to formal parameter
+            "[a.py(8) reference x] -> [a.py(14) definition x]",
+        ],
+    );
+}
+
+#[test]
+fn cyclic_imports_python() {
+    let fixture = test_graphs::cyclic_imports_python::new();
+    check_jump_to_definition(
+        &fixture.graph,
+        &[
+            // reference to `a` in import statement
+            "[main.py(8) reference a] -> [a.py(0) definition a]",
+            // reference to `foo` resolves through intermediate file to find `b.foo`
+            "[main.py(6) reference foo] -> [b.py(6) definition foo]",
+            // reference to `b` in import statement
+            "[a.py(6) reference b] -> [b.py(0) definition b]",
+            // reference to `a` in import statement
+            "[b.py(8) reference a] -> [a.py(0) definition a]",
+        ],
+    );
+}
+
+#[test]
+fn cyclic_imports_rust() {
+    let fixture = test_graphs::cyclic_imports_rust::new();
+    check_jump_to_definition(
+        &fixture.graph,
+        &[
+            // reference to `a` in `a::FOO` resolves to module definition
+            "[test.rs(103) reference a] -> [test.rs(201) definition a]",
+            // reference to `a::FOO` in `main` can resolve either to `a::BAR` or `b::FOO`
+            "[test.rs(101) reference FOO] -> [test.rs(304) definition FOO]",
+            "[test.rs(101) reference FOO] -> [test.rs(204) definition BAR]",
+            // reference to `b` in use statement resolves to module definition
+            "[test.rs(206) reference b] -> [test.rs(301) definition b]",
+            // reference to `a` in use statement resolves to module definition
+            "[test.rs(307) reference a] -> [test.rs(201) definition a]",
+            // reference to `BAR` in module `b` can _only_ resolve to `a::BAR`
+            "[test.rs(305) reference BAR] -> [test.rs(204) definition BAR]",
+        ],
+    );
+}
+
+#[test]
+fn sequenced_import_star() {
+    let fixture = test_graphs::sequenced_import_star::new();
+    check_jump_to_definition(
+        &fixture.graph,
+        &[
+            // reference to `a` in import statement
+            "[main.py(8) reference a] -> [a.py(0) definition a]",
+            // reference to `foo` resolves through intermediate file to find `b.foo`
+            "[main.py(6) reference foo] -> [b.py(5) definition foo]",
+            // reference to `b` in import statement
+            "[a.py(6) reference b] -> [b.py(0) definition b]",
+        ],
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -13,5 +13,6 @@ mod can_find_node_partial_paths_in_database;
 mod can_find_partial_paths_in_file;
 mod can_find_root_partial_paths_in_database;
 mod can_jump_to_definition;
+mod can_jump_to_definition_with_partial_paths;
 mod graph;
 mod paths;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -9,7 +9,9 @@ pub mod test_graphs;
 
 mod arena;
 mod can_create_graph;
+mod can_find_node_partial_paths_in_database;
 mod can_find_partial_paths_in_file;
+mod can_find_root_partial_paths_in_database;
 mod can_jump_to_definition;
 mod graph;
 mod paths;


### PR DESCRIPTION
This is an implementation of the path stitching algorithm that's divided up into "phases".  At the start of each phase, we process whatever (possibly incomplete) paths are currently in the queue.  As we extend those paths with partial paths, we queue up the newly extended paths to be processed in the _next_ phase.  This phasing approach means that the Database instance doesn't need to be pre-loaded with _all_ of the partial paths that we might ever need to process.  Instead, you're notified of each path in the phase _before_ it will be processed, giving you a chance to add its extensions to the database before allowing the next phase to proceed.