### PR TITLE
Use “collapsed” strings in C API 

### DIFF
--- a/include/stack-graphs.h
+++ b/include/stack-graphs.h
@@ -493,9 +493,10 @@ void sg_partial_path_database_free(struct sg_partial_path_database *db);
 // pointer is only valid until the next call to any function that mutates the stack graph.
 struct sg_symbols sg_stack_graph_symbols(const struct sg_stack_graph *graph);
 
-// Adds new symbols to the stack graph.  You provide an array of symbol content, and an output
-// array, which must have the same length.  We will place each symbol's handle in the output
-// array.
+// Adds new symbols to the stack graph.  You provide all of the symbol content concatenated
+// together into a single string, and an array of the lengths of each symbol.  You also provide an
+// output array, which must have the same size as `lengths`.  We will place each symbol's handle
+// in the output array.
 //
 // We ensure that there is only ever one copy of a particular symbol stored in the graph — we
 // guarantee that identical symbols will have the same handles, meaning that you can compare the
@@ -508,7 +509,7 @@ struct sg_symbols sg_stack_graph_symbols(const struct sg_stack_graph *graph);
 // to the stack graph, and the corresponding entry in the output array will be the null handle.
 void sg_stack_graph_add_symbols(struct sg_stack_graph *graph,
                                 size_t count,
-                                const char *const *symbols,
+                                const char *symbols,
                                 const size_t *lengths,
                                 sg_symbol_handle *handles_out);
 
@@ -516,8 +517,10 @@ void sg_stack_graph_add_symbols(struct sg_stack_graph *graph,
 // is only valid until the next call to any function that mutates the stack graph.
 struct sg_files sg_stack_graph_files(const struct sg_stack_graph *graph);
 
-// Adds new files to the stack graph.  You provide an array of file content, and an output array,
-// which must have the same length.  We will place each file's handle in the output array.
+// Adds new files to the stack graph.  You provide all of the file content concatenated together
+// into a single string, and an array of the lengths of each file.  You also provide an output
+// array, which must have the same size as `lengths`.  We will place each file's handle in the
+// output array.
 //
 // There can only ever be one file with a particular name in the graph.  If you try to add a file
 // with a name that already exists, you'll get the same handle as a result.
@@ -530,7 +533,7 @@ struct sg_files sg_stack_graph_files(const struct sg_stack_graph *graph);
 // handle.
 void sg_stack_graph_add_files(struct sg_stack_graph *graph,
                               size_t count,
-                              const char *const *files,
+                              const char *files,
                               const size_t *lengths,
                               sg_file_handle *handles_out);
 

--- a/tests/it/c/files.rs
+++ b/tests/it/c/files.rs
@@ -15,12 +15,6 @@ use stack_graphs::c::sg_stack_graph_free;
 use stack_graphs::c::sg_stack_graph_new;
 use stack_graphs::graph::File;
 
-fn strings(data: &[&'static str]) -> Vec<*const c_char> {
-    data.iter()
-        .map(|s| s.as_bytes().as_ptr() as *const c_char)
-        .collect()
-}
-
 fn lengths(data: &[&'static str]) -> Vec<usize> {
     data.iter().map(|s| s.len()).collect()
 }
@@ -43,7 +37,7 @@ fn can_create_files() {
     sg_stack_graph_add_files(
         graph,
         filenames.len(),
-        strings(&filenames).as_ptr(),
+        filenames.join("").as_ptr() as *const c_char,
         lengths(&filenames).as_ptr(),
         handles.as_mut_ptr() as *mut sg_file_handle,
     );

--- a/tests/it/c/nodes.rs
+++ b/tests/it/c/nodes.rs
@@ -32,13 +32,12 @@ fn node_id(file: sg_file_handle, local_id: u32) -> NodeID {
 }
 
 fn add_file(graph: *mut sg_stack_graph, filename: &str) -> sg_file_handle {
-    let strings = [filename.as_bytes().as_ptr() as *const c_char];
     let lengths = [filename.len()];
     let mut handles: [sg_file_handle; 1] = [0; 1];
     sg_stack_graph_add_files(
         graph,
         1,
-        strings.as_ptr(),
+        filename.as_bytes().as_ptr() as *const c_char,
         lengths.as_ptr(),
         handles.as_mut_ptr(),
     );
@@ -47,13 +46,12 @@ fn add_file(graph: *mut sg_stack_graph, filename: &str) -> sg_file_handle {
 }
 
 fn add_symbol(graph: *mut sg_stack_graph, symbol: &str) -> sg_symbol_handle {
-    let strings = [symbol.as_bytes().as_ptr() as *const c_char];
     let lengths = [symbol.len()];
     let mut handles: [sg_symbol_handle; 1] = [0; 1];
     sg_stack_graph_add_symbols(
         graph,
         1,
-        strings.as_ptr(),
+        symbol.as_bytes().as_ptr() as *const c_char,
         lengths.as_ptr(),
         handles.as_mut_ptr(),
     );

--- a/tests/it/c/partial.rs
+++ b/tests/it/c/partial.rs
@@ -39,13 +39,12 @@ use stack_graphs::c::sg_symbol_handle;
 use stack_graphs::c::SG_LIST_EMPTY_HANDLE;
 
 fn add_file(graph: *mut sg_stack_graph, filename: &str) -> sg_file_handle {
-    let strings = [filename.as_bytes().as_ptr() as *const c_char];
     let lengths = [filename.len()];
     let mut handles: [sg_file_handle; 1] = [0; 1];
     sg_stack_graph_add_files(
         graph,
         1,
-        strings.as_ptr(),
+        filename.as_bytes().as_ptr() as *const c_char,
         lengths.as_ptr(),
         handles.as_mut_ptr(),
     );
@@ -54,13 +53,12 @@ fn add_file(graph: *mut sg_stack_graph, filename: &str) -> sg_file_handle {
 }
 
 fn add_symbol(graph: *mut sg_stack_graph, value: &str) -> sg_symbol_handle {
-    let strings = [value.as_bytes().as_ptr() as *const c_char];
     let lengths = [value.len()];
     let mut handles: [sg_symbol_handle; 1] = [0; 1];
     sg_stack_graph_add_symbols(
         graph,
         1,
-        strings.as_ptr(),
+        value.as_bytes().as_ptr() as *const c_char,
         lengths.as_ptr(),
         handles.as_mut_ptr(),
     );

--- a/tests/it/c/paths.rs
+++ b/tests/it/c/paths.rs
@@ -39,13 +39,12 @@ use stack_graphs::c::sg_symbol_stack_cells;
 use stack_graphs::c::SG_LIST_EMPTY_HANDLE;
 
 fn add_file(graph: *mut sg_stack_graph, filename: &str) -> sg_file_handle {
-    let strings = [filename.as_bytes().as_ptr() as *const c_char];
     let lengths = [filename.len()];
     let mut handles: [sg_file_handle; 1] = [0; 1];
     sg_stack_graph_add_files(
         graph,
         1,
-        strings.as_ptr(),
+        filename.as_bytes().as_ptr() as *const c_char,
         lengths.as_ptr(),
         handles.as_mut_ptr(),
     );
@@ -54,13 +53,12 @@ fn add_file(graph: *mut sg_stack_graph, filename: &str) -> sg_file_handle {
 }
 
 fn add_symbol(graph: *mut sg_stack_graph, value: &str) -> sg_symbol_handle {
-    let strings = [value.as_bytes().as_ptr() as *const c_char];
     let lengths = [value.len()];
     let mut handles: [sg_symbol_handle; 1] = [0; 1];
     sg_stack_graph_add_symbols(
         graph,
         1,
-        strings.as_ptr(),
+        value.as_bytes().as_ptr() as *const c_char,
         lengths.as_ptr(),
         handles.as_mut_ptr(),
     );

--- a/tests/it/c/symbols.rs
+++ b/tests/it/c/symbols.rs
@@ -15,12 +15,6 @@ use stack_graphs::c::sg_symbol_handle;
 use stack_graphs::c::sg_symbols;
 use stack_graphs::graph::Symbol;
 
-fn strings(data: &[&'static str]) -> Vec<*const c_char> {
-    data.iter()
-        .map(|s| s.as_bytes().as_ptr() as *const c_char)
-        .collect()
-}
-
 fn lengths(data: &[&'static str]) -> Vec<usize> {
     data.iter().map(|s| s.len()).collect()
 }
@@ -43,7 +37,7 @@ fn can_create_symbols() {
     sg_stack_graph_add_symbols(
         graph,
         symbol_data.len(),
-        strings(&symbol_data).as_ptr(),
+        symbol_data.join("").as_ptr() as *const c_char,
         lengths(&symbol_data).as_ptr(),
         handles.as_mut_ptr() as *mut sg_symbol_handle,
     );

--- a/tests/it/c/test_graph.rs
+++ b/tests/it/c/test_graph.rs
@@ -107,13 +107,12 @@ impl CreateStackGraph for TestGraph {
     }
 
     fn file(&mut self, name: &str) -> sg_file_handle {
-        let names = [name.as_bytes().as_ptr() as *const c_char];
         let lengths = [name.len()];
         let mut handles: [sg_file_handle; 1] = [0; 1];
         sg_stack_graph_add_files(
             self.graph,
-            names.len(),
-            names.as_ptr(),
+            1,
+            name.as_bytes().as_ptr() as *const c_char,
             lengths.as_ptr(),
             handles.as_mut_ptr(),
         );
@@ -220,13 +219,12 @@ impl CreateStackGraph for TestGraph {
     }
 
     fn symbol(&mut self, value: &str) -> sg_symbol_handle {
-        let symbols = [value.as_bytes().as_ptr() as *const c_char];
         let lengths = [value.len()];
         let mut handles: [sg_symbol_handle; 1] = [0; 1];
         sg_stack_graph_add_symbols(
             self.graph,
-            symbols.len(),
-            symbols.as_ptr(),
+            1,
+            value.as_bytes().as_ptr() as *const c_char,
             lengths.as_ptr(),
             handles.as_mut_ptr(),
         );


### PR DESCRIPTION
Symbols and files both consist only of a single string.  Before, the C API functions for bulk-loading symbols and files expected you to pass in an array of arrays of string content.  This patch updates the functions to have you pass in a single `const char*`, containing the content of everything you want to add _concatenated together_. Consumers will already likely be building up the string content dynamically, and so it's not harder to build that up into a single string buffer instead of into an array of string pointers.  And the result should both require fewer allocations in all languages, and should play more nicely with Cgo in particular, which prohibits Go pointers within Go pointers for any data that you pass into a C call.