### PR TITLE
Add C bindings for partial paths and friends

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -68,6 +68,11 @@ impl<T> Handle<T> {
     }
 
     #[inline(always)]
+    pub fn as_u32(self) -> u32 {
+        self.index.get()
+    }
+
+    #[inline(always)]
     pub fn as_usize(self) -> usize {
         self.index.get() as usize
     }

--- a/src/c.rs
+++ b/src/c.rs
@@ -1271,13 +1271,14 @@ pub extern "C" fn sg_partial_path_arena_find_partial_paths_in_file(
     let partials = unsafe { &mut (*partials).inner };
     let file = file.into();
     let partial_path_list = unsafe { &mut *partial_path_list };
-    partials.find_all_partial_paths_in_file(graph, file, |graph, partials, path| {
+    partials.find_all_partial_paths_in_file(graph, file, |graph, partials, mut path| {
         if !path.is_complete_as_possible(graph) {
             return;
         }
         if !path.is_productive(partials) {
             return;
         }
+        path.ensure_both_directions(partials);
         partial_path_list.partial_paths.push(path);
     });
 }

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -156,6 +156,7 @@ where
 // Scope stack variables
 
 /// Represents an unknown list of exported scopes.
+#[repr(transparent)]
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct ScopeStackVariable(NonZeroU32);
 
@@ -635,6 +636,7 @@ impl DisplayWithPartialPaths for PartialSymbolStack {
 
 /// A pattern that might match against a scope stack.  Consists of a (possibly empty) list of
 /// exported scopes, along with an optional scope stack variable.
+#[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PartialScopeStack {
     scopes: Deque<Handle<Node>>,
@@ -1676,7 +1678,7 @@ impl Path {
 /// algorithm or path-stitching algorithm.
 pub struct PartialPaths {
     partial_symbol_stacks: DequeArena<PartialScopedSymbol>,
-    partial_scope_stacks: DequeArena<Handle<Node>>,
+    pub(crate) partial_scope_stacks: DequeArena<Handle<Node>>,
     partial_path_edges: DequeArena<PartialPathEdge>,
 }
 

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -1164,6 +1164,7 @@ impl DisplayWithPartialPaths for PartialPathEdgeList {
 /// (or parts of a scope symbol's attached scope list) whose contents we don't care about.  The
 /// postconditions can _also_ refer to those variables, and describe how those variable parts of
 /// the input scope stacks are carried through unmodified into the resulting scope stack.
+#[repr(C)]
 #[derive(Clone)]
 pub struct PartialPath {
     pub start_node: Handle<Node>,

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -932,6 +932,7 @@ impl PartialScopeStackBindings {
 //-------------------------------------------------------------------------------------------------
 // Edge lists
 
+#[repr(C)]
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct PartialPathEdge {
     pub source_node_id: NodeID,
@@ -983,6 +984,7 @@ impl DisplayWithPartialPaths for PartialPathEdge {
 
 /// The edges in a path keep track of precedence information so that we can correctly handle
 /// shadowed definitions.
+#[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PartialPathEdgeList {
     edges: Deque<PartialPathEdge>,
@@ -1681,7 +1683,7 @@ impl Path {
 pub struct PartialPaths {
     pub(crate) partial_symbol_stacks: DequeArena<PartialScopedSymbol>,
     pub(crate) partial_scope_stacks: DequeArena<Handle<Node>>,
-    partial_path_edges: DequeArena<PartialPathEdge>,
+    pub(crate) partial_path_edges: DequeArena<PartialPathEdge>,
 }
 
 impl PartialPaths {

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -602,6 +602,13 @@ impl PartialSymbolStack {
             .iter_unordered(&partials.partial_symbol_stacks)
             .copied()
     }
+
+    fn ensure_both_directions(&mut self, partials: &mut PartialPaths) {
+        self.deque
+            .ensure_backwards(&mut partials.partial_symbol_stacks);
+        self.deque
+            .ensure_forwards(&mut partials.partial_symbol_stacks);
+    }
 }
 
 impl DisplayWithPartialPaths for PartialSymbolStack {
@@ -815,6 +822,13 @@ impl PartialScopeStack {
         partials: &'a mut PartialPaths,
     ) -> impl Display + 'a {
         display_with(self, graph, partials)
+    }
+
+    fn ensure_both_directions(&mut self, partials: &mut PartialPaths) {
+        self.scopes
+            .ensure_backwards(&mut partials.partial_scope_stacks);
+        self.scopes
+            .ensure_forwards(&mut partials.partial_scope_stacks);
     }
 }
 
@@ -1121,6 +1135,12 @@ impl PartialPathEdgeList {
             .iter_unordered(&partials.partial_path_edges)
             .copied()
     }
+
+    fn ensure_both_directions(&mut self, partials: &mut PartialPaths) {
+        self.edges
+            .ensure_backwards(&mut partials.partial_path_edges);
+        self.edges.ensure_forwards(&mut partials.partial_path_edges);
+    }
 }
 
 impl DisplayWithPartialPaths for PartialPathEdgeList {
@@ -1329,6 +1349,20 @@ impl PartialPath {
             return true;
         }
         false
+    }
+
+    /// Ensures that the content of this partial path is available in both forwards and backwards
+    /// directions.
+    pub fn ensure_both_directions(&mut self, partials: &mut PartialPaths) {
+        self.symbol_stack_precondition
+            .ensure_both_directions(partials);
+        self.symbol_stack_postcondition
+            .ensure_both_directions(partials);
+        self.scope_stack_precondition
+            .ensure_both_directions(partials);
+        self.scope_stack_postcondition
+            .ensure_both_directions(partials);
+        self.edges.ensure_both_directions(partials);
     }
 
     /// Returns a fresh scope stack variable that is not already used anywhere in this partial

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -297,6 +297,7 @@ impl ScopeStackBindings {
 // Partial symbol stacks
 
 /// A symbol with an unknown, but possibly empty, list of exported scopes attached to it.
+#[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PartialScopedSymbol {
     pub symbol: Handle<Symbol>,
@@ -424,6 +425,7 @@ impl DisplayWithPartialPaths for PartialScopedSymbol {
 /// one symbol stack variable, which will appear at the end of its precondition and postcondition.
 /// So for simplicity we just leave it out.  At some point in the future we might add it in so that
 /// the symbol and scope stack formalisms and implementations are more obviously symmetric.)
+#[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PartialSymbolStack {
     deque: Deque<PartialScopedSymbol>,
@@ -1677,7 +1679,7 @@ impl Path {
 /// Manages the state of a collection of partial paths built up as part of the partial-path-finding
 /// algorithm or path-stitching algorithm.
 pub struct PartialPaths {
-    partial_symbol_stacks: DequeArena<PartialScopedSymbol>,
+    pub(crate) partial_symbol_stacks: DequeArena<PartialScopedSymbol>,
     pub(crate) partial_scope_stacks: DequeArena<Handle<Node>>,
     partial_path_edges: DequeArena<PartialPathEdge>,
 }

--- a/tests/it/c/can_find_partial_paths_in_file.rs
+++ b/tests/it/c/can_find_partial_paths_in_file.rs
@@ -1,0 +1,227 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use std::collections::HashSet;
+
+use stack_graphs::c::sg_partial_path_arena_find_partial_paths_in_file;
+use stack_graphs::c::sg_partial_path_arena_free;
+use stack_graphs::c::sg_partial_path_arena_new;
+use stack_graphs::c::sg_partial_path_list_count;
+use stack_graphs::c::sg_partial_path_list_free;
+use stack_graphs::c::sg_partial_path_list_new;
+use stack_graphs::c::sg_partial_path_list_paths;
+use stack_graphs::partial::PartialPath;
+
+use crate::c::test_graph::TestGraph;
+use crate::test_graphs;
+
+fn check_partial_paths_in_file(graph: &TestGraph, file: &str, expected_paths: &[&str]) {
+    let rust_graph = unsafe { &(*graph.graph).inner };
+    let file = rust_graph.get_file_unchecked(file);
+
+    let partials = sg_partial_path_arena_new();
+    let path_list = sg_partial_path_list_new();
+    sg_partial_path_arena_find_partial_paths_in_file(
+        graph.graph,
+        partials,
+        file.as_u32(),
+        path_list,
+    );
+
+    let rust_partials = unsafe { &mut (*partials).inner };
+    let results = unsafe {
+        std::slice::from_raw_parts(
+            sg_partial_path_list_paths(path_list) as *const PartialPath,
+            sg_partial_path_list_count(path_list),
+        )
+    };
+    let results = results
+        .iter()
+        .map(|s| s.display(rust_graph, rust_partials).to_string())
+        .collect::<HashSet<_>>();
+    let expected_paths = expected_paths
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<HashSet<_>>();
+    assert_eq!(results, expected_paths);
+
+    sg_partial_path_list_free(path_list);
+    sg_partial_path_arena_free(partials);
+}
+
+#[test]
+fn class_field_through_function_parameter() {
+    let graph = test_graphs::class_field_through_function_parameter::new();
+    check_partial_paths_in_file(
+        &graph,
+        "main.py",
+        &[
+            // definition of `__main__` module
+            "<__main__> ($1) [root] -> [main.py(0) definition __main__] <> ($1)",
+            // reference to `a` in import statement
+            "<> () [main.py(17) reference a] -> [root] <a> ()",
+            // `from a import *` means we can rewrite any lookup of `__main__.*` → `a.*`
+            "<__main__.> ($1) [root] -> [root] <a.> ($1)",
+            // reference to `b` in import statement
+            "<> () [main.py(15) reference b] -> [root] <b> ()",
+            // `from b import *` means we can rewrite any lookup of `__main__.*` → `b.*`
+            "<__main__.> ($1) [root] -> [root] <b.> ($1)",
+            // we can look for every reference in either `a` or `b`
+            "<> () [main.py(9) reference A] -> [root] <a.A> ()",
+            "<> () [main.py(9) reference A] -> [root] <b.A> ()",
+            "<> () [main.py(10) reference bar] -> [root] <a.foo()/[main.py(7)].bar> ()",
+            "<> () [main.py(10) reference bar] -> [root] <b.foo()/[main.py(7)].bar> ()",
+            "<> () [main.py(13) reference foo] -> [root] <a.foo> ()",
+            "<> () [main.py(13) reference foo] -> [root] <b.foo> ()",
+            // parameter 0 of function call is `A`, which we can look up in either `a` or `b`
+            "<0> ($1) [main.py(7) exported scope] -> [root] <a.A> ($1)",
+            "<0> ($1) [main.py(7) exported scope] -> [root] <b.A> ($1)",
+        ],
+    );
+    check_partial_paths_in_file(
+        &graph,
+        "a.py",
+        &[
+            // definition of `a` module
+            "<a> ($1) [root] -> [a.py(0) definition a] <> ($1)",
+            // definition of `foo` function
+            "<a.foo> ($1) [root] -> [a.py(5) definition foo] <> ($1)",
+            // reference to `x` in function body can resolve to formal parameter
+            "<> () [a.py(8) reference x] -> [a.py(14) definition x] <> ()",
+            // result of function is `x`, which is passed in as a formal parameter...
+            "<a.foo()/$2> ($1) [root] -> [a.py(14) definition x] <> ()",
+            // ...which we can look up either the 0th actual positional parameter...
+            "<a.foo()/$2> ($1) [root] -> [jump to scope] <0> ($2)",
+            // ...or the actual named parameter `x`
+            "<a.foo()/$2> ($1) [root] -> [jump to scope] <x> ($2)",
+        ],
+    );
+    check_partial_paths_in_file(
+        &graph,
+        "b.py",
+        &[
+            // definition of `b` module
+            "<b> ($1) [root] -> [b.py(0) definition b] <> ($1)",
+            // definition of class `A`
+            "<b.A> ($1) [root] -> [b.py(5) definition A] <> ($1)",
+            // definition of class member `A.bar`
+            "<b.A.bar> ($1) [root] -> [b.py(8) definition bar] <> ($1)",
+            // `bar` can also be accessed as an instance member
+            "<b.A()/$2.bar> ($1) [root] -> [b.py(8) definition bar] <> ($2)",
+        ],
+    );
+}
+
+#[test]
+fn cyclic_imports_python() {
+    let graph = test_graphs::cyclic_imports_python::new();
+    check_partial_paths_in_file(
+        &graph,
+        "main.py",
+        &[
+            // definition of `__main__` module
+            "<__main__> ($1) [root] -> [main.py(0) definition __main__] <> ($1)",
+            // reference to `a` in import statement
+            "<> () [main.py(8) reference a] -> [root] <a> ()",
+            // `from a import *` means we can rewrite any lookup of `__main__.*` → `a.*`
+            "<__main__.> ($1) [root] -> [root] <a.> ($1)",
+            // reference to `foo` becomes `a.foo` because of import statement
+            "<> () [main.py(6) reference foo] -> [root] <a.foo> ()",
+        ],
+    );
+    check_partial_paths_in_file(
+        &graph,
+        "a.py",
+        &[
+            // definition of `a` module
+            "<a> ($1) [root] -> [a.py(0) definition a] <> ($1)",
+            // reference to `b` in import statement
+            "<> () [a.py(6) reference b] -> [root] <b> ()",
+            // `from b import *` means we can rewrite any lookup of `a.*` → `b.*`
+            "<a.> ($1) [root] -> [root] <b.> ($1)",
+        ],
+    );
+    check_partial_paths_in_file(
+        &graph,
+        "b.py",
+        &[
+            // definition of `b` module
+            "<b> ($1) [root] -> [b.py(0) definition b] <> ($1)",
+            // reference to `a` in import statement
+            "<> () [b.py(8) reference a] -> [root] <a> ()",
+            // `from a import *` means we can rewrite any lookup of `b.*` → `a.*`
+            "<b.> ($1) [root] -> [root] <a.> ($1)",
+            // definition of `foo`
+            "<b.foo> ($1) [root] -> [b.py(6) definition foo] <> ($1)",
+        ],
+    );
+}
+
+#[test]
+fn cyclic_imports_rust() {
+    let graph = test_graphs::cyclic_imports_rust::new();
+    check_partial_paths_in_file(
+        &graph,
+        "test.rs",
+        // NOTE: Because everything in this example is local to one file, there aren't any partial
+        // paths involving the root node.
+        &[
+            // reference to `a` in `main` function
+            "<> () [test.rs(103) reference a] -> [test.rs(201) definition a] <> ()",
+            // reference to `a` in `b` function
+            "<> () [test.rs(307) reference a] -> [test.rs(201) definition a] <> ()",
+            // reference to `b` in `a` function
+            "<> () [test.rs(206) reference b] -> [test.rs(301) definition b] <> ()",
+            // reference to `FOO` in `main` can resolve either to `a::BAR` or `b::FOO`
+            "<> () [test.rs(101) reference FOO] -> [test.rs(204) definition BAR] <> ()",
+            "<> () [test.rs(101) reference FOO] -> [test.rs(304) definition FOO] <> ()",
+            // reference to `BAR` in `b` resolves _only_ to `a::BAR`
+            "<> () [test.rs(305) reference BAR] -> [test.rs(204) definition BAR] <> ()",
+        ],
+    );
+}
+
+#[test]
+fn sequenced_import_star() {
+    let graph = test_graphs::sequenced_import_star::new();
+    check_partial_paths_in_file(
+        &graph,
+        "main.py",
+        &[
+            // definition of `__main__` module
+            "<__main__> ($1) [root] -> [main.py(0) definition __main__] <> ($1)",
+            // reference to `a` in import statement
+            "<> () [main.py(8) reference a] -> [root] <a> ()",
+            // `from a import *` means we can rewrite any lookup of `__main__.*` → `a.*`
+            "<__main__.> ($1) [root] -> [root] <a.> ($1)",
+            // reference to `foo` becomes `a.foo` because of import statement
+            "<> () [main.py(6) reference foo] -> [root] <a.foo> ()",
+        ],
+    );
+    check_partial_paths_in_file(
+        &graph,
+        "a.py",
+        &[
+            // definition of `a` module
+            "<a> ($1) [root] -> [a.py(0) definition a] <> ($1)",
+            // reference to `b` in import statement
+            "<> () [a.py(6) reference b] -> [root] <b> ()",
+            // `from b import *` means we can rewrite any lookup of `a.*` → `b.*`
+            "<a.> ($1) [root] -> [root] <b.> ($1)",
+        ],
+    );
+    check_partial_paths_in_file(
+        &graph,
+        "b.py",
+        &[
+            // definition of `b` module
+            "<b> ($1) [root] -> [b.py(0) definition b] <> ($1)",
+            // definition of `foo` inside of `b` module
+            "<b.foo> ($1) [root] -> [b.py(5) definition foo] <> ($1)",
+        ],
+    );
+}

--- a/tests/it/c/mod.rs
+++ b/tests/it/c/mod.rs
@@ -6,6 +6,7 @@
 // ------------------------------------------------------------------------------------------------
 
 mod can_create_graph;
+mod can_find_partial_paths_in_file;
 mod can_jump_to_definition;
 mod files;
 mod nodes;

--- a/tests/it/c/mod.rs
+++ b/tests/it/c/mod.rs
@@ -9,6 +9,7 @@ mod can_create_graph;
 mod can_jump_to_definition;
 mod files;
 mod nodes;
+mod partial;
 mod paths;
 mod symbols;
 mod test_graph;

--- a/tests/it/c/partial.rs
+++ b/tests/it/c/partial.rs
@@ -129,6 +129,19 @@ fn partial_symbol_stack_contains(
     current == SG_LIST_EMPTY_HANDLE
 }
 
+fn partial_symbol_stack_available_in_both_directions(
+    cells: &sg_partial_symbol_stack_cells,
+    list: &sg_partial_symbol_stack,
+) -> bool {
+    let cells = unsafe { std::slice::from_raw_parts(cells.cells, cells.count) };
+    let head = list.cells;
+    if head == SG_LIST_EMPTY_HANDLE {
+        return true;
+    }
+    let cell = &cells[head as usize];
+    cell.reversed != 0
+}
+
 #[test]
 fn can_create_partial_symbol_stacks() {
     let graph = sg_stack_graph_new();
@@ -182,6 +195,17 @@ fn can_create_partial_symbol_stacks() {
     assert!(partial_symbol_stack_contains(&cells, &stacks[0], &symbols0));
     assert!(partial_symbol_stack_contains(&cells, &stacks[1], &symbols1));
     assert!(partial_symbol_stack_contains(&cells, &stacks[2], &symbols2));
+
+    // Verify that each stack is available in both directions.
+    assert!(partial_symbol_stack_available_in_both_directions(
+        &cells, &stacks[0]
+    ));
+    assert!(partial_symbol_stack_available_in_both_directions(
+        &cells, &stacks[1]
+    ));
+    assert!(partial_symbol_stack_available_in_both_directions(
+        &cells, &stacks[2]
+    ));
 
     sg_partial_path_arena_free(partials);
     sg_stack_graph_free(graph);

--- a/tests/it/c/partial.rs
+++ b/tests/it/c/partial.rs
@@ -1,0 +1,156 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use either::Either;
+use libc::c_char;
+use stack_graphs::c::sg_deque_direction;
+use stack_graphs::c::sg_file_handle;
+use stack_graphs::c::sg_node;
+use stack_graphs::c::sg_node_handle;
+use stack_graphs::c::sg_node_id;
+use stack_graphs::c::sg_node_kind;
+use stack_graphs::c::sg_partial_path_arena_add_partial_scope_stacks;
+use stack_graphs::c::sg_partial_path_arena_free;
+use stack_graphs::c::sg_partial_path_arena_new;
+use stack_graphs::c::sg_partial_path_arena_partial_scope_stack_cells;
+use stack_graphs::c::sg_partial_scope_stack;
+use stack_graphs::c::sg_partial_scope_stack_cells;
+use stack_graphs::c::sg_stack_graph;
+use stack_graphs::c::sg_stack_graph_add_files;
+use stack_graphs::c::sg_stack_graph_add_nodes;
+use stack_graphs::c::sg_stack_graph_free;
+use stack_graphs::c::sg_stack_graph_new;
+use stack_graphs::c::SG_LIST_EMPTY_HANDLE;
+
+fn add_file(graph: *mut sg_stack_graph, filename: &str) -> sg_file_handle {
+    let strings = [filename.as_bytes().as_ptr() as *const c_char];
+    let lengths = [filename.len()];
+    let mut handles: [sg_file_handle; 1] = [0; 1];
+    sg_stack_graph_add_files(
+        graph,
+        1,
+        strings.as_ptr(),
+        lengths.as_ptr(),
+        handles.as_mut_ptr(),
+    );
+    assert!(handles[0] != 0);
+    handles[0]
+}
+
+fn add_exported_scope(
+    graph: *mut sg_stack_graph,
+    file: sg_file_handle,
+    local_id: u32,
+) -> sg_node_handle {
+    let node = sg_node {
+        kind: sg_node_kind::SG_NODE_KIND_EXPORTED_SCOPE,
+        id: sg_node_id { file, local_id },
+        symbol: 0,
+        is_clickable: false,
+        scope: 0,
+    };
+    let nodes = [node];
+    let mut handles: [sg_node_handle; 1] = [0; 1];
+    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    handles[0]
+}
+
+//-------------------------------------------------------------------------------------------------
+// Partial scope stacks
+
+fn partial_scope_stack_contains(
+    cells: &sg_partial_scope_stack_cells,
+    stack: &sg_partial_scope_stack,
+    expected: &[sg_node_handle],
+) -> bool {
+    let cells = unsafe { std::slice::from_raw_parts(cells.cells, cells.count) };
+    let mut current = stack.cells;
+    let expected = if stack.direction == sg_deque_direction::SG_DEQUE_FORWARDS {
+        Either::Left(expected.iter())
+    } else {
+        Either::Right(expected.iter().rev())
+    };
+    for node in expected {
+        if current == SG_LIST_EMPTY_HANDLE {
+            return false;
+        }
+        let cell = &cells[current as usize];
+        if cell.head != *node {
+            return false;
+        }
+        current = cell.tail;
+    }
+    current == SG_LIST_EMPTY_HANDLE
+}
+
+fn partial_scope_stack_available_in_both_directions(
+    cells: &sg_partial_scope_stack_cells,
+    list: &sg_partial_scope_stack,
+) -> bool {
+    let cells = unsafe { std::slice::from_raw_parts(cells.cells, cells.count) };
+    let head = list.cells;
+    if head == SG_LIST_EMPTY_HANDLE {
+        return true;
+    }
+    let cell = &cells[head as usize];
+    cell.reversed != 0
+}
+
+#[test]
+fn can_create_partial_scope_stacks() {
+    let graph = sg_stack_graph_new();
+    let partials = sg_partial_path_arena_new();
+    let file = add_file(graph, "test.py");
+    let node1 = add_exported_scope(graph, file, 1);
+    let node2 = add_exported_scope(graph, file, 2);
+    let node3 = add_exported_scope(graph, file, 3);
+    let node4 = add_exported_scope(graph, file, 4);
+
+    // Build up the arrays of stack content and add the stacks to the path arena.
+    let scopes0 = [];
+    let scopes1 = [node1];
+    let scopes2 = [node2, node3, node4];
+    let lengths = [scopes0.len(), scopes1.len(), scopes2.len()];
+    let variables = [0, 0, 1];
+    let mut scopeses = Vec::new();
+    scopeses.extend_from_slice(&scopes0);
+    scopeses.extend_from_slice(&scopes1);
+    scopeses.extend_from_slice(&scopes2);
+    let mut stacks = [sg_partial_scope_stack::default(); 3];
+    sg_partial_path_arena_add_partial_scope_stacks(
+        partials,
+        lengths.len(),
+        scopeses.as_slice().as_ptr(),
+        lengths.as_ptr(),
+        variables.as_ptr(),
+        stacks.as_mut_ptr(),
+    );
+
+    // Then verify that we can dereference all of the new stacks.
+    let cells = sg_partial_path_arena_partial_scope_stack_cells(partials);
+    assert!(partial_scope_stack_contains(&cells, &stacks[0], &scopes0));
+    assert!(partial_scope_stack_contains(&cells, &stacks[1], &scopes1));
+    assert!(partial_scope_stack_contains(&cells, &stacks[2], &scopes2));
+
+    assert_eq!(stacks[0].variable, variables[0]);
+    assert_eq!(stacks[1].variable, variables[1]);
+    assert_eq!(stacks[2].variable, variables[2]);
+
+    // Verify that each stack is available in both directions.
+    assert!(partial_scope_stack_available_in_both_directions(
+        &cells, &stacks[0]
+    ));
+    assert!(partial_scope_stack_available_in_both_directions(
+        &cells, &stacks[1]
+    ));
+    assert!(partial_scope_stack_available_in_both_directions(
+        &cells, &stacks[2]
+    ));
+
+    sg_partial_path_arena_free(partials);
+    sg_stack_graph_free(graph);
+}

--- a/tests/it/c/partial.rs
+++ b/tests/it/c/partial.rs
@@ -13,12 +13,17 @@ use stack_graphs::c::sg_node;
 use stack_graphs::c::sg_node_handle;
 use stack_graphs::c::sg_node_id;
 use stack_graphs::c::sg_node_kind;
+use stack_graphs::c::sg_partial_path_arena_add_partial_path_edge_lists;
 use stack_graphs::c::sg_partial_path_arena_add_partial_scope_stacks;
 use stack_graphs::c::sg_partial_path_arena_add_partial_symbol_stacks;
 use stack_graphs::c::sg_partial_path_arena_free;
 use stack_graphs::c::sg_partial_path_arena_new;
+use stack_graphs::c::sg_partial_path_arena_partial_path_edge_list_cells;
 use stack_graphs::c::sg_partial_path_arena_partial_scope_stack_cells;
 use stack_graphs::c::sg_partial_path_arena_partial_symbol_stack_cells;
+use stack_graphs::c::sg_partial_path_edge;
+use stack_graphs::c::sg_partial_path_edge_list;
+use stack_graphs::c::sg_partial_path_edge_list_cells;
 use stack_graphs::c::sg_partial_scope_stack;
 use stack_graphs::c::sg_partial_scope_stack_cells;
 use stack_graphs::c::sg_partial_scoped_symbol;
@@ -272,6 +277,104 @@ fn can_create_partial_scope_stacks() {
     ));
     assert!(partial_scope_stack_available_in_both_directions(
         &cells, &stacks[2]
+    ));
+
+    sg_partial_path_arena_free(partials);
+    sg_stack_graph_free(graph);
+}
+
+//-------------------------------------------------------------------------------------------------
+// Partial path edge lists
+
+fn partial_path_edge(file: sg_file_handle, local_id: u32, precedence: i32) -> sg_partial_path_edge {
+    let source_node_id = sg_node_id { file, local_id };
+    sg_partial_path_edge {
+        source_node_id,
+        precedence,
+    }
+}
+
+fn partial_path_edge_list_contains(
+    cells: &sg_partial_path_edge_list_cells,
+    list: &sg_partial_path_edge_list,
+    expected: &[sg_partial_path_edge],
+) -> bool {
+    let cells = unsafe { std::slice::from_raw_parts(cells.cells, cells.count) };
+    let mut current = list.cells;
+    let expected = if list.direction == sg_deque_direction::SG_DEQUE_FORWARDS {
+        Either::Left(expected.iter())
+    } else {
+        Either::Right(expected.iter().rev())
+    };
+    for node in expected {
+        if current == SG_LIST_EMPTY_HANDLE {
+            return false;
+        }
+        let cell = &cells[current as usize];
+        if cell.head != *node {
+            return false;
+        }
+        current = cell.tail;
+    }
+    current == SG_LIST_EMPTY_HANDLE
+}
+
+fn partial_path_edge_list_available_in_both_directions(
+    cells: &sg_partial_path_edge_list_cells,
+    list: &sg_partial_path_edge_list,
+) -> bool {
+    let cells = unsafe { std::slice::from_raw_parts(cells.cells, cells.count) };
+    let head = list.cells;
+    if head == SG_LIST_EMPTY_HANDLE {
+        return true;
+    }
+    let cell = &cells[head as usize];
+    cell.reversed != 0
+}
+
+#[test]
+fn can_create_partial_path_edge_lists() {
+    let graph = sg_stack_graph_new();
+    let partials = sg_partial_path_arena_new();
+    let file = add_file(graph, "test.py");
+
+    // Build up the arrays of edge list content and add the lists to the path arena.
+    let edges0 = [];
+    let edges1 = [partial_path_edge(file, 25, 25)];
+    let edges2 = [
+        partial_path_edge(file, 1, 11),
+        partial_path_edge(file, 2, 12),
+        partial_path_edge(file, 3, 13),
+    ];
+    let lengths = [edges0.len(), edges1.len(), edges2.len()];
+    let mut edgeses = Vec::new();
+    edgeses.extend_from_slice(&edges0);
+    edgeses.extend_from_slice(&edges1);
+    edgeses.extend_from_slice(&edges2);
+    let mut lists = [sg_partial_path_edge_list::default(); 3];
+    sg_partial_path_arena_add_partial_path_edge_lists(
+        partials,
+        lengths.len(),
+        edgeses.as_slice().as_ptr(),
+        lengths.as_ptr(),
+        lists.as_mut_ptr(),
+    );
+
+    // Then verify that we can dereference all of the new lists.
+    let cells = sg_partial_path_arena_partial_path_edge_list_cells(partials);
+    assert!(partial_path_edge_list_contains(&cells, &lists[0], &edges0));
+    assert!(partial_path_edge_list_contains(&cells, &lists[1], &edges1));
+    assert!(partial_path_edge_list_contains(&cells, &lists[2], &edges2));
+
+    // Verify that each list is available in both directions.
+    assert!(partial_path_edge_list_available_in_both_directions(
+        &cells, &lists[0]
+    ));
+    assert!(partial_path_edge_list_available_in_both_directions(
+        &cells, &lists[1]
+    ));
+    assert!(partial_path_edge_list_available_in_both_directions(
+        &cells, &lists[2]
     ));
 
     sg_partial_path_arena_free(partials);


### PR DESCRIPTION
This is largely a copy/paste job of the previous PRs to add concrete paths to the C API.  It culminates in another test case that can be invoked purely via the C API, which tests the algorithm that finds partial paths in a file.