### PR TITLE
Refer to exported scopes by ID, not handle

### DIFF
--- a/include/stack-graphs.h
+++ b/include/stack-graphs.h
@@ -13,10 +13,10 @@
 #define SG_LIST_EMPTY_HANDLE 4294967295
 
 // The local_id of the singleton root node.
-#define SG_ROOT_NODE_ID 0
+#define SG_ROOT_NODE_ID 1
 
 // The local_id of the singleton "jump to scope" node.
-#define SG_JUMP_TO_NODE_ID 1
+#define SG_JUMP_TO_NODE_ID 2
 
 // Describes in which direction the content of a deque is stored in memory.
 enum sg_deque_direction {
@@ -140,9 +140,6 @@ struct sg_node_id {
     uint32_t local_id;
 };
 
-// A handle to a node in a stack graph.  A zero handle represents a missing node.
-typedef uint32_t sg_node_handle;
-
 // A node in a stack graph.
 struct sg_node {
     enum sg_node_kind kind;
@@ -154,7 +151,7 @@ struct sg_node {
     // The scope associated with this node.  For push scope nodes, this is the scope that will be
     // attached to the symbol before it's pushed onto the symbol stack.  For all other node types,
     // this will be null.
-    sg_node_handle scope;
+    struct sg_node_id scope;
     // Whether this node is "clickable".  For push nodes, this indicates that the node represents
     // a reference in the source.  For pop nodes, this indicates that the node represents a
     // definition in the source.  For all other node types, this field will be unused.
@@ -168,6 +165,9 @@ struct sg_nodes {
     const struct sg_node *nodes;
     size_t count;
 };
+
+// A handle to a node in a stack graph.  A zero handle represents a missing node.
+typedef uint32_t sg_node_handle;
 
 // Connects two nodes in a stack graph.
 //

--- a/tests/it/c/nodes.rs
+++ b/tests/it/c/nodes.rs
@@ -73,7 +73,7 @@ fn jump_to_node() -> sg_node {
         },
         symbol: 0,
         is_clickable: false,
-        scope: 0,
+        scope: sg_node_id::default(),
     }
 }
 
@@ -86,7 +86,7 @@ fn root_node() -> sg_node {
         },
         symbol: 0,
         is_clickable: false,
-        scope: 0,
+        scope: sg_node_id::default(),
     }
 }
 
@@ -124,7 +124,7 @@ fn drop_scopes(file: sg_file_handle, local_id: u32) -> sg_node {
         id: sg_node_id { file, local_id },
         symbol: 0,
         is_clickable: false,
-        scope: 0,
+        scope: sg_node_id::default(),
     }
 }
 
@@ -164,7 +164,10 @@ fn drop_scopes_cannot_have_scope() {
     let graph = sg_stack_graph_new();
     let file = add_file(graph, "test.py");
     let mut nodes = [drop_scopes(file, 42)];
-    nodes[0].scope = SG_JUMP_TO_NODE_HANDLE;
+    nodes[0].scope = sg_node_id {
+        file: 0,
+        local_id: SG_JUMP_TO_NODE_ID,
+    };
     let mut handles: [sg_node_handle; 1] = [0; 1];
     sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     assert!(handles[0] == 0);
@@ -180,7 +183,7 @@ fn exported_scope(file: sg_file_handle, local_id: u32) -> sg_node {
         id: sg_node_id { file, local_id },
         symbol: 0,
         is_clickable: false,
-        scope: 0,
+        scope: sg_node_id::default(),
     }
 }
 
@@ -220,7 +223,10 @@ fn exported_scope_cannot_have_scope() {
     let graph = sg_stack_graph_new();
     let file = add_file(graph, "test.py");
     let mut nodes = [exported_scope(file, 42)];
-    nodes[0].scope = SG_JUMP_TO_NODE_HANDLE;
+    nodes[0].scope = sg_node_id {
+        file: 0,
+        local_id: SG_JUMP_TO_NODE_ID,
+    };
     let mut handles: [sg_node_handle; 1] = [0; 1];
     sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     assert!(handles[0] == 0);
@@ -236,7 +242,7 @@ fn internal_scope(file: sg_file_handle, local_id: u32) -> sg_node {
         id: sg_node_id { file, local_id },
         symbol: 0,
         is_clickable: false,
-        scope: 0,
+        scope: sg_node_id::default(),
     }
 }
 
@@ -276,7 +282,10 @@ fn internal_scope_cannot_have_scope() {
     let graph = sg_stack_graph_new();
     let file = add_file(graph, "test.py");
     let mut nodes = [internal_scope(file, 42)];
-    nodes[0].scope = SG_JUMP_TO_NODE_HANDLE;
+    nodes[0].scope = sg_node_id {
+        file: 0,
+        local_id: SG_JUMP_TO_NODE_ID,
+    };
     let mut handles: [sg_node_handle; 1] = [0; 1];
     sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     assert!(handles[0] == 0);
@@ -292,7 +301,7 @@ fn pop_scoped_symbol(file: sg_file_handle, local_id: u32, symbol: sg_symbol_hand
         id: sg_node_id { file, local_id },
         symbol,
         is_clickable: true,
-        scope: 0,
+        scope: sg_node_id::default(),
     }
 }
 
@@ -334,7 +343,10 @@ fn pop_scoped_symbol_cannot_have_scope() {
     let file = add_file(graph, "test.py");
     let symbol = add_symbol(graph, "a");
     let mut nodes = [pop_scoped_symbol(file, 42, symbol)];
-    nodes[0].scope = SG_JUMP_TO_NODE_HANDLE;
+    nodes[0].scope = sg_node_id {
+        file: 0,
+        local_id: SG_JUMP_TO_NODE_ID,
+    };
     let mut handles: [sg_node_handle; 1] = [0; 1];
     sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     assert!(handles[0] == 0);
@@ -350,7 +362,7 @@ fn pop_symbol(file: sg_file_handle, local_id: u32, symbol: sg_symbol_handle) -> 
         id: sg_node_id { file, local_id },
         symbol,
         is_clickable: true,
-        scope: 0,
+        scope: sg_node_id::default(),
     }
 }
 
@@ -392,7 +404,10 @@ fn pop_symbol_cannot_have_scope() {
     let file = add_file(graph, "test.py");
     let symbol = add_symbol(graph, "a");
     let mut nodes = [pop_symbol(file, 42, symbol)];
-    nodes[0].scope = SG_JUMP_TO_NODE_HANDLE;
+    nodes[0].scope = sg_node_id {
+        file: 0,
+        local_id: SG_JUMP_TO_NODE_ID,
+    };
     let mut handles: [sg_node_handle; 1] = [0; 1];
     sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     assert!(handles[0] == 0);
@@ -406,8 +421,13 @@ fn push_scoped_symbol(
     file: sg_file_handle,
     local_id: u32,
     symbol: sg_symbol_handle,
-    scope: sg_node_handle,
+    scope_file: sg_file_handle,
+    scope_id: u32,
 ) -> sg_node {
+    let scope = sg_node_id {
+        file: scope_file,
+        local_id: scope_id,
+    };
     sg_node {
         kind: sg_node_kind::SG_NODE_KIND_PUSH_SCOPED_SYMBOL,
         id: sg_node_id { file, local_id },
@@ -422,7 +442,7 @@ fn can_add_push_scoped_symbol_node() {
     let graph = sg_stack_graph_new();
     let file = add_file(graph, "test.py");
     let symbol = add_symbol(graph, "a");
-    let nodes = [push_scoped_symbol(file, 42, symbol, SG_JUMP_TO_NODE_HANDLE)];
+    let nodes = [push_scoped_symbol(file, 42, symbol, 0, SG_JUMP_TO_NODE_ID)];
     let mut handles: [sg_node_handle; 1] = [0; 1];
     // Add the node and verify its contents after dereferencing it.
     sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
@@ -431,7 +451,7 @@ fn can_add_push_scoped_symbol_node() {
     assert!(matches!(node, Node::PushScopedSymbol(_)));
     assert!(node.id() == node_id(file, 42));
     assert!(node.symbol().unwrap().as_usize() == symbol as usize);
-    assert!(node.scope().unwrap().as_usize() == SG_JUMP_TO_NODE_HANDLE as usize);
+    assert!(node.scope().unwrap().is_jump_to());
     assert!(node.is_reference());
     // Make sure we can't add the same node again.
     sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
@@ -443,7 +463,7 @@ fn can_add_push_scoped_symbol_node() {
 fn push_scoped_symbol_must_have_symbol() {
     let graph = sg_stack_graph_new();
     let file = add_file(graph, "test.py");
-    let nodes = [push_scoped_symbol(file, 42, 0, SG_JUMP_TO_NODE_HANDLE)];
+    let nodes = [push_scoped_symbol(file, 42, 0, 0, SG_JUMP_TO_NODE_ID)];
     let mut handles: [sg_node_handle; 1] = [0; 1];
     sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     assert!(handles[0] == 0);
@@ -455,7 +475,7 @@ fn push_scoped_symbol_must_have_scope() {
     let graph = sg_stack_graph_new();
     let file = add_file(graph, "test.py");
     let symbol = add_symbol(graph, "a");
-    let nodes = [push_scoped_symbol(file, 42, symbol, 0)];
+    let nodes = [push_scoped_symbol(file, 42, symbol, 0, 0)];
     let mut handles: [sg_node_handle; 1] = [0; 1];
     sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     assert!(handles[0] == 0);
@@ -471,7 +491,7 @@ fn push_symbol(file: sg_file_handle, local_id: u32, symbol: sg_symbol_handle) ->
         id: sg_node_id { file, local_id },
         symbol,
         is_clickable: true,
-        scope: 0,
+        scope: sg_node_id::default(),
     }
 }
 
@@ -513,7 +533,10 @@ fn push_symbol_cannot_have_scope() {
     let file = add_file(graph, "test.py");
     let symbol = add_symbol(graph, "a");
     let mut nodes = [push_symbol(file, 42, symbol)];
-    nodes[0].scope = SG_JUMP_TO_NODE_HANDLE;
+    nodes[0].scope = sg_node_id {
+        file: 0,
+        local_id: SG_JUMP_TO_NODE_ID,
+    };
     let mut handles: [sg_node_handle; 1] = [0; 1];
     sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     assert!(handles[0] == 0);

--- a/tests/it/c/partial.rs
+++ b/tests/it/c/partial.rs
@@ -78,7 +78,7 @@ fn add_exported_scope(
         id: sg_node_id { file, local_id },
         symbol: 0,
         is_clickable: false,
-        scope: 0,
+        scope: sg_node_id::default(),
     };
     let nodes = [node];
     let mut handles: [sg_node_handle; 1] = [0; 1];

--- a/tests/it/c/paths.rs
+++ b/tests/it/c/paths.rs
@@ -78,7 +78,7 @@ fn add_exported_scope(
         id: sg_node_id { file, local_id },
         symbol: 0,
         is_clickable: false,
-        scope: 0,
+        scope: sg_node_id::default(),
     };
     let nodes = [node];
     let mut handles: [sg_node_handle; 1] = [0; 1];

--- a/tests/it/c/test_graph.rs
+++ b/tests/it/c/test_graph.rs
@@ -72,7 +72,7 @@ impl CreateStackGraph for TestGraph {
             id: sg_node_id { file, local_id },
             symbol,
             is_clickable: true,
-            scope: 0,
+            scope: sg_node_id::default(),
         })
     }
 
@@ -82,7 +82,7 @@ impl CreateStackGraph for TestGraph {
             id: sg_node_id { file, local_id },
             symbol: 0,
             is_clickable: false,
-            scope: 0,
+            scope: sg_node_id::default(),
         })
     }
 
@@ -102,7 +102,7 @@ impl CreateStackGraph for TestGraph {
             id: sg_node_id { file, local_id },
             symbol: 0,
             is_clickable: false,
-            scope: 0,
+            scope: sg_node_id::default(),
         })
     }
 
@@ -126,7 +126,7 @@ impl CreateStackGraph for TestGraph {
             id: sg_node_id { file, local_id },
             symbol: 0,
             is_clickable: false,
-            scope: 0,
+            scope: sg_node_id::default(),
         })
     }
 
@@ -145,7 +145,7 @@ impl CreateStackGraph for TestGraph {
             id: sg_node_id { file, local_id },
             symbol,
             is_clickable: false,
-            scope: 0,
+            scope: sg_node_id::default(),
         })
     }
 
@@ -160,7 +160,7 @@ impl CreateStackGraph for TestGraph {
             id: sg_node_id { file, local_id },
             symbol,
             is_clickable: false,
-            scope: 0,
+            scope: sg_node_id::default(),
         })
     }
 
@@ -169,8 +169,13 @@ impl CreateStackGraph for TestGraph {
         file: sg_file_handle,
         local_id: u32,
         symbol: sg_symbol_handle,
-        scope: sg_node_handle,
+        scope_file: sg_file_handle,
+        scope_id: u32,
     ) -> sg_node_handle {
+        let scope = sg_node_id {
+            file: scope_file,
+            local_id: scope_id,
+        };
         self.add_node(sg_node {
             kind: sg_node_kind::SG_NODE_KIND_PUSH_SCOPED_SYMBOL,
             id: sg_node_id { file, local_id },
@@ -191,7 +196,7 @@ impl CreateStackGraph for TestGraph {
             id: sg_node_id { file, local_id },
             symbol,
             is_clickable: false,
-            scope: 0,
+            scope: sg_node_id::default(),
         })
     }
 
@@ -206,7 +211,7 @@ impl CreateStackGraph for TestGraph {
             id: sg_node_id { file, local_id },
             symbol,
             is_clickable: true,
-            scope: 0,
+            scope: sg_node_id::default(),
         })
     }
 

--- a/tests/it/test_graphs/class_field_through_function_parameter.rs
+++ b/tests/it/test_graphs/class_field_through_function_parameter.rs
@@ -59,7 +59,7 @@ where
     let main_A = graph.reference(main_file, 9, sym_A);
     let main_bar = graph.reference(main_file, 10, sym_bar);
     let main_dot_11 = graph.push_symbol(main_file, 11, sym_dot);
-    let main_call_12 = graph.push_scoped_symbol(main_file, 12, sym_call, main_exported);
+    let main_call_12 = graph.push_scoped_symbol(main_file, 12, sym_call, main_file, 7);
     let main_foo = graph.reference(main_file, 13, sym_foo);
     let main_dot_14 = graph.push_symbol(main_file, 14, sym_dot);
     let main_b = graph.reference(main_file, 15, sym_b);

--- a/tests/it/test_graphs/mod.rs
+++ b/tests/it/test_graphs/mod.rs
@@ -49,7 +49,8 @@ pub trait CreateStackGraph {
         file: Self::File,
         local_id: u32,
         symbol: Self::Symbol,
-        scope: Self::Node,
+        scope_file: Self::File,
+        scope_id: u32,
     ) -> Self::Node;
 
     fn push_symbol(&mut self, file: Self::File, local_id: u32, symbol: Self::Symbol) -> Self::Node;
@@ -128,8 +129,10 @@ impl CreateStackGraph for StackGraph {
         file: Handle<File>,
         local_id: u32,
         symbol: Handle<Symbol>,
-        scope: Handle<Node>,
+        scope_file: Handle<File>,
+        scope_id: u32,
     ) -> Handle<Node> {
+        let scope = NodeID::new_in_file(scope_file, scope_id);
         self.add_push_scoped_symbol_node(NodeID::new_in_file(file, local_id), symbol, scope, false)
             .expect("Duplicate node ID")
     }


### PR DESCRIPTION
“Push scoped symbol” nodes need to refer to an exported scope node, which will be added to the scope stack that's attached to the symbol that is pushed onto the symbol stack.  Before, you would pass in the handle of the exported scope node.  Now, you pass in its ID.  Both of these are unique identifiers, and so there's no danger of an ambiguous node reference.  This does mean that we need to look up the node's handle as part of the path-finding algorithm, since we are still storing node handles in our scope stack representations.

The reason for this change is that before this patch, you had to add nodes to a stack graph in separate passes: first you would add your exported scope nodes, and only then would you add your pushed scope symbol nodes.  You had to use this ordering so that you'd have a valid handle to pass in to the pushed scope symbol constructor.  By using node IDs, there is no constraint on the order that you add nodes — it's perfectly fine to add the pushed scoped symbol node first, as long you as eventually add the exported scope node with the desired ID before performing any lookups.

It's important to not enforce a particular order on node construction since users of the C API have to use a batched API to add stack graph content.  With this change, C consumers can use a single call to `sg_stack_graph_add_nodes`, including _all_ of the nodes that they want to create, instead of having to choreograph two separate calls to the function.