### PR TITLE
Handle empty interned strings correctly

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -120,7 +120,7 @@ impl InternedStringContent {
         // room, we allocate a _completely new buffer_ to replace it.
         let start_index = self.current_buffer.len();
         self.current_buffer.extend_from_slice(value);
-        let start = &self.current_buffer[start_index] as *const _;
+        let start = unsafe { self.current_buffer.as_ptr().add(start_index) };
         InternedString { start, len }
     }
 }

--- a/tests/it/graph.rs
+++ b/tests/it/graph.rs
@@ -24,6 +24,7 @@ fn can_create_symbols() {
     let a2 = graph.add_symbol("a");
     let b = graph.add_symbol("b");
     let c = graph.add_symbol("c");
+    let empty1 = graph.add_symbol("");
     // The content of each symbol be comparable
     assert_eq!(graph[a1], graph[a2]);
     assert_ne!(graph[a1], graph[b]);
@@ -31,6 +32,7 @@ fn can_create_symbols() {
     assert_ne!(graph[a2], graph[b]);
     assert_ne!(graph[a2], graph[c]);
     assert_ne!(graph[b], graph[c]);
+    assert_ne!(graph[empty1], graph[a1]);
     // and because we deduplicate symbols, the handles should be comparable too.
     assert_eq!(a1, a2);
     assert_ne!(a1, b);
@@ -38,6 +40,7 @@ fn can_create_symbols() {
     assert_ne!(a2, b);
     assert_ne!(a2, c);
     assert_ne!(b, c);
+    assert_ne!(empty1, a1);
 }
 
 #[test]


### PR DESCRIPTION
Our new, overly clever interned string storage implementation wasn't handling 0-length strings correctly.  Sprinkle a little bit of unsafe to skip the bounds checks, and we're back in business.