### PR TITLE
Add precedences to edges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,5 @@ libc = "0.2"
 smallvec = { version="1.6", features=["union"] }
 
 [dev-dependencies]
+itertools = "0.10"
 maplit = "1.0"

--- a/include/stack-graphs.h
+++ b/include/stack-graphs.h
@@ -146,6 +146,7 @@ struct sg_nodes {
 struct sg_edge {
     sg_node_handle source;
     sg_node_handle sink;
+    int32_t precedence;
 };
 
 // The handle of the singleton root node.

--- a/src/c.rs
+++ b/src/c.rs
@@ -12,7 +12,6 @@
 use libc::c_char;
 
 use crate::arena::Handle;
-use crate::graph::Edge;
 use crate::graph::File;
 use crate::graph::Node;
 use crate::graph::NodeID;
@@ -389,6 +388,7 @@ fn validate_node(graph: &StackGraph, node: &sg_node) -> Option<Node> {
 pub struct sg_edge {
     pub source: sg_node_handle,
     pub sink: sg_node_handle,
+    pub precedence: i32,
 }
 
 /// Adds new edges to the stack graph.  You provide an array of `struct sg_edges` instances.  A
@@ -405,6 +405,6 @@ pub extern "C" fn sg_stack_graph_add_edges(
     for i in 0..count {
         let source = unsafe { std::mem::transmute(edges[i].source) };
         let sink = unsafe { std::mem::transmute(edges[i].sink) };
-        graph.add_edge(Edge { source, sink });
+        graph.add_edge(source, sink, edges[i].precedence);
     }
 }

--- a/src/cycles.rs
+++ b/src/cycles.rs
@@ -65,7 +65,7 @@ impl HasPathKey for Path {
     }
 
     fn is_shorter_than(&self, other: &Self) -> bool {
-        self.edge_count < other.edge_count && self.symbol_stack.len() <= other.symbol_stack.len()
+        self.edges.len() < other.edges.len() && self.symbol_stack.len() <= other.symbol_stack.len()
     }
 }
 
@@ -78,7 +78,7 @@ impl HasPathKey for PartialPath {
     }
 
     fn is_shorter_than(&self, other: &Self) -> bool {
-        self.edge_count < other.edge_count
+        self.edges.len() < other.edges.len()
     }
 }
 

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -18,12 +18,15 @@
 use std::collections::VecDeque;
 use std::fmt::Display;
 
+use crate::arena::Deque;
+use crate::arena::DequeArena;
 use crate::arena::Handle;
 use crate::arena::List;
 use crate::arena::ListArena;
 use crate::cycles::CycleDetector;
 use crate::graph::Edge;
 use crate::graph::Node;
+use crate::graph::NodeID;
 use crate::graph::StackGraph;
 use crate::graph::Symbol;
 use crate::utils::cmp_option;
@@ -337,6 +340,169 @@ impl DisplayWithPaths for ScopeStack {
 }
 
 //-------------------------------------------------------------------------------------------------
+// Edge lists
+
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+pub struct PathEdge {
+    pub source_node_id: NodeID,
+    pub precedence: i32,
+}
+
+impl PathEdge {
+    pub fn display<'a>(self, graph: &'a StackGraph, paths: &'a mut Paths) -> impl Display + 'a {
+        display_with(self, graph, paths)
+    }
+}
+
+impl DisplayWithPaths for PathEdge {
+    fn display_with(
+        &self,
+        graph: &StackGraph,
+        _paths: &Paths,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        match graph.node_for_id(self.source_node_id) {
+            Some(node) => write!(f, "{:#}", node.display(graph))?,
+            None => write!(f, "[missing]")?,
+        }
+        if self.precedence != 0 {
+            write!(f, "({})", self.precedence)?;
+        }
+        Ok(())
+    }
+}
+
+/// The edges in a path keep track of precedence information so that we can correctly handle
+/// shadowed definitions.
+#[derive(Clone, Copy)]
+pub struct PathEdgeList {
+    edges: Deque<PathEdge>,
+    length: usize,
+}
+
+impl PathEdgeList {
+    /// Returns whether this edge list is empty.
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.edges.is_empty()
+    }
+
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.length
+    }
+
+    /// Returns an empty edge list.
+    pub fn empty() -> PathEdgeList {
+        PathEdgeList {
+            edges: Deque::empty(),
+            length: 0,
+        }
+    }
+
+    /// Pushes a new edge onto the front of this edge list.
+    pub fn push_front(&mut self, paths: &mut Paths, edge: PathEdge) {
+        self.length += 1;
+        self.edges.push_front(&mut paths.path_edges, edge);
+    }
+
+    /// Pushes a new edge onto the back of this edge list.
+    pub fn push_back(&mut self, paths: &mut Paths, edge: PathEdge) {
+        self.length += 1;
+        self.edges.push_back(&mut paths.path_edges, edge);
+    }
+
+    /// Removes and returns the edge at the front of this edge list.  If the list is empty, returns
+    /// `None`.
+    pub fn pop_front(&mut self, paths: &mut Paths) -> Option<PathEdge> {
+        let result = self.edges.pop_front(&mut paths.path_edges);
+        if result.is_some() {
+            self.length -= 1;
+        }
+        result.copied()
+    }
+
+    /// Removes and returns the edge at the back of this edge list.  If the list is empty, returns
+    /// `None`.
+    pub fn pop_back(&mut self, paths: &mut Paths) -> Option<PathEdge> {
+        let result = self.edges.pop_back(&mut paths.path_edges);
+        if result.is_some() {
+            self.length -= 1;
+        }
+        result.copied()
+    }
+
+    pub fn display<'a>(self, graph: &'a StackGraph, paths: &'a mut Paths) -> impl Display + 'a {
+        display_with(self, graph, paths)
+    }
+
+    pub fn equals(mut self, paths: &mut Paths, mut other: PathEdgeList) -> bool {
+        while let Some(self_edge) = self.pop_front(paths) {
+            if let Some(other_edge) = other.pop_front(paths) {
+                if self_edge != other_edge {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+        other.edges.is_empty()
+    }
+
+    pub fn cmp(mut self, paths: &mut Paths, mut other: PathEdgeList) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+        while let Some(self_edge) = self.pop_front(paths) {
+            if let Some(other_edge) = other.pop_front(paths) {
+                match self_edge.cmp(&other_edge) {
+                    Ordering::Equal => continue,
+                    result @ _ => return result,
+                }
+            } else {
+                return Ordering::Greater;
+            }
+        }
+        if other.edges.is_empty() {
+            Ordering::Equal
+        } else {
+            Ordering::Less
+        }
+    }
+
+    /// Returns an iterator over the contents of this edge list.
+    pub fn iter<'a>(&self, paths: &'a mut Paths) -> impl Iterator<Item = PathEdge> + 'a {
+        self.edges.iter(&mut paths.path_edges).copied()
+    }
+
+    /// Returns an iterator over the contents of this edge list, with no guarantee about the
+    /// ordering of the elements.
+    pub fn iter_unordered<'a>(&self, paths: &'a Paths) -> impl Iterator<Item = PathEdge> + 'a {
+        self.edges.iter_unordered(&paths.path_edges).copied()
+    }
+}
+
+impl DisplayWithPaths for PathEdgeList {
+    fn prepare(&mut self, graph: &StackGraph, paths: &mut Paths) {
+        self.edges.ensure_forwards(&mut paths.path_edges);
+        let mut edges = self.edges;
+        while let Some(mut edge) = edges.pop_front(&mut paths.path_edges).copied() {
+            edge.prepare(graph, paths);
+        }
+    }
+
+    fn display_with(
+        &self,
+        graph: &StackGraph,
+        paths: &Paths,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        for edge in self.edges.iter_reused(&paths.path_edges) {
+            edge.display_with(graph, paths, f)?;
+        }
+        Ok(())
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
 // Paths
 
 /// A sequence of edges from a stack graph.  A _complete_ path represents a full name binding in a
@@ -347,7 +513,7 @@ pub struct Path {
     pub end_node: Handle<Node>,
     pub symbol_stack: SymbolStack,
     pub scope_stack: ScopeStack,
-    pub edge_count: usize,
+    pub edges: PathEdgeList,
 }
 
 impl Path {
@@ -376,23 +542,25 @@ impl Path {
             end_node: node,
             symbol_stack,
             scope_stack,
-            edge_count: 0,
+            edges: PathEdgeList::empty(),
         })
     }
 
-    pub fn equals(&self, paths: &Paths, other: &Path) -> bool {
+    pub fn equals(&self, paths: &mut Paths, other: &Path) -> bool {
         self.start_node == other.start_node
             && self.end_node == other.end_node
             && self.symbol_stack.equals(paths, &other.symbol_stack)
             && self.scope_stack.equals(paths, &other.scope_stack)
+            && self.edges.equals(paths, other.edges)
     }
 
-    pub fn cmp(&self, graph: &StackGraph, paths: &Paths, other: &Path) -> std::cmp::Ordering {
+    pub fn cmp(&self, graph: &StackGraph, paths: &mut Paths, other: &Path) -> std::cmp::Ordering {
         std::cmp::Ordering::Equal
             .then_with(|| self.start_node.cmp(&other.start_node))
             .then_with(|| self.end_node.cmp(&other.end_node))
             .then_with(|| self.symbol_stack.cmp(graph, paths, &other.symbol_stack))
             .then_with(|| self.scope_stack.cmp(paths, &other.scope_stack))
+            .then_with(|| self.edges.cmp(paths, other.edges))
     }
 
     /// A _complete_ path represents a full name binding that resolves a reference to a definition.
@@ -546,7 +714,13 @@ impl Path {
         }
 
         self.end_node = edge.sink;
-        self.edge_count += 1;
+        self.edges.push_back(
+            paths,
+            PathEdge {
+                source_node_id: graph[edge.source].id(),
+                precedence: edge.precedence,
+            },
+        );
         Ok(())
     }
 
@@ -556,7 +730,7 @@ impl Path {
     pub fn resolve(
         &mut self,
         graph: &StackGraph,
-        paths: &Paths,
+        paths: &mut Paths,
     ) -> Result<(), PathResolutionError> {
         if !graph[self.end_node].is_jump_to() {
             return Ok(());
@@ -565,8 +739,14 @@ impl Path {
             Some(scope) => scope,
             None => return Err(PathResolutionError::EmptyScopeStack),
         };
+        self.edges.push_back(
+            paths,
+            PathEdge {
+                source_node_id: graph[self.end_node].id(),
+                precedence: 0,
+            },
+        );
         self.end_node = top_scope;
-        self.edge_count += 1;
         Ok(())
     }
 
@@ -666,6 +846,7 @@ impl<T> Extend<T> for VecDeque<T> {
 pub struct Paths {
     scope_stacks: ListArena<Handle<Node>>,
     symbol_stacks: ListArena<ScopedSymbol>,
+    path_edges: DequeArena<PathEdge>,
 }
 
 impl Paths {
@@ -673,6 +854,7 @@ impl Paths {
         Paths {
             scope_stacks: List::new_arena(),
             symbol_stacks: List::new_arena(),
+            path_edges: Deque::new_arena(),
         }
     }
 }

--- a/tests/it/c/test_graph.rs
+++ b/tests/it/c/test_graph.rs
@@ -87,7 +87,11 @@ impl CreateStackGraph for TestGraph {
     }
 
     fn edge(&mut self, source: sg_node_handle, sink: sg_node_handle) {
-        let edge = sg_edge { source, sink };
+        let edge = sg_edge {
+            source,
+            sink,
+            precedence: 0,
+        };
         let edges = [edge];
         sg_stack_graph_add_edges(self.graph, edges.len(), edges.as_ptr());
     }

--- a/tests/it/graph.rs
+++ b/tests/it/graph.rs
@@ -8,7 +8,6 @@
 use std::collections::HashSet;
 
 use maplit::hashset;
-use stack_graphs::graph::Edge;
 use stack_graphs::graph::StackGraph;
 
 use crate::test_graphs::CreateStackGraph;
@@ -90,29 +89,19 @@ fn can_add_and_remove_edges() {
     let h2 = graph.internal_scope(file, 1);
     let h3 = graph.internal_scope(file, 2);
     let h4 = graph.internal_scope(file, 3);
-    graph.add_edge(Edge {
-        source: h1,
-        sink: h2,
-    });
-    graph.add_edge(Edge {
-        source: h1,
-        sink: h3,
-    });
-    graph.add_edge(Edge {
-        source: h1,
-        sink: h4,
-    });
+    graph.add_edge(h1, h2, 0);
+    graph.add_edge(h1, h3, 0);
+    graph.add_edge(h1, h4, 0);
+    // If you try to overwrite an edge, the original edge takes precedence.
+    graph.add_edge(h1, h3, 1);
     assert_eq!(
         graph
             .outgoing_edges(h1)
-            .map(|edge| edge.sink)
+            .map(|edge| (edge.sink, edge.precedence))
             .collect::<HashSet<_>>(),
-        hashset! { h2, h3, h4 }
+        hashset! { (h2, 0), (h3, 0), (h4, 0) }
     );
-    graph.remove_edge(Edge {
-        source: h1,
-        sink: h3,
-    });
+    graph.remove_edge(h1, h3);
     assert_eq!(
         graph
             .outgoing_edges(h1)

--- a/tests/it/paths.rs
+++ b/tests/it/paths.rs
@@ -5,7 +5,14 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+use itertools::Itertools;
+use stack_graphs::arena::Handle;
+use stack_graphs::graph::Edge;
+use stack_graphs::graph::File;
+use stack_graphs::graph::Node;
+use stack_graphs::graph::NodeID;
 use stack_graphs::graph::StackGraph;
+use stack_graphs::paths::Path;
 use stack_graphs::paths::Paths;
 use stack_graphs::paths::ScopeStack;
 use stack_graphs::paths::ScopedSymbol;
@@ -76,4 +83,107 @@ fn can_iterate_scope_stacks() {
         rendered,
         "[test.py(0) exported scope][test.py(1) exported scope][test.py(2) exported scope]"
     );
+}
+
+struct ShadowingTest {
+    graph: StackGraph,
+    paths: Paths,
+    file: Handle<File>,
+}
+
+impl ShadowingTest {
+    fn new() -> ShadowingTest {
+        let mut graph = StackGraph::new();
+        let paths = Paths::new();
+        let file = graph.get_or_create_file("test.py");
+        ShadowingTest { graph, paths, file }
+    }
+
+    fn new_node(&mut self, local_id: u32) -> Handle<Node> {
+        let id = NodeID::new_in_file(self.file, local_id);
+        match self.graph.node_for_id(id) {
+            Some(node) => node,
+            None => self.graph.internal_scope(self.file, local_id),
+        }
+    }
+
+    fn new_path(&mut self, start_node: u32, edges: &[(i32, u32)]) -> Path {
+        let start_node = self.new_node(start_node);
+        let mut path = Path::from_node(&mut self.graph, &mut self.paths, start_node).unwrap();
+        let mut previous = start_node;
+        for (precedence, node) in edges.iter().copied() {
+            let node = self.new_node(node);
+            path.append(
+                &mut self.graph,
+                &mut self.paths,
+                Edge {
+                    source: previous,
+                    sink: node,
+                    precedence,
+                },
+            )
+            .unwrap();
+            previous = node;
+        }
+        path
+    }
+}
+
+#[test]
+fn paths_can_shadow_other_paths() {
+    let mut test = ShadowingTest::new();
+    let path1 = test.new_path(1, &vec![(0, 2), (0, 3), (1, 4), (0, 5)]);
+    let path2 = test.new_path(1, &vec![(0, 2), (1, 5), (0, 6)]);
+    assert!(path2.shadows(&mut test.paths, &path1));
+    assert!(!path1.shadows(&mut test.paths, &path2));
+}
+
+#[test]
+fn path_does_not_shadow_if_source_ids_differ() {
+    let mut test = ShadowingTest::new();
+    let path1 = test.new_path(1, &vec![(0, 2), (1, 3), (0, 4)]);
+    let path2 = test.new_path(2, &vec![(0, 3), (1, 4), (0, 5)]);
+    assert!(!path1.shadows(&mut test.paths, &path2));
+    assert!(!path2.shadows(&mut test.paths, &path1));
+}
+
+#[test]
+fn can_remove_shadowed_paths() {
+    let mut test = ShadowingTest::new();
+    // path1 is shadowed by path2 because of their second edges.
+    let path1 = test.new_path(1, &vec![(0, 2), (0, 3), (1, 4), (0, 5)]);
+    let path2 = test.new_path(1, &vec![(0, 2), (1, 5), (0, 3)]);
+    let mut paths = vec![path1.clone(), path2.clone()];
+    test.paths.remove_shadowed_paths(&mut paths);
+    let expected = vec![path2];
+    assert!(paths
+        .into_iter()
+        .zip_eq(expected)
+        .all(|(a, b)| a.equals(&mut test.paths, &b)));
+}
+
+#[test]
+fn nonshadowed_paths_are_not_removed() {
+    let mut test = ShadowingTest::new();
+    let path1 = test.new_path(1, &vec![(0, 2), (1, 3), (0, 4)]);
+    let path2 = test.new_path(1, &vec![(0, 5), (1, 6), (0, 7)]);
+    let mut paths = vec![path1.clone(), path2.clone()];
+    test.paths.remove_shadowed_paths(&mut paths);
+    let expected = vec![path1, path2];
+    assert!(paths
+        .into_iter()
+        .zip_eq(expected)
+        .all(|(a, b)| a.equals(&mut test.paths, &b)));
+}
+
+#[test]
+fn can_remove_shadowed_paths_for_empty_paths() {
+    let mut test = ShadowingTest::new();
+    let mut paths = vec![];
+    test.paths.remove_shadowed_paths(&mut paths);
+    let expected = vec![];
+    assert!(paths
+        .into_iter()
+        .zip_eq(expected)
+        .all(|(a, b)| a.equals(&mut test.paths, &b)));
 }

--- a/tests/it/test_graphs/mod.rs
+++ b/tests/it/test_graphs/mod.rs
@@ -82,8 +82,7 @@ impl CreateStackGraph for StackGraph {
     }
 
     fn edge(&mut self, source: Handle<Node>, sink: Handle<Node>) {
-        let edge = Edge { source, sink };
-        self.add_edge(edge);
+        self.add_edge(source, sink, 0);
     }
 
     fn exported_scope(&mut self, file: Handle<File>, local_id: u32) -> Handle<Node> {


### PR DESCRIPTION
Edges can now have precedence values, which can be taken into account when finding or stitching paths.  This is used to model how some definitions can "shadow" others in a source file.