### PR TITLE
Use fewer “empty list” constants in C API

### DIFF
--- a/include/stack-graphs.h
+++ b/include/stack-graphs.h
@@ -9,6 +9,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+// The handle of an empty list.
+#define SG_LIST_EMPTY_HANDLE 4294967295
+
 // The local_id of the singleton root node.
 #define SG_ROOT_NODE_ID 0
 
@@ -167,8 +170,8 @@ typedef uint32_t sg_scope_stack_cell_handle;
 
 // A sequence of exported scopes, used to pass name-binding context around a stack graph.
 struct sg_scope_stack {
-    // The handle of the first element in the scope stack, or SG_SCOPE_STACK_EMPTY_HANDLE if the
-    // list is empty, or 0 if the list is null.
+    // The handle of the first element in the scope stack, or SG_LIST_EMPTY_HANDLE if the list is
+    // empty, or 0 if the list is null.
     sg_scope_stack_cell_handle cells;
 };
 
@@ -186,8 +189,8 @@ typedef uint32_t sg_symbol_stack_cell_handle;
 struct sg_symbol_stack_cell {
     // The scoped symbol at this position in the symbol stack.
     struct sg_scoped_symbol head;
-    // The handle of the next element in the symbol stack, or SG_SYMBOL_STACK_EMPTY_HANDLE if this
-    // is the last element.
+    // The handle of the next element in the symbol stack, or SG_LIST_EMPTY_HANDLE if this is the
+    // last element.
     sg_symbol_stack_cell_handle tail;
 };
 
@@ -200,8 +203,8 @@ struct sg_symbol_stack_cells {
 // A sequence of symbols that describe what we are currently looking for while in the middle of
 // the path-finding algorithm.
 struct sg_symbol_stack {
-    // The handle of the first element in the symbol stack, or SG_SYMBOL_STACK_EMPTY_HANDLE if the
-    // list is empty, or 0 if the list is null.
+    // The handle of the first element in the symbol stack, or SG_LIST_EMPTY_HANDLE if the list is
+    // empty, or 0 if the list is null.
     sg_symbol_stack_cell_handle cells;
     size_t length;
 };
@@ -210,8 +213,8 @@ struct sg_symbol_stack {
 struct sg_scope_stack_cell {
     // The exported scope at this position in the scope stack.
     sg_node_handle head;
-    // The handle of the next element in the scope stack, or SG_SCOPE_STACK_EMPTY_HANDLE if this
-    // is the last element.
+    // The handle of the next element in the scope stack, or SG_LIST_EMPTY_HANDLE if this is the
+    // last element.
     sg_scope_stack_cell_handle tail;
 };
 
@@ -235,8 +238,8 @@ typedef uint32_t sg_path_edge_list_cell_handle;
 struct sg_path_edge_list_cell {
     // The path edge at this position in the path edge list.
     struct sg_path_edge head;
-    // The handle of the next element in the path edge list, or SG_PATH_EDGE_LIST_EMPTY_HANDLE if
-    // this is the last element.
+    // The handle of the next element in the path edge list, or SG_LIST_EMPTY_HANDLE if this is
+    // the last element.
     sg_path_edge_list_cell_handle tail;
     // The handle of the reversal of this list.
     sg_path_edge_list_cell_handle reversed;
@@ -251,8 +254,8 @@ struct sg_path_edge_list_cells {
 // The edges in a path keep track of precedence information so that we can correctly handle
 // shadowed definitions.
 struct sg_path_edge_list {
-    // The handle of the first element in the edge list, or SG_PATH_EDGE_LIST_EMPTY_HANDLE if the
-    // list is empty, or 0 if the list is null.
+    // The handle of the first element in the edge list, or SG_LIST_EMPTY_HANDLE if the list is
+    // empty, or 0 if the list is null.
     sg_path_edge_list_cell_handle cells;
     enum sg_deque_direction direction;
     size_t length;
@@ -273,15 +276,6 @@ struct sg_path {
 
 // The handle of the singleton "jump to scope" node.
 #define SG_JUMP_TO_NODE_HANDLE 2
-
-// The handle of the empty symbol stack.
-#define SG_SYMBOL_STACK_EMPTY_HANDLE 4294967295
-
-// The handle of the empty scope stack.
-#define SG_SCOPE_STACK_EMPTY_HANDLE 4294967295
-
-// The handle of the empty path edge list.
-#define SG_PATH_EDGE_LIST_EMPTY_HANDLE 4294967295
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/c.rs
+++ b/src/c.rs
@@ -63,6 +63,9 @@ pub extern "C" fn sg_path_arena_free(paths: *mut sg_path_arena) {
     drop(unsafe { Box::from_raw(paths) })
 }
 
+/// The handle of an empty list.
+pub const SG_LIST_EMPTY_HANDLE: u32 = 0xffffffff;
+
 /// Describes in which direction the content of a deque is stored in memory.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -477,8 +480,8 @@ impl Into<ScopedSymbol> for sg_scoped_symbol {
 #[repr(C)]
 #[derive(Clone, Copy, Default, Eq, PartialEq)]
 pub struct sg_symbol_stack {
-    /// The handle of the first element in the symbol stack, or SG_SYMBOL_STACK_EMPTY_HANDLE if the
-    /// list is empty, or 0 if the list is null.
+    /// The handle of the first element in the symbol stack, or SG_LIST_EMPTY_HANDLE if the list is
+    /// empty, or 0 if the list is null.
     pub cells: sg_symbol_stack_cell_handle,
     pub length: usize,
 }
@@ -493,16 +496,13 @@ impl From<SymbolStack> for sg_symbol_stack {
 /// UINT32_MAX handle represents an empty symbol stack.
 pub type sg_symbol_stack_cell_handle = u32;
 
-/// The handle of the empty symbol stack.
-pub const SG_SYMBOL_STACK_EMPTY_HANDLE: sg_symbol_stack_cell_handle = 0xffffffff;
-
 /// An element of a symbol stack.
 #[repr(C)]
 pub struct sg_symbol_stack_cell {
     /// The scoped symbol at this position in the symbol stack.
     pub head: sg_scoped_symbol,
-    /// The handle of the next element in the symbol stack, or SG_SYMBOL_STACK_EMPTY_HANDLE if this
-    /// is the last element.
+    /// The handle of the next element in the symbol stack, or SG_LIST_EMPTY_HANDLE if this is the
+    /// last element.
     pub tail: sg_symbol_stack_cell_handle,
 }
 
@@ -565,8 +565,8 @@ pub extern "C" fn sg_path_arena_add_symbol_stacks(
 #[repr(C)]
 #[derive(Clone, Copy, Default, Eq, PartialEq)]
 pub struct sg_scope_stack {
-    /// The handle of the first element in the scope stack, or SG_SCOPE_STACK_EMPTY_HANDLE if the
-    /// list is empty, or 0 if the list is null.
+    /// The handle of the first element in the scope stack, or SG_LIST_EMPTY_HANDLE if the list is
+    /// empty, or 0 if the list is null.
     pub cells: sg_scope_stack_cell_handle,
 }
 
@@ -580,16 +580,13 @@ impl From<ScopeStack> for sg_scope_stack {
 /// UINT32_MAX handle represents an empty scope stack.
 pub type sg_scope_stack_cell_handle = u32;
 
-/// The handle of the empty scope stack.
-pub const SG_SCOPE_STACK_EMPTY_HANDLE: sg_scope_stack_cell_handle = 0xffffffff;
-
 /// An element of a scope stack.
 #[repr(C)]
 pub struct sg_scope_stack_cell {
     /// The exported scope at this position in the scope stack.
     pub head: sg_node_handle,
-    /// The handle of the next element in the scope stack, or SG_SCOPE_STACK_EMPTY_HANDLE if this
-    /// is the last element.
+    /// The handle of the next element in the scope stack, or SG_LIST_EMPTY_HANDLE if this is the
+    /// last element.
     pub tail: sg_scope_stack_cell_handle,
 }
 
@@ -667,8 +664,8 @@ impl Into<PathEdge> for sg_path_edge {
 #[repr(C)]
 #[derive(Clone, Copy, Default, Eq, PartialEq)]
 pub struct sg_path_edge_list {
-    /// The handle of the first element in the edge list, or SG_PATH_EDGE_LIST_EMPTY_HANDLE if the
-    /// list is empty, or 0 if the list is null.
+    /// The handle of the first element in the edge list, or SG_LIST_EMPTY_HANDLE if the list is
+    /// empty, or 0 if the list is null.
     pub cells: sg_path_edge_list_cell_handle,
     pub direction: sg_deque_direction,
     pub length: usize,
@@ -684,16 +681,13 @@ impl From<PathEdgeList> for sg_path_edge_list {
 /// A UINT32_MAX handle represents an empty path edge list.
 pub type sg_path_edge_list_cell_handle = u32;
 
-/// The handle of the empty path edge list.
-pub const SG_PATH_EDGE_LIST_EMPTY_HANDLE: sg_path_edge_list_cell_handle = 0xffffffff;
-
 /// An element of a path edge list.
 #[repr(C)]
 pub struct sg_path_edge_list_cell {
     /// The path edge at this position in the path edge list.
     pub head: sg_path_edge,
-    /// The handle of the next element in the path edge list, or SG_PATH_EDGE_LIST_EMPTY_HANDLE if
-    /// this is the last element.
+    /// The handle of the next element in the path edge list, or SG_LIST_EMPTY_HANDLE if this is
+    /// the last element.
     pub tail: sg_path_edge_list_cell_handle,
     /// The handle of the reversal of this list.
     pub reversed: sg_path_edge_list_cell_handle,

--- a/tests/it/c/paths.rs
+++ b/tests/it/c/paths.rs
@@ -36,9 +36,7 @@ use stack_graphs::c::sg_stack_graph_new;
 use stack_graphs::c::sg_symbol_handle;
 use stack_graphs::c::sg_symbol_stack;
 use stack_graphs::c::sg_symbol_stack_cells;
-use stack_graphs::c::SG_PATH_EDGE_LIST_EMPTY_HANDLE;
-use stack_graphs::c::SG_SCOPE_STACK_EMPTY_HANDLE;
-use stack_graphs::c::SG_SYMBOL_STACK_EMPTY_HANDLE;
+use stack_graphs::c::SG_LIST_EMPTY_HANDLE;
 
 fn add_file(graph: *mut sg_stack_graph, filename: &str) -> sg_file_handle {
     let strings = [filename.as_bytes().as_ptr() as *const c_char];
@@ -107,7 +105,7 @@ fn symbol_stack_contains(
     let cells = unsafe { std::slice::from_raw_parts(cells.cells, cells.count) };
     let mut current = stack.cells;
     for node in expected {
-        if current == SG_SYMBOL_STACK_EMPTY_HANDLE {
+        if current == SG_LIST_EMPTY_HANDLE {
             return false;
         }
         let cell = &cells[current as usize];
@@ -116,7 +114,7 @@ fn symbol_stack_contains(
         }
         current = cell.tail;
     }
-    current == SG_SYMBOL_STACK_EMPTY_HANDLE
+    current == SG_LIST_EMPTY_HANDLE
 }
 
 #[test]
@@ -186,7 +184,7 @@ fn scope_stack_contains(
     let cells = unsafe { std::slice::from_raw_parts(cells.cells, cells.count) };
     let mut current = stack.cells;
     for node in expected {
-        if current == SG_SCOPE_STACK_EMPTY_HANDLE {
+        if current == SG_LIST_EMPTY_HANDLE {
             return false;
         }
         let cell = &cells[current as usize];
@@ -195,7 +193,7 @@ fn scope_stack_contains(
         }
         current = cell.tail;
     }
-    current == SG_SCOPE_STACK_EMPTY_HANDLE
+    current == SG_LIST_EMPTY_HANDLE
 }
 
 #[test]
@@ -260,7 +258,7 @@ fn path_edge_list_contains(
         Either::Right(expected.iter().rev())
     };
     for node in expected {
-        if current == SG_PATH_EDGE_LIST_EMPTY_HANDLE {
+        if current == SG_LIST_EMPTY_HANDLE {
             return false;
         }
         let cell = &cells[current as usize];
@@ -269,7 +267,7 @@ fn path_edge_list_contains(
         }
         current = cell.tail;
     }
-    current == SG_PATH_EDGE_LIST_EMPTY_HANDLE
+    current == SG_LIST_EMPTY_HANDLE
 }
 
 fn path_edge_list_available_in_both_directions(
@@ -278,7 +276,7 @@ fn path_edge_list_available_in_both_directions(
 ) -> bool {
     let cells = unsafe { std::slice::from_raw_parts(cells.cells, cells.count) };
     let head = list.cells;
-    if head == SG_PATH_EDGE_LIST_EMPTY_HANDLE {
+    if head == SG_LIST_EMPTY_HANDLE {
         return true;
     }
     let cell = &cells[head as usize];


### PR DESCRIPTION
All of our lists and deques use the same value to represent an empty list.  There's no need for separate constants for each one.