### PR TITLE
Get or create nodes in C API

### DIFF
--- a/include/stack-graphs.h
+++ b/include/stack-graphs.h
@@ -551,13 +551,16 @@ struct sg_nodes sg_stack_graph_nodes(const struct sg_stack_graph *graph);
 // You cannot add new instances of the root node or "jump to scope" node, since those are
 // singletons and already exist in the stack graph.
 //
+// If you try to add a new node that has the same ID as an existing node in the stack graph, the
+// new node will be ignored, and the corresponding entry in the `handles_out` array will contain
+// the handle of the _existing_ node with that ID.
+//
 // If any node that you pass in is invalid, it will not be added to the graph, and the
-// corresponding entry in the `handles_out` array will be null.  (Note that includes trying to add
-// a node with the same ID as an existing node, since all nodes must have unique IDs.)
-void sg_stack_graph_add_nodes(struct sg_stack_graph *graph,
-                              size_t count,
-                              const struct sg_node *nodes,
-                              sg_node_handle *handles_out);
+// corresponding entry in the `handles_out` array will be null.
+void sg_stack_graph_get_or_create_nodes(struct sg_stack_graph *graph,
+                                        size_t count,
+                                        const struct sg_node *nodes,
+                                        sg_node_handle *handles_out);
 
 // Adds new edges to the stack graph.  You provide an array of `struct sg_edges` instances.  A
 // stack graph can contain at most one edge between any two nodes.  It is not an error if you try

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -603,6 +603,15 @@ impl StackGraph {
         self.node_id_handles.set_handle_for_id(id, handle);
         Some(handle)
     }
+
+    pub(crate) fn get_or_create_node(&mut self, id: NodeID, node: Node) -> Handle<Node> {
+        if let Some(handle) = self.node_id_handles.handle_for_id(id) {
+            return handle;
+        }
+        let handle = self.nodes.add(node);
+        self.node_id_handles.set_handle_for_id(id, handle);
+        handle
+    }
 }
 
 #[doc(hidden)]

--- a/tests/it/c/partial.rs
+++ b/tests/it/c/partial.rs
@@ -31,9 +31,9 @@ use stack_graphs::c::sg_partial_symbol_stack;
 use stack_graphs::c::sg_partial_symbol_stack_cells;
 use stack_graphs::c::sg_stack_graph;
 use stack_graphs::c::sg_stack_graph_add_files;
-use stack_graphs::c::sg_stack_graph_add_nodes;
 use stack_graphs::c::sg_stack_graph_add_symbols;
 use stack_graphs::c::sg_stack_graph_free;
+use stack_graphs::c::sg_stack_graph_get_or_create_nodes;
 use stack_graphs::c::sg_stack_graph_new;
 use stack_graphs::c::sg_symbol_handle;
 use stack_graphs::c::SG_LIST_EMPTY_HANDLE;
@@ -80,7 +80,7 @@ fn add_exported_scope(
     };
     let nodes = [node];
     let mut handles: [sg_node_handle; 1] = [0; 1];
-    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    sg_stack_graph_get_or_create_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     handles[0]
 }
 

--- a/tests/it/c/paths.rs
+++ b/tests/it/c/paths.rs
@@ -29,9 +29,9 @@ use stack_graphs::c::sg_scope_stack_cells;
 use stack_graphs::c::sg_scoped_symbol;
 use stack_graphs::c::sg_stack_graph;
 use stack_graphs::c::sg_stack_graph_add_files;
-use stack_graphs::c::sg_stack_graph_add_nodes;
 use stack_graphs::c::sg_stack_graph_add_symbols;
 use stack_graphs::c::sg_stack_graph_free;
+use stack_graphs::c::sg_stack_graph_get_or_create_nodes;
 use stack_graphs::c::sg_stack_graph_new;
 use stack_graphs::c::sg_symbol_handle;
 use stack_graphs::c::sg_symbol_stack;
@@ -80,7 +80,7 @@ fn add_exported_scope(
     };
     let nodes = [node];
     let mut handles: [sg_node_handle; 1] = [0; 1];
-    sg_stack_graph_add_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
+    sg_stack_graph_get_or_create_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     handles[0]
 }
 

--- a/tests/it/c/test_graph.rs
+++ b/tests/it/c/test_graph.rs
@@ -15,9 +15,9 @@ use stack_graphs::c::sg_node_kind;
 use stack_graphs::c::sg_stack_graph;
 use stack_graphs::c::sg_stack_graph_add_edges;
 use stack_graphs::c::sg_stack_graph_add_files;
-use stack_graphs::c::sg_stack_graph_add_nodes;
 use stack_graphs::c::sg_stack_graph_add_symbols;
 use stack_graphs::c::sg_stack_graph_free;
+use stack_graphs::c::sg_stack_graph_get_or_create_nodes;
 use stack_graphs::c::sg_stack_graph_new;
 use stack_graphs::c::sg_symbol_handle;
 use stack_graphs::c::SG_JUMP_TO_NODE_HANDLE;
@@ -46,7 +46,7 @@ impl TestGraph {
     fn add_node(&mut self, node: sg_node) -> sg_node_handle {
         let nodes = [node];
         let mut handles: [sg_node_handle; 1] = [0; 1];
-        sg_stack_graph_add_nodes(
+        sg_stack_graph_get_or_create_nodes(
             self.graph,
             nodes.len(),
             nodes.as_ptr(),


### PR DESCRIPTION
The C API's function for adding nodes to a stack graph is now a “get or create” function.  If there's already a node in the stack graph with the same ID, we now return the handle of the existing node, instead of a null handle.  We've renamed the function to make it explicitly clear that there's a change of behavior.