### PR TITLE
Add C bindings for creating nodes and edges

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -644,6 +644,9 @@ impl IndexMut<Handle<Node>> for StackGraph {
 pub struct DropScopesNode {
     /// The unique identifier for this node.
     pub id: NodeID,
+    _symbol: Option<Handle<Symbol>>,
+    _scope: Option<Handle<Node>>,
+    _is_clickable: bool,
 }
 
 impl From<DropScopesNode> for Node {
@@ -652,12 +655,20 @@ impl From<DropScopesNode> for Node {
     }
 }
 
-impl DropScopesNode {
-    /// Adds the node to a stack graph.
-    pub fn add_to_graph(self, graph: &mut StackGraph) -> Option<Handle<Node>> {
-        graph.add_node(self.id, self.into())
+impl StackGraph {
+    /// Adds a _drop scopes_ node to the stack graph.
+    pub fn add_drop_scopes_node(&mut self, id: NodeID) -> Option<Handle<Node>> {
+        let node = DropScopesNode {
+            id,
+            _symbol: None,
+            _scope: None,
+            _is_clickable: false,
+        };
+        self.add_node(id, node.into())
     }
+}
 
+impl DropScopesNode {
     pub fn display<'a>(&'a self, graph: &'a StackGraph) -> impl Display + 'a {
         DisplayDropScopesNode {
             wrapped: self,
@@ -687,6 +698,9 @@ impl<'a> Display for DisplayDropScopesNode<'a> {
 pub struct ExportedScopeNode {
     /// The unique identifier for this node.
     pub id: NodeID,
+    _symbol: Option<Handle<Symbol>>,
+    _scope: Option<Handle<Node>>,
+    _is_clickable: bool,
 }
 
 impl From<ExportedScopeNode> for Node {
@@ -695,12 +709,20 @@ impl From<ExportedScopeNode> for Node {
     }
 }
 
-impl ExportedScopeNode {
-    /// Adds the node to a stack graph.
-    pub fn add_to_graph(self, graph: &mut StackGraph) -> Option<Handle<Node>> {
-        graph.add_node(self.id, self.into())
+impl StackGraph {
+    /// Adds a _exported scope_ node to the stack graph.
+    pub fn add_exported_scope_node(&mut self, id: NodeID) -> Option<Handle<Node>> {
+        let node = ExportedScopeNode {
+            id,
+            _symbol: None,
+            _scope: None,
+            _is_clickable: false,
+        };
+        self.add_node(id, node.into())
     }
+}
 
+impl ExportedScopeNode {
     pub fn display<'a>(&'a self, graph: &'a StackGraph) -> impl Display + 'a {
         DisplayExportedScopeNode {
             wrapped: self,
@@ -734,6 +756,9 @@ impl<'a> Display for DisplayExportedScopeNode<'a> {
 pub struct InternalScopeNode {
     /// The unique identifier for this node.
     pub id: NodeID,
+    _symbol: Option<Handle<Symbol>>,
+    _scope: Option<Handle<Node>>,
+    _is_clickable: bool,
 }
 
 impl From<InternalScopeNode> for Node {
@@ -742,12 +767,20 @@ impl From<InternalScopeNode> for Node {
     }
 }
 
-impl InternalScopeNode {
-    /// Adds the node to a stack graph.
-    pub fn add_to_graph(self, graph: &mut StackGraph) -> Option<Handle<Node>> {
-        graph.add_node(self.id, self.into())
+impl StackGraph {
+    /// Adds a _internal scope_ node to the stack graph.
+    pub fn add_internal_scope_node(&mut self, id: NodeID) -> Option<Handle<Node>> {
+        let node = InternalScopeNode {
+            id,
+            _symbol: None,
+            _scope: None,
+            _is_clickable: false,
+        };
+        self.add_node(id, node.into())
     }
+}
 
+impl InternalScopeNode {
     pub fn display<'a>(&'a self, graph: &'a StackGraph) -> impl Display + 'a {
         DisplayInternalScopeNode {
             wrapped: self,
@@ -778,11 +811,30 @@ impl<'a> Display for DisplayInternalScopeNode<'a> {
 
 /// The singleton "jump to" node, which allows a name binding path to jump back to another part of
 /// the graph.
-pub struct JumpToNode;
+pub struct JumpToNode {
+    _id: NodeID,
+    _symbol: Option<Handle<Symbol>>,
+    _scope: Option<Handle<Node>>,
+    _is_clickable: bool,
+}
 
 impl From<JumpToNode> for Node {
     fn from(node: JumpToNode) -> Node {
         Node::JumpTo(node)
+    }
+}
+
+impl JumpToNode {
+    fn new() -> JumpToNode {
+        JumpToNode {
+            _id: NodeID {
+                file: None,
+                local_id: 0,
+            },
+            _symbol: None,
+            _scope: None,
+            _is_clickable: false,
+        }
     }
 }
 
@@ -800,6 +852,7 @@ pub struct PopScopedSymbolNode {
     pub id: NodeID,
     /// The symbol to pop off the symbol stack.
     pub symbol: Handle<Symbol>,
+    _scope: Option<Handle<Node>>,
     /// Whether this node represents a reference in the source language.
     pub is_definition: bool,
 }
@@ -810,12 +863,25 @@ impl From<PopScopedSymbolNode> for Node {
     }
 }
 
-impl PopScopedSymbolNode {
-    /// Adds the node to a stack graph.
-    pub fn add_to_graph(self, graph: &mut StackGraph) -> Option<Handle<Node>> {
-        graph.add_node(self.id, self.into())
+impl StackGraph {
+    /// Adds a _pop scoped symbol_ node to the stack graph.
+    pub fn add_pop_scoped_symbol_node(
+        &mut self,
+        id: NodeID,
+        symbol: Handle<Symbol>,
+        is_definition: bool,
+    ) -> Option<Handle<Node>> {
+        let node = PopScopedSymbolNode {
+            id,
+            symbol,
+            _scope: None,
+            is_definition,
+        };
+        self.add_node(id, node.into())
     }
+}
 
+impl PopScopedSymbolNode {
     pub fn display<'a>(&'a self, graph: &'a StackGraph) -> impl Display + 'a {
         DisplayPopScopedSymbolNode {
             wrapped: self,
@@ -857,6 +923,7 @@ pub struct PopSymbolNode {
     pub id: NodeID,
     /// The symbol to pop off the symbol stack.
     pub symbol: Handle<Symbol>,
+    _scope: Option<Handle<Node>>,
     /// Whether this node represents a reference in the source language.
     pub is_definition: bool,
 }
@@ -867,12 +934,25 @@ impl From<PopSymbolNode> for Node {
     }
 }
 
-impl PopSymbolNode {
-    /// Adds the node to a stack graph.
-    pub fn add_to_graph(self, graph: &mut StackGraph) -> Option<Handle<Node>> {
-        graph.add_node(self.id, self.into())
+impl StackGraph {
+    /// Adds a _pop symbol_ node to the stack graph.
+    pub fn add_pop_symbol_node(
+        &mut self,
+        id: NodeID,
+        symbol: Handle<Symbol>,
+        is_definition: bool,
+    ) -> Option<Handle<Node>> {
+        let node = PopSymbolNode {
+            id,
+            symbol,
+            _scope: None,
+            is_definition,
+        };
+        self.add_node(id, node.into())
     }
+}
 
+impl PopSymbolNode {
     pub fn display<'a>(&'a self, graph: &'a StackGraph) -> impl Display + 'a {
         DisplayPopSymbolNode {
             wrapped: self,
@@ -918,6 +998,7 @@ pub struct PushScopedSymbolNode {
     pub scope: Handle<Node>,
     /// Whether this node represents a reference in the source language.
     pub is_reference: bool,
+    _phantom: (),
 }
 
 impl From<PushScopedSymbolNode> for Node {
@@ -926,12 +1007,27 @@ impl From<PushScopedSymbolNode> for Node {
     }
 }
 
-impl PushScopedSymbolNode {
-    /// Adds the node to a stack graph.
-    pub fn add_to_graph(self, graph: &mut StackGraph) -> Option<Handle<Node>> {
-        graph.add_node(self.id, self.into())
+impl StackGraph {
+    /// Adds a _push scoped symbol_ node to the stack graph.
+    pub fn add_push_scoped_symbol_node(
+        &mut self,
+        id: NodeID,
+        symbol: Handle<Symbol>,
+        scope: Handle<Node>,
+        is_reference: bool,
+    ) -> Option<Handle<Node>> {
+        let node = PushScopedSymbolNode {
+            id,
+            symbol,
+            scope,
+            is_reference,
+            _phantom: (),
+        };
+        self.add_node(id, node.into())
     }
+}
 
+impl PushScopedSymbolNode {
     pub fn display<'a>(&'a self, graph: &'a StackGraph) -> impl Display + 'a {
         DisplayPushScopedSymbolNode {
             wrapped: self,
@@ -973,6 +1069,7 @@ pub struct PushSymbolNode {
     pub id: NodeID,
     /// The symbol to push onto the symbol stack.
     pub symbol: Handle<Symbol>,
+    _scope: Option<Handle<Node>>,
     /// Whether this node represents a reference in the source language.
     pub is_reference: bool,
 }
@@ -983,12 +1080,25 @@ impl From<PushSymbolNode> for Node {
     }
 }
 
-impl PushSymbolNode {
-    /// Adds the node to a stack graph.
-    pub fn add_to_graph(self, graph: &mut StackGraph) -> Option<Handle<Node>> {
-        graph.add_node(self.id, self.into())
+impl StackGraph {
+    /// Adds a _push symbol_ node to the stack graph.
+    pub fn add_push_symbol_node(
+        &mut self,
+        id: NodeID,
+        symbol: Handle<Symbol>,
+        is_reference: bool,
+    ) -> Option<Handle<Node>> {
+        let node = PushSymbolNode {
+            id,
+            symbol,
+            _scope: None,
+            is_reference,
+        };
+        self.add_node(id, node.into())
     }
+}
 
+impl PushSymbolNode {
     pub fn display<'a>(&'a self, graph: &'a StackGraph) -> impl Display + 'a {
         DisplayPushSymbolNode {
             wrapped: self,
@@ -1024,11 +1134,30 @@ impl<'a> Display for DisplayPushSymbolNode<'a> {
 }
 
 /// The singleton root node, which allows a name binding path to cross between files.
-pub struct RootNode;
+pub struct RootNode {
+    _id: NodeID,
+    _symbol: Option<Handle<Symbol>>,
+    _scope: Option<Handle<Node>>,
+    _is_clickable: bool,
+}
 
 impl From<RootNode> for Node {
     fn from(node: RootNode) -> Node {
         Node::Root(node)
+    }
+}
+
+impl RootNode {
+    fn new() -> RootNode {
+        RootNode {
+            _id: NodeID {
+                file: None,
+                local_id: 0,
+            },
+            _symbol: None,
+            _scope: None,
+            _is_clickable: false,
+        }
     }
 }
 
@@ -1162,8 +1291,8 @@ impl StackGraph {
 impl Default for StackGraph {
     fn default() -> StackGraph {
         let mut nodes = Arena::new();
-        let root_node = nodes.add(RootNode.into());
-        let jump_to_node = nodes.add(JumpToNode.into());
+        let root_node = nodes.add(RootNode::new().into());
+        let jump_to_node = nodes.add(JumpToNode::new().into());
 
         StackGraph {
             interned_strings: InternedStringContent::new(),

--- a/tests/it/c/can_create_graph.rs
+++ b/tests/it/c/can_create_graph.rs
@@ -1,0 +1,29 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use crate::c::test_graph::TestGraph;
+use crate::test_graphs;
+
+#[test]
+fn class_field_through_function_parameter() {
+    let _: TestGraph = test_graphs::class_field_through_function_parameter::new();
+}
+
+#[test]
+fn cyclic_imports_python() {
+    let _: TestGraph = test_graphs::cyclic_imports_python::new();
+}
+
+#[test]
+fn cyclic_imports_rust() {
+    let _: TestGraph = test_graphs::cyclic_imports_rust::new();
+}
+
+#[test]
+fn sequenced_import_star() {
+    let _: TestGraph = test_graphs::sequenced_import_star::new();
+}

--- a/tests/it/c/mod.rs
+++ b/tests/it/c/mod.rs
@@ -5,5 +5,8 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+mod can_create_graph;
 mod files;
+mod nodes;
 mod symbols;
+mod test_graph;

--- a/tests/it/c/nodes.rs
+++ b/tests/it/c/nodes.rs
@@ -1,0 +1,521 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use libc::c_char;
+use stack_graphs::c::sg_file_handle;
+use stack_graphs::c::sg_node;
+use stack_graphs::c::sg_node_handle;
+use stack_graphs::c::sg_node_id;
+use stack_graphs::c::sg_node_kind;
+use stack_graphs::c::sg_nodes;
+use stack_graphs::c::sg_stack_graph;
+use stack_graphs::c::sg_stack_graph_add_files;
+use stack_graphs::c::sg_stack_graph_add_nodes;
+use stack_graphs::c::sg_stack_graph_add_symbols;
+use stack_graphs::c::sg_stack_graph_free;
+use stack_graphs::c::sg_stack_graph_new;
+use stack_graphs::c::sg_stack_graph_nodes;
+use stack_graphs::c::sg_symbol_handle;
+use stack_graphs::c::SG_JUMP_TO_NODE_HANDLE;
+use stack_graphs::c::SG_JUMP_TO_NODE_ID;
+use stack_graphs::c::SG_ROOT_NODE_HANDLE;
+use stack_graphs::c::SG_ROOT_NODE_ID;
+use stack_graphs::graph::Node;
+use stack_graphs::graph::NodeID;
+
+fn node_id(file: sg_file_handle, local_id: u32) -> NodeID {
+    NodeID::new_in_file(unsafe { std::mem::transmute(file) }, local_id)
+}
+
+fn add_file(graph: *mut sg_stack_graph, filename: &str) -> sg_file_handle {
+    let strings = [filename.as_bytes().as_ptr() as *const c_char];
+    let lengths = [filename.len()];
+    let mut handles: [sg_file_handle; 1] = [0; 1];
+    sg_stack_graph_add_files(
+        graph,
+        1,
+        strings.as_ptr(),
+        lengths.as_ptr(),
+        handles.as_mut_ptr(),
+    );
+    assert!(handles[0] != 0);
+    handles[0]
+}
+
+fn add_symbol(graph: *mut sg_stack_graph, symbol: &str) -> sg_symbol_handle {
+    let strings = [symbol.as_bytes().as_ptr() as *const c_char];
+    let lengths = [symbol.len()];
+    let mut handles: [sg_symbol_handle; 1] = [0; 1];
+    sg_stack_graph_add_symbols(
+        graph,
+        1,
+        strings.as_ptr(),
+        lengths.as_ptr(),
+        handles.as_mut_ptr(),
+    );
+    assert!(handles[0] != 0);
+    handles[0]
+}
+
+//-------------------------------------------------------------------------------------------------
+// Singleton nodes
+
+fn jump_to_node() -> sg_node {
+    sg_node {
+        kind: sg_node_kind::SG_NODE_KIND_JUMP_TO,
+        id: sg_node_id {
+            file: 0,
+            local_id: SG_JUMP_TO_NODE_ID,
+        },
+        symbol: 0,
+        is_clickable: false,
+        scope: 0,
+    }
+}
+
+fn root_node() -> sg_node {
+    sg_node {
+        kind: sg_node_kind::SG_NODE_KIND_ROOT,
+        id: sg_node_id {
+            file: 0,
+            local_id: SG_ROOT_NODE_ID,
+        },
+        symbol: 0,
+        is_clickable: false,
+        scope: 0,
+    }
+}
+
+fn get_node(arena: &sg_nodes, handle: sg_node_handle) -> &Node {
+    assert!(handle != 0);
+    let slice = unsafe { std::slice::from_raw_parts(arena.nodes as *const Node, arena.count) };
+    &slice[handle as usize]
+}
+
+#[test]
+fn cannot_add_singleton_nodes() {
+    let graph = sg_stack_graph_new();
+    let nodes = [root_node(), jump_to_node()];
+    let mut handles: [sg_node_handle; 2] = [0; 2];
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    assert!(handles.iter().all(|h| *h == 0));
+    sg_stack_graph_free(graph);
+}
+
+#[test]
+fn can_dereference_singleton_nodes() {
+    let graph = sg_stack_graph_new();
+    let node_arena = sg_stack_graph_nodes(graph);
+    assert!(get_node(&node_arena, SG_ROOT_NODE_HANDLE).is_root());
+    assert!(get_node(&node_arena, SG_JUMP_TO_NODE_HANDLE).is_jump_to());
+    sg_stack_graph_free(graph);
+}
+
+//-------------------------------------------------------------------------------------------------
+// Drop scopes node
+
+fn drop_scopes(file: sg_file_handle, local_id: u32) -> sg_node {
+    sg_node {
+        kind: sg_node_kind::SG_NODE_KIND_DROP_SCOPES,
+        id: sg_node_id { file, local_id },
+        symbol: 0,
+        is_clickable: false,
+        scope: 0,
+    }
+}
+
+#[test]
+fn can_add_drop_scopes_node() {
+    let graph = sg_stack_graph_new();
+    let file = add_file(graph, "test.py");
+    let nodes = [drop_scopes(file, 42)];
+    let mut handles: [sg_node_handle; 1] = [0; 1];
+    // Add the node and verify its contents after dereferencing it.
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    let node_arena = sg_stack_graph_nodes(graph);
+    let node = get_node(&node_arena, handles[0]);
+    assert!(matches!(node, Node::DropScopes(_)));
+    assert!(node.id() == node_id(file, 42));
+    // Make sure we can't add the same node again.
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    assert!(handles[0] == 0);
+    sg_stack_graph_free(graph);
+}
+
+#[test]
+fn drop_scopes_cannot_have_symbol() {
+    let graph = sg_stack_graph_new();
+    let file = add_file(graph, "test.py");
+    let symbol = add_symbol(graph, "a");
+    let mut nodes = [drop_scopes(file, 42)];
+    nodes[0].symbol = symbol;
+    let mut handles: [sg_node_handle; 1] = [0; 1];
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    assert!(handles[0] == 0);
+    sg_stack_graph_free(graph);
+}
+
+#[test]
+fn drop_scopes_cannot_have_scope() {
+    let graph = sg_stack_graph_new();
+    let file = add_file(graph, "test.py");
+    let mut nodes = [drop_scopes(file, 42)];
+    nodes[0].scope = SG_JUMP_TO_NODE_HANDLE;
+    let mut handles: [sg_node_handle; 1] = [0; 1];
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    assert!(handles[0] == 0);
+    sg_stack_graph_free(graph);
+}
+
+//-------------------------------------------------------------------------------------------------
+// Exported scope node
+
+fn exported_scope(file: sg_file_handle, local_id: u32) -> sg_node {
+    sg_node {
+        kind: sg_node_kind::SG_NODE_KIND_EXPORTED_SCOPE,
+        id: sg_node_id { file, local_id },
+        symbol: 0,
+        is_clickable: false,
+        scope: 0,
+    }
+}
+
+#[test]
+fn can_add_exported_scope_node() {
+    let graph = sg_stack_graph_new();
+    let file = add_file(graph, "test.py");
+    let nodes = [exported_scope(file, 42)];
+    let mut handles: [sg_node_handle; 1] = [0; 1];
+    // Add the node and verify its contents after dereferencing it.
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    let node_arena = sg_stack_graph_nodes(graph);
+    let node = get_node(&node_arena, handles[0]);
+    assert!(matches!(node, Node::ExportedScope(_)));
+    assert!(node.id() == node_id(file, 42));
+    // Make sure we can't add the same node again.
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    assert!(handles[0] == 0);
+    sg_stack_graph_free(graph);
+}
+
+#[test]
+fn exported_scope_cannot_have_symbol() {
+    let graph = sg_stack_graph_new();
+    let file = add_file(graph, "test.py");
+    let symbol = add_symbol(graph, "a");
+    let mut nodes = [exported_scope(file, 42)];
+    nodes[0].symbol = symbol;
+    let mut handles: [sg_node_handle; 1] = [0; 1];
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    assert!(handles[0] == 0);
+    sg_stack_graph_free(graph);
+}
+
+#[test]
+fn exported_scope_cannot_have_scope() {
+    let graph = sg_stack_graph_new();
+    let file = add_file(graph, "test.py");
+    let mut nodes = [exported_scope(file, 42)];
+    nodes[0].scope = SG_JUMP_TO_NODE_HANDLE;
+    let mut handles: [sg_node_handle; 1] = [0; 1];
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    assert!(handles[0] == 0);
+    sg_stack_graph_free(graph);
+}
+
+//-------------------------------------------------------------------------------------------------
+// Internal scope node
+
+fn internal_scope(file: sg_file_handle, local_id: u32) -> sg_node {
+    sg_node {
+        kind: sg_node_kind::SG_NODE_KIND_INTERNAL_SCOPE,
+        id: sg_node_id { file, local_id },
+        symbol: 0,
+        is_clickable: false,
+        scope: 0,
+    }
+}
+
+#[test]
+fn can_add_internal_scope_node() {
+    let graph = sg_stack_graph_new();
+    let file = add_file(graph, "test.py");
+    let nodes = [internal_scope(file, 42)];
+    let mut handles: [sg_node_handle; 1] = [0; 1];
+    // Add the node and verify its contents after dereferencing it.
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    let node_arena = sg_stack_graph_nodes(graph);
+    let node = get_node(&node_arena, handles[0]);
+    assert!(matches!(node, Node::InternalScope(_)));
+    assert!(node.id() == node_id(file, 42));
+    // Make sure we can't add the same node again.
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    assert!(handles[0] == 0);
+    sg_stack_graph_free(graph);
+}
+
+#[test]
+fn internal_scope_cannot_have_symbol() {
+    let graph = sg_stack_graph_new();
+    let file = add_file(graph, "test.py");
+    let symbol = add_symbol(graph, "a");
+    let mut nodes = [internal_scope(file, 42)];
+    nodes[0].symbol = symbol;
+    let mut handles: [sg_node_handle; 1] = [0; 1];
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    assert!(handles[0] == 0);
+    sg_stack_graph_free(graph);
+}
+
+#[test]
+fn internal_scope_cannot_have_scope() {
+    let graph = sg_stack_graph_new();
+    let file = add_file(graph, "test.py");
+    let mut nodes = [internal_scope(file, 42)];
+    nodes[0].scope = SG_JUMP_TO_NODE_HANDLE;
+    let mut handles: [sg_node_handle; 1] = [0; 1];
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    assert!(handles[0] == 0);
+    sg_stack_graph_free(graph);
+}
+
+//-------------------------------------------------------------------------------------------------
+// Pop scoped symbol node
+
+fn pop_scoped_symbol(file: sg_file_handle, local_id: u32, symbol: sg_symbol_handle) -> sg_node {
+    sg_node {
+        kind: sg_node_kind::SG_NODE_KIND_POP_SCOPED_SYMBOL,
+        id: sg_node_id { file, local_id },
+        symbol,
+        is_clickable: true,
+        scope: 0,
+    }
+}
+
+#[test]
+fn can_add_pop_scoped_symbol_node() {
+    let graph = sg_stack_graph_new();
+    let file = add_file(graph, "test.py");
+    let symbol = add_symbol(graph, "a");
+    let nodes = [pop_scoped_symbol(file, 42, symbol)];
+    let mut handles: [sg_node_handle; 1] = [0; 1];
+    // Add the node and verify its contents after dereferencing it.
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    let node_arena = sg_stack_graph_nodes(graph);
+    let node = get_node(&node_arena, handles[0]);
+    assert!(matches!(node, Node::PopScopedSymbol(_)));
+    assert!(node.id() == node_id(file, 42));
+    assert!(node.symbol().unwrap().as_usize() == symbol as usize);
+    assert!(node.is_definition());
+    // Make sure we can't add the same node again.
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    assert!(handles[0] == 0);
+    sg_stack_graph_free(graph);
+}
+
+#[test]
+fn pop_scoped_symbol_must_have_symbol() {
+    let graph = sg_stack_graph_new();
+    let file = add_file(graph, "test.py");
+    let nodes = [pop_scoped_symbol(file, 42, 0)];
+    let mut handles: [sg_node_handle; 1] = [0; 1];
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    assert!(handles[0] == 0);
+    sg_stack_graph_free(graph);
+}
+
+#[test]
+fn pop_scoped_symbol_cannot_have_scope() {
+    let graph = sg_stack_graph_new();
+    let file = add_file(graph, "test.py");
+    let symbol = add_symbol(graph, "a");
+    let mut nodes = [pop_scoped_symbol(file, 42, symbol)];
+    nodes[0].scope = SG_JUMP_TO_NODE_HANDLE;
+    let mut handles: [sg_node_handle; 1] = [0; 1];
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    assert!(handles[0] == 0);
+    sg_stack_graph_free(graph);
+}
+
+//-------------------------------------------------------------------------------------------------
+// Pop symbol node
+
+fn pop_symbol(file: sg_file_handle, local_id: u32, symbol: sg_symbol_handle) -> sg_node {
+    sg_node {
+        kind: sg_node_kind::SG_NODE_KIND_POP_SYMBOL,
+        id: sg_node_id { file, local_id },
+        symbol,
+        is_clickable: true,
+        scope: 0,
+    }
+}
+
+#[test]
+fn can_add_pop_symbol_node() {
+    let graph = sg_stack_graph_new();
+    let file = add_file(graph, "test.py");
+    let symbol = add_symbol(graph, "a");
+    let nodes = [pop_symbol(file, 42, symbol)];
+    let mut handles: [sg_node_handle; 1] = [0; 1];
+    // Add the node and verify its contents after dereferencing it.
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    let node_arena = sg_stack_graph_nodes(graph);
+    let node = get_node(&node_arena, handles[0]);
+    assert!(matches!(node, Node::PopSymbol(_)));
+    assert!(node.id() == node_id(file, 42));
+    assert!(node.symbol().unwrap().as_usize() == symbol as usize);
+    assert!(node.is_definition());
+    // Make sure we can't add the same node again.
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    assert!(handles[0] == 0);
+    sg_stack_graph_free(graph);
+}
+
+#[test]
+fn pop_symbol_must_have_symbol() {
+    let graph = sg_stack_graph_new();
+    let file = add_file(graph, "test.py");
+    let nodes = [pop_symbol(file, 42, 0)];
+    let mut handles: [sg_node_handle; 1] = [0; 1];
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    assert!(handles[0] == 0);
+    sg_stack_graph_free(graph);
+}
+
+#[test]
+fn pop_symbol_cannot_have_scope() {
+    let graph = sg_stack_graph_new();
+    let file = add_file(graph, "test.py");
+    let symbol = add_symbol(graph, "a");
+    let mut nodes = [pop_symbol(file, 42, symbol)];
+    nodes[0].scope = SG_JUMP_TO_NODE_HANDLE;
+    let mut handles: [sg_node_handle; 1] = [0; 1];
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    assert!(handles[0] == 0);
+    sg_stack_graph_free(graph);
+}
+
+//-------------------------------------------------------------------------------------------------
+// Push scoped symbol node
+
+fn push_scoped_symbol(
+    file: sg_file_handle,
+    local_id: u32,
+    symbol: sg_symbol_handle,
+    scope: sg_node_handle,
+) -> sg_node {
+    sg_node {
+        kind: sg_node_kind::SG_NODE_KIND_PUSH_SCOPED_SYMBOL,
+        id: sg_node_id { file, local_id },
+        symbol,
+        is_clickable: true,
+        scope,
+    }
+}
+
+#[test]
+fn can_add_push_scoped_symbol_node() {
+    let graph = sg_stack_graph_new();
+    let file = add_file(graph, "test.py");
+    let symbol = add_symbol(graph, "a");
+    let nodes = [push_scoped_symbol(file, 42, symbol, SG_JUMP_TO_NODE_HANDLE)];
+    let mut handles: [sg_node_handle; 1] = [0; 1];
+    // Add the node and verify its contents after dereferencing it.
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    let node_arena = sg_stack_graph_nodes(graph);
+    let node = get_node(&node_arena, handles[0]);
+    assert!(matches!(node, Node::PushScopedSymbol(_)));
+    assert!(node.id() == node_id(file, 42));
+    assert!(node.symbol().unwrap().as_usize() == symbol as usize);
+    assert!(node.scope().unwrap().as_usize() == SG_JUMP_TO_NODE_HANDLE as usize);
+    assert!(node.is_reference());
+    // Make sure we can't add the same node again.
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    assert!(handles[0] == 0);
+    sg_stack_graph_free(graph);
+}
+
+#[test]
+fn push_scoped_symbol_must_have_symbol() {
+    let graph = sg_stack_graph_new();
+    let file = add_file(graph, "test.py");
+    let nodes = [push_scoped_symbol(file, 42, 0, SG_JUMP_TO_NODE_HANDLE)];
+    let mut handles: [sg_node_handle; 1] = [0; 1];
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    assert!(handles[0] == 0);
+    sg_stack_graph_free(graph);
+}
+
+#[test]
+fn push_scoped_symbol_must_have_scope() {
+    let graph = sg_stack_graph_new();
+    let file = add_file(graph, "test.py");
+    let symbol = add_symbol(graph, "a");
+    let nodes = [push_scoped_symbol(file, 42, symbol, 0)];
+    let mut handles: [sg_node_handle; 1] = [0; 1];
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    assert!(handles[0] == 0);
+    sg_stack_graph_free(graph);
+}
+
+//-------------------------------------------------------------------------------------------------
+// Push symbol node
+
+fn push_symbol(file: sg_file_handle, local_id: u32, symbol: sg_symbol_handle) -> sg_node {
+    sg_node {
+        kind: sg_node_kind::SG_NODE_KIND_PUSH_SYMBOL,
+        id: sg_node_id { file, local_id },
+        symbol,
+        is_clickable: true,
+        scope: 0,
+    }
+}
+
+#[test]
+fn can_add_push_symbol_node() {
+    let graph = sg_stack_graph_new();
+    let file = add_file(graph, "test.py");
+    let symbol = add_symbol(graph, "a");
+    let nodes = [push_symbol(file, 42, symbol)];
+    let mut handles: [sg_node_handle; 1] = [0; 1];
+    // Add the node and verify its contents after dereferencing it.
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    let node_arena = sg_stack_graph_nodes(graph);
+    let node = get_node(&node_arena, handles[0]);
+    assert!(matches!(node, Node::PushSymbol(_)));
+    assert!(node.id() == node_id(file, 42));
+    assert!(node.symbol().unwrap().as_usize() == symbol as usize);
+    assert!(node.is_reference());
+    // Make sure we can't add the same node again.
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    assert!(handles[0] == 0);
+    sg_stack_graph_free(graph);
+}
+
+#[test]
+fn push_symbol_must_have_symbol() {
+    let graph = sg_stack_graph_new();
+    let file = add_file(graph, "test.py");
+    let nodes = [push_symbol(file, 42, 0)];
+    let mut handles: [sg_node_handle; 1] = [0; 1];
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    assert!(handles[0] == 0);
+    sg_stack_graph_free(graph);
+}
+
+#[test]
+fn push_symbol_cannot_have_scope() {
+    let graph = sg_stack_graph_new();
+    let file = add_file(graph, "test.py");
+    let symbol = add_symbol(graph, "a");
+    let mut nodes = [push_symbol(file, 42, symbol)];
+    nodes[0].scope = SG_JUMP_TO_NODE_HANDLE;
+    let mut handles: [sg_node_handle; 1] = [0; 1];
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    assert!(handles[0] == 0);
+    sg_stack_graph_free(graph);
+}

--- a/tests/it/c/test_graph.rs
+++ b/tests/it/c/test_graph.rs
@@ -1,0 +1,226 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use libc::c_char;
+use stack_graphs::c::sg_edge;
+use stack_graphs::c::sg_file_handle;
+use stack_graphs::c::sg_node;
+use stack_graphs::c::sg_node_handle;
+use stack_graphs::c::sg_node_id;
+use stack_graphs::c::sg_node_kind;
+use stack_graphs::c::sg_stack_graph;
+use stack_graphs::c::sg_stack_graph_add_edges;
+use stack_graphs::c::sg_stack_graph_add_files;
+use stack_graphs::c::sg_stack_graph_add_nodes;
+use stack_graphs::c::sg_stack_graph_add_symbols;
+use stack_graphs::c::sg_stack_graph_free;
+use stack_graphs::c::sg_stack_graph_new;
+use stack_graphs::c::sg_symbol_handle;
+use stack_graphs::c::SG_JUMP_TO_NODE_HANDLE;
+use stack_graphs::c::SG_ROOT_NODE_HANDLE;
+
+use crate::test_graphs::CreateStackGraph;
+
+pub struct TestGraph {
+    pub graph: *mut sg_stack_graph,
+}
+
+impl Default for TestGraph {
+    fn default() -> TestGraph {
+        let graph = sg_stack_graph_new();
+        TestGraph { graph }
+    }
+}
+
+impl Drop for TestGraph {
+    fn drop(&mut self) {
+        sg_stack_graph_free(self.graph);
+    }
+}
+
+impl TestGraph {
+    fn add_node(&mut self, node: sg_node) -> sg_node_handle {
+        let nodes = [node];
+        let mut handles: [sg_node_handle; 1] = [0; 1];
+        sg_stack_graph_add_nodes(
+            self.graph,
+            nodes.len(),
+            nodes.as_ptr(),
+            handles.as_mut_ptr(),
+        );
+        handles[0]
+    }
+}
+
+impl CreateStackGraph for TestGraph {
+    type File = sg_file_handle;
+    type Node = sg_node_handle;
+    type Symbol = sg_symbol_handle;
+
+    fn definition(
+        &mut self,
+        file: sg_file_handle,
+        local_id: u32,
+        symbol: sg_symbol_handle,
+    ) -> sg_node_handle {
+        self.add_node(sg_node {
+            kind: sg_node_kind::SG_NODE_KIND_POP_SYMBOL,
+            id: sg_node_id { file, local_id },
+            symbol,
+            is_clickable: true,
+            scope: 0,
+        })
+    }
+
+    fn drop_scopes(&mut self, file: sg_file_handle, local_id: u32) -> sg_node_handle {
+        self.add_node(sg_node {
+            kind: sg_node_kind::SG_NODE_KIND_DROP_SCOPES,
+            id: sg_node_id { file, local_id },
+            symbol: 0,
+            is_clickable: false,
+            scope: 0,
+        })
+    }
+
+    fn edge(&mut self, source: sg_node_handle, sink: sg_node_handle) {
+        let edge = sg_edge { source, sink };
+        let edges = [edge];
+        sg_stack_graph_add_edges(self.graph, edges.len(), edges.as_ptr());
+    }
+
+    fn exported_scope(&mut self, file: sg_file_handle, local_id: u32) -> sg_node_handle {
+        self.add_node(sg_node {
+            kind: sg_node_kind::SG_NODE_KIND_EXPORTED_SCOPE,
+            id: sg_node_id { file, local_id },
+            symbol: 0,
+            is_clickable: false,
+            scope: 0,
+        })
+    }
+
+    fn file(&mut self, name: &str) -> sg_file_handle {
+        let names = [name.as_bytes().as_ptr() as *const c_char];
+        let lengths = [name.len()];
+        let mut handles: [sg_file_handle; 1] = [0; 1];
+        sg_stack_graph_add_files(
+            self.graph,
+            names.len(),
+            names.as_ptr(),
+            lengths.as_ptr(),
+            handles.as_mut_ptr(),
+        );
+        handles[0]
+    }
+
+    fn internal_scope(&mut self, file: sg_file_handle, local_id: u32) -> sg_node_handle {
+        self.add_node(sg_node {
+            kind: sg_node_kind::SG_NODE_KIND_INTERNAL_SCOPE,
+            id: sg_node_id { file, local_id },
+            symbol: 0,
+            is_clickable: false,
+            scope: 0,
+        })
+    }
+
+    fn jump_to_node(&mut self) -> sg_node_handle {
+        SG_JUMP_TO_NODE_HANDLE
+    }
+
+    fn pop_scoped_symbol(
+        &mut self,
+        file: sg_file_handle,
+        local_id: u32,
+        symbol: sg_symbol_handle,
+    ) -> sg_node_handle {
+        self.add_node(sg_node {
+            kind: sg_node_kind::SG_NODE_KIND_POP_SCOPED_SYMBOL,
+            id: sg_node_id { file, local_id },
+            symbol,
+            is_clickable: false,
+            scope: 0,
+        })
+    }
+
+    fn pop_symbol(
+        &mut self,
+        file: sg_file_handle,
+        local_id: u32,
+        symbol: sg_symbol_handle,
+    ) -> sg_node_handle {
+        self.add_node(sg_node {
+            kind: sg_node_kind::SG_NODE_KIND_POP_SYMBOL,
+            id: sg_node_id { file, local_id },
+            symbol,
+            is_clickable: false,
+            scope: 0,
+        })
+    }
+
+    fn push_scoped_symbol(
+        &mut self,
+        file: sg_file_handle,
+        local_id: u32,
+        symbol: sg_symbol_handle,
+        scope: sg_node_handle,
+    ) -> sg_node_handle {
+        self.add_node(sg_node {
+            kind: sg_node_kind::SG_NODE_KIND_PUSH_SCOPED_SYMBOL,
+            id: sg_node_id { file, local_id },
+            symbol,
+            is_clickable: false,
+            scope,
+        })
+    }
+
+    fn push_symbol(
+        &mut self,
+        file: sg_file_handle,
+        local_id: u32,
+        symbol: sg_symbol_handle,
+    ) -> sg_node_handle {
+        self.add_node(sg_node {
+            kind: sg_node_kind::SG_NODE_KIND_PUSH_SYMBOL,
+            id: sg_node_id { file, local_id },
+            symbol,
+            is_clickable: false,
+            scope: 0,
+        })
+    }
+
+    fn reference(
+        &mut self,
+        file: sg_file_handle,
+        local_id: u32,
+        symbol: sg_symbol_handle,
+    ) -> sg_node_handle {
+        self.add_node(sg_node {
+            kind: sg_node_kind::SG_NODE_KIND_PUSH_SYMBOL,
+            id: sg_node_id { file, local_id },
+            symbol,
+            is_clickable: true,
+            scope: 0,
+        })
+    }
+
+    fn root_node(&mut self) -> sg_node_handle {
+        SG_ROOT_NODE_HANDLE
+    }
+
+    fn symbol(&mut self, value: &str) -> sg_symbol_handle {
+        let symbols = [value.as_bytes().as_ptr() as *const c_char];
+        let lengths = [value.len()];
+        let mut handles: [sg_symbol_handle; 1] = [0; 1];
+        sg_stack_graph_add_symbols(
+            self.graph,
+            symbols.len(),
+            symbols.as_ptr(),
+            lengths.as_ptr(),
+            handles.as_mut_ptr(),
+        );
+        handles[0]
+    }
+}

--- a/tests/it/test_graphs/mod.rs
+++ b/tests/it/test_graphs/mod.rs
@@ -72,19 +72,13 @@ impl CreateStackGraph for StackGraph {
         local_id: u32,
         symbol: Handle<Symbol>,
     ) -> Handle<Node> {
-        let node = PopSymbolNode {
-            id: NodeID::new_in_file(file, local_id),
-            symbol,
-            is_definition: true,
-        };
-        node.add_to_graph(self).expect("Duplicate node ID")
+        self.add_pop_symbol_node(NodeID::new_in_file(file, local_id), symbol, true)
+            .expect("Duplicate node ID")
     }
 
     fn drop_scopes(&mut self, file: Handle<File>, local_id: u32) -> Handle<Node> {
-        let node = DropScopesNode {
-            id: NodeID::new_in_file(file, local_id),
-        };
-        node.add_to_graph(self).expect("Duplicate node ID")
+        self.add_drop_scopes_node(NodeID::new_in_file(file, local_id))
+            .expect("Duplicate node ID")
     }
 
     fn edge(&mut self, source: Handle<Node>, sink: Handle<Node>) {
@@ -93,10 +87,8 @@ impl CreateStackGraph for StackGraph {
     }
 
     fn exported_scope(&mut self, file: Handle<File>, local_id: u32) -> Handle<Node> {
-        let node = ExportedScopeNode {
-            id: NodeID::new_in_file(file, local_id),
-        };
-        node.add_to_graph(self).expect("Duplicate node ID")
+        self.add_exported_scope_node(NodeID::new_in_file(file, local_id))
+            .expect("Duplicate node ID")
     }
 
     fn file(&mut self, name: &str) -> Handle<File> {
@@ -104,10 +96,8 @@ impl CreateStackGraph for StackGraph {
     }
 
     fn internal_scope(&mut self, file: Handle<File>, local_id: u32) -> Handle<Node> {
-        let node = InternalScopeNode {
-            id: NodeID::new_in_file(file, local_id),
-        };
-        node.add_to_graph(self).expect("Duplicate node ID")
+        self.add_internal_scope_node(NodeID::new_in_file(file, local_id))
+            .expect("Duplicate node ID")
     }
 
     fn jump_to_node(&mut self) -> Handle<Node> {
@@ -120,12 +110,8 @@ impl CreateStackGraph for StackGraph {
         local_id: u32,
         symbol: Handle<Symbol>,
     ) -> Handle<Node> {
-        let node = PopScopedSymbolNode {
-            id: NodeID::new_in_file(file, local_id),
-            symbol,
-            is_definition: false,
-        };
-        node.add_to_graph(self).expect("Duplicate node ID")
+        self.add_pop_scoped_symbol_node(NodeID::new_in_file(file, local_id), symbol, false)
+            .expect("Duplicate node ID")
     }
 
     fn pop_symbol(
@@ -134,12 +120,8 @@ impl CreateStackGraph for StackGraph {
         local_id: u32,
         symbol: Handle<Symbol>,
     ) -> Handle<Node> {
-        let node = PopSymbolNode {
-            id: NodeID::new_in_file(file, local_id),
-            symbol,
-            is_definition: false,
-        };
-        node.add_to_graph(self).expect("Duplicate node ID")
+        self.add_pop_symbol_node(NodeID::new_in_file(file, local_id), symbol, false)
+            .expect("Duplicate node ID")
     }
 
     fn push_scoped_symbol(
@@ -149,13 +131,8 @@ impl CreateStackGraph for StackGraph {
         symbol: Handle<Symbol>,
         scope: Handle<Node>,
     ) -> Handle<Node> {
-        let node = PushScopedSymbolNode {
-            id: NodeID::new_in_file(file, local_id),
-            symbol,
-            scope,
-            is_reference: false,
-        };
-        node.add_to_graph(self).expect("Duplicate node ID")
+        self.add_push_scoped_symbol_node(NodeID::new_in_file(file, local_id), symbol, scope, false)
+            .expect("Duplicate node ID")
     }
 
     fn push_symbol(
@@ -164,12 +141,8 @@ impl CreateStackGraph for StackGraph {
         local_id: u32,
         symbol: Handle<Symbol>,
     ) -> Handle<Node> {
-        let node = PushSymbolNode {
-            id: NodeID::new_in_file(file, local_id),
-            symbol,
-            is_reference: false,
-        };
-        node.add_to_graph(self).expect("Duplicate node ID")
+        self.add_push_symbol_node(NodeID::new_in_file(file, local_id), symbol, false)
+            .expect("Duplicate node ID")
     }
 
     fn reference(
@@ -178,12 +151,8 @@ impl CreateStackGraph for StackGraph {
         local_id: u32,
         symbol: Handle<Symbol>,
     ) -> Handle<Node> {
-        let node = PushSymbolNode {
-            id: NodeID::new_in_file(file, local_id),
-            symbol,
-            is_reference: true,
-        };
-        node.add_to_graph(self).expect("Duplicate node ID")
+        self.add_push_symbol_node(NodeID::new_in_file(file, local_id), symbol, true)
+            .expect("Duplicate node ID")
     }
 
     fn root_node(&mut self) -> Handle<Node> {


### PR DESCRIPTION
You provide an array of `sg_node` instances and we add them into the stack graph.  If any of the nodes are invalid, we skip those and return a null handle for them.  Same for edges, although duplicate edges aren't considered an error.

This patch also adds a `TestGraph` helper type, and an implementation of `CreateStackGraph` that calls the A API.  This lets us add a copy of the `can_create_graph` test that exercises the C API instead of the Rust API.