### PR TITLE
Ensure edge lists are available in both directions

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -810,6 +810,11 @@ impl<T> Deque<T> {
         }
     }
 
+    /// Returns whether we have already calculated the reversal of this deque.
+    pub fn have_reversal(&self, arena: &DequeArena<T>) -> bool {
+        self.list.have_reversal(arena)
+    }
+
     fn is_backwards(&self) -> bool {
         matches!(self.direction, DequeDirection::Backwards)
     }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -421,6 +421,12 @@ impl PathEdgeList {
         self.length
     }
 
+    /// Returns whether this edge list is iterable in both directions without needing mutable
+    /// access to the arena.
+    pub fn have_reversal(&self, paths: &Paths) -> bool {
+        self.edges.have_reversal(&paths.path_edges)
+    }
+
     /// Returns an empty edge list.
     pub fn empty() -> PathEdgeList {
         PathEdgeList {

--- a/src/stitching.rs
+++ b/src/stitching.rs
@@ -338,6 +338,13 @@ impl PathStitcher {
         self.next_iteration.as_slices().0
     }
 
+    /// Returns a mutable slice of all of the (possibly incomplete) paths that were encountered
+    /// during the most recent phase of the path-stitching algorithm.
+    pub fn previous_phase_paths_slice_mut(&mut self) -> &mut [Path] {
+        self.next_iteration.make_contiguous();
+        self.next_iteration.as_mut_slices().0
+    }
+
     /// Attempts to extend one path as part of the path-stitching algorithm.  When calling this
     /// function, you are responsible for ensuring that `db` already contains all of the possible
     /// partial paths that we might want to extend `path` with.

--- a/tests/it/c/can_jump_to_definition_with_partial_paths.rs
+++ b/tests/it/c/can_jump_to_definition_with_partial_paths.rs
@@ -163,6 +163,9 @@ fn check_jump_to_definition(graph: &TestGraph, file: &str, expected_paths: &[&st
         for path in paths_slice {
             eprintln!("--> {}", path.display(rust_graph, rust_paths));
 
+            // Verify that path's edge list is available in both directions.
+            assert!(path.edges.have_reversal(rust_paths));
+
             // If we found a complete path, add it to the result set.
             if path.is_complete(rust_graph) {
                 eprintln!("    COMPLETE");


### PR DESCRIPTION
The forward path stitcher returns a list of paths that have been encountered in the most recent phase.  In the C wrapper API, we need to ensure that the content of each paths' edge list is available in either direction, so that the C caller can iterate through them in either direction.