### PR TITLE
Take control of C representation of None values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,5 @@ jobs:
         run: cargo test
       - name: Run test suite under valgrind
         run: cargo valgrind test
+      - name: Run test suite with all optimizations
+        run: cargo test --release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ edition = "2018"
 test = false
 
 [dependencies]
+controlled-option = "0.4"
 either = "1.6"
 fxhash = "0.2"
 libc = "0.2"

--- a/tests/it/c/files.rs
+++ b/tests/it/c/files.rs
@@ -5,6 +5,7 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+use controlled_option::ControlledOption;
 use libc::c_char;
 use stack_graphs::arena::Handle;
 use stack_graphs::c::sg_file_handle;
@@ -65,4 +66,14 @@ fn can_create_files() {
     assert_eq!(get_file(&file_arena, c), "c.py");
 
     sg_stack_graph_free(graph);
+}
+
+#[test]
+#[allow(unused_assignments)]
+fn verify_null_file_representation() {
+    let bytes = [0x55u8; std::mem::size_of::<Handle<File>>()];
+    let mut rust: ControlledOption<Handle<File>> = unsafe { std::mem::transmute(bytes) };
+    rust = ControlledOption::none();
+    let c: sg_file_handle = unsafe { std::mem::transmute(rust) };
+    assert_eq!(c, 0);
 }

--- a/tests/it/c/nodes.rs
+++ b/tests/it/c/nodes.rs
@@ -5,7 +5,9 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+use controlled_option::ControlledOption;
 use libc::c_char;
+use stack_graphs::arena::Handle;
 use stack_graphs::c::sg_file_handle;
 use stack_graphs::c::sg_node;
 use stack_graphs::c::sg_node_handle;
@@ -57,6 +59,19 @@ fn add_symbol(graph: *mut sg_stack_graph, symbol: &str) -> sg_symbol_handle {
     );
     assert!(handles[0] != 0);
     handles[0]
+}
+
+//-------------------------------------------------------------------------------------------------
+// Representation
+
+#[test]
+#[allow(unused_assignments)]
+fn verify_null_node_representation() {
+    let bytes = [0x55u8; std::mem::size_of::<Handle<Node>>()];
+    let mut rust: ControlledOption<Handle<Node>> = unsafe { std::mem::transmute(bytes) };
+    rust = ControlledOption::none();
+    let c: sg_node_handle = unsafe { std::mem::transmute(rust) };
+    assert_eq!(c, 0);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/tests/it/c/partial.rs
+++ b/tests/it/c/partial.rs
@@ -5,6 +5,7 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+use controlled_option::ControlledOption;
 use either::Either;
 use libc::c_char;
 use stack_graphs::c::sg_deque_direction;
@@ -37,6 +38,9 @@ use stack_graphs::c::sg_stack_graph_get_or_create_nodes;
 use stack_graphs::c::sg_stack_graph_new;
 use stack_graphs::c::sg_symbol_handle;
 use stack_graphs::c::SG_LIST_EMPTY_HANDLE;
+use stack_graphs::partial::PartialPathEdgeList;
+use stack_graphs::partial::PartialScopeStack;
+use stack_graphs::partial::PartialSymbolStack;
 
 fn add_file(graph: *mut sg_stack_graph, filename: &str) -> sg_file_handle {
     let lengths = [filename.len()];
@@ -209,6 +213,16 @@ fn can_create_partial_symbol_stacks() {
     sg_stack_graph_free(graph);
 }
 
+#[test]
+#[allow(unused_assignments)]
+fn verify_null_partial_symbol_stack_representation() {
+    let bytes = [0x55u8; std::mem::size_of::<PartialSymbolStack>()];
+    let mut rust: ControlledOption<PartialSymbolStack> = unsafe { std::mem::transmute(bytes) };
+    rust = ControlledOption::none();
+    let c: sg_partial_symbol_stack = unsafe { std::mem::transmute(rust) };
+    assert_eq!(c.cells, 0);
+}
+
 //-------------------------------------------------------------------------------------------------
 // Partial scope stacks
 
@@ -303,6 +317,16 @@ fn can_create_partial_scope_stacks() {
 
     sg_partial_path_arena_free(partials);
     sg_stack_graph_free(graph);
+}
+
+#[test]
+#[allow(unused_assignments)]
+fn verify_null_partial_scope_stack_representation() {
+    let bytes = [0x55u8; std::mem::size_of::<PartialScopeStack>()];
+    let mut rust: ControlledOption<PartialScopeStack> = unsafe { std::mem::transmute(bytes) };
+    rust = ControlledOption::none();
+    let c: sg_partial_scope_stack = unsafe { std::mem::transmute(rust) };
+    assert_eq!(c.cells, 0);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -401,4 +425,14 @@ fn can_create_partial_path_edge_lists() {
 
     sg_partial_path_arena_free(partials);
     sg_stack_graph_free(graph);
+}
+
+#[test]
+#[allow(unused_assignments)]
+fn verify_null_partial_path_edge_list_representation() {
+    let bytes = [0x55u8; std::mem::size_of::<PartialPathEdgeList>()];
+    let mut rust: ControlledOption<PartialPathEdgeList> = unsafe { std::mem::transmute(bytes) };
+    rust = ControlledOption::none();
+    let c: sg_partial_path_edge_list = unsafe { std::mem::transmute(rust) };
+    assert_eq!(c.cells, 0);
 }

--- a/tests/it/c/paths.rs
+++ b/tests/it/c/paths.rs
@@ -5,6 +5,7 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+use controlled_option::ControlledOption;
 use either::Either;
 use libc::c_char;
 use stack_graphs::c::sg_deque_direction;
@@ -37,6 +38,9 @@ use stack_graphs::c::sg_symbol_handle;
 use stack_graphs::c::sg_symbol_stack;
 use stack_graphs::c::sg_symbol_stack_cells;
 use stack_graphs::c::SG_LIST_EMPTY_HANDLE;
+use stack_graphs::paths::PathEdgeList;
+use stack_graphs::paths::ScopeStack;
+use stack_graphs::paths::SymbolStack;
 
 fn add_file(graph: *mut sg_stack_graph, filename: &str) -> sg_file_handle {
     let lengths = [filename.len()];
@@ -171,6 +175,16 @@ fn can_create_symbol_stacks() {
     sg_stack_graph_free(graph);
 }
 
+#[test]
+#[allow(unused_assignments)]
+fn verify_null_symbol_stack_representation() {
+    let bytes = [0x55u8; std::mem::size_of::<SymbolStack>()];
+    let mut rust: ControlledOption<SymbolStack> = unsafe { std::mem::transmute(bytes) };
+    rust = ControlledOption::none();
+    let c: sg_symbol_stack = unsafe { std::mem::transmute(rust) };
+    assert_eq!(c.cells, 0);
+}
+
 //-------------------------------------------------------------------------------------------------
 // Scope stacks
 
@@ -230,6 +244,16 @@ fn can_create_scope_stacks() {
 
     sg_path_arena_free(paths);
     sg_stack_graph_free(graph);
+}
+
+#[test]
+#[allow(unused_assignments)]
+fn verify_null_scope_stack_representation() {
+    let bytes = [0x55u8; std::mem::size_of::<ScopeStack>()];
+    let mut rust: ControlledOption<ScopeStack> = unsafe { std::mem::transmute(bytes) };
+    rust = ControlledOption::none();
+    let c: sg_scope_stack = unsafe { std::mem::transmute(rust) };
+    assert_eq!(c.cells, 0);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -328,4 +352,14 @@ fn can_create_path_edge_lists() {
 
     sg_path_arena_free(paths);
     sg_stack_graph_free(graph);
+}
+
+#[test]
+#[allow(unused_assignments)]
+fn verify_null_path_edge_list_representation() {
+    let bytes = [0x55u8; std::mem::size_of::<PathEdgeList>()];
+    let mut rust: ControlledOption<PathEdgeList> = unsafe { std::mem::transmute(bytes) };
+    rust = ControlledOption::none();
+    let c: sg_path_edge_list = unsafe { std::mem::transmute(rust) };
+    assert_eq!(c.cells, 0);
 }

--- a/tests/it/c/symbols.rs
+++ b/tests/it/c/symbols.rs
@@ -5,6 +5,7 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+use controlled_option::ControlledOption;
 use libc::c_char;
 use stack_graphs::arena::Handle;
 use stack_graphs::c::sg_stack_graph_add_symbols;
@@ -65,4 +66,14 @@ fn can_create_symbols() {
     assert_eq!(get_symbol(&symbol_arena, c), "c");
 
     sg_stack_graph_free(graph);
+}
+
+#[test]
+#[allow(unused_assignments)]
+fn verify_null_symbol_representation() {
+    let bytes = [0x55u8; std::mem::size_of::<Handle<Symbol>>()];
+    let mut rust: ControlledOption<Handle<Symbol>> = unsafe { std::mem::transmute(bytes) };
+    rust = ControlledOption::none();
+    let c: sg_symbol_handle = unsafe { std::mem::transmute(rust) };
+    assert_eq!(c, 0);
 }

--- a/tests/it/can_find_root_partial_paths_in_database.rs
+++ b/tests/it/can_find_root_partial_paths_in_database.rs
@@ -7,6 +7,7 @@
 
 use std::collections::HashSet;
 
+use controlled_option::ControlledOption;
 use stack_graphs::arena::Handle;
 use stack_graphs::graph::StackGraph;
 use stack_graphs::partial::PartialPath;
@@ -43,7 +44,7 @@ fn check_root_partial_paths(
         let symbol = graph.add_symbol(symbol);
         let scoped_symbol = ScopedSymbol {
             symbol,
-            scopes: None,
+            scopes: ControlledOption::none(),
         };
         symbol_stack.push_front(&mut paths, scoped_symbol);
     }

--- a/tests/it/paths.rs
+++ b/tests/it/paths.rs
@@ -5,6 +5,7 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+use controlled_option::ControlledOption;
 use itertools::Itertools;
 use stack_graphs::arena::Handle;
 use stack_graphs::graph::Edge;
@@ -36,21 +37,21 @@ fn can_iterate_symbol_stacks() {
         &mut paths,
         ScopedSymbol {
             symbol: sym_b,
-            scopes: Some(scope_stack),
+            scopes: ControlledOption::some(scope_stack),
         },
     );
     symbol_stack.push_front(
         &mut paths,
         ScopedSymbol {
             symbol: sym_dot,
-            scopes: None,
+            scopes: ControlledOption::none(),
         },
     );
     symbol_stack.push_front(
         &mut paths,
         ScopedSymbol {
             symbol: sym_a,
-            scopes: None,
+            scopes: ControlledOption::none(),
         },
     );
 


### PR DESCRIPTION
Our C API already includes comments describing how null values are stored for several types.  This patch adds test cases to verify that that's actually how we're storing them in memory.  In several cases (mostly involving attached scope lists), we weren't, because the Rust compiler was choosing a different field deep down inside the struct to sneak the None value into.  (In particular, anything with a `Deque` was using the value 2 for the deque's `direction` field, instead of the value 0 for its `list` field.)

Fixing the test cases required a new [`controlled-option` crate](https://docs.rs/controlled-option/*/), which uses a new `Niche` trait to take control over which "niche" value is used to represent a None value.  This lets us explicitly say, for instance, that null deques should use the 0 value of its `list` field.

After this patch, the rule of thumb is that any type that has a `#[repr(C)]` annotation must use `ControlledOption` instead of `Option` for any of its optional fields and nested subfields.