### PR TITLE
Add ‘copious-debugging’ feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,5 +47,7 @@ jobs:
         run: cargo test
       - name: Run test suite under valgrind
         run: cargo valgrind test
+      - name: Run test suite with copious debugging
+        run: cargo test --features copious-debugging
       - name: Run test suite with all optimizations
         run: cargo test --release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ authors = [
 ]
 edition = "2018"
 
+[features]
+copious-debugging = []
+
 [lib]
 # All of our tests are in the tests/it "integration" test executable.
 test = false

--- a/src/debugging.rs
+++ b/src/debugging.rs
@@ -1,0 +1,19 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+#[cfg(feature = "copious-debugging")]
+#[macro_export]
+macro_rules! copious_debugging {
+    ($($arg:tt)*) => {{ ::std::eprintln!($($arg)*); }}
+
+}
+
+#[cfg(not(feature = "copious-debugging"))]
+#[macro_export]
+macro_rules! copious_debugging {
+    ($($arg:tt)*) => {};
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,8 @@
 pub mod arena;
 pub mod c;
 pub mod cycles;
+#[macro_use]
+mod debugging;
 pub mod graph;
 pub mod partial;
 pub mod paths;

--- a/tests/it/can_find_node_partial_paths_in_database.rs
+++ b/tests/it/can_find_node_partial_paths_in_database.rs
@@ -37,7 +37,7 @@ fn check_node_partial_paths(
     });
 
     let mut results = Vec::<Handle<PartialPath>>::new();
-    database.find_candidate_partial_paths_from_node(node, &mut results);
+    database.find_candidate_partial_paths_from_node(graph, &mut partials, node, &mut results);
 
     let actual_partial_paths = results
         .into_iter()

--- a/tests/it/can_find_root_partial_paths_in_database.rs
+++ b/tests/it/can_find_root_partial_paths_in_database.rs
@@ -50,7 +50,13 @@ fn check_root_partial_paths(
     }
 
     let mut results = Vec::<Handle<PartialPath>>::new();
-    database.find_candidate_partial_paths_from_root(&mut paths, symbol_stack, &mut results);
+    database.find_candidate_partial_paths_from_root(
+        graph,
+        &mut paths,
+        &mut partials,
+        symbol_stack,
+        &mut results,
+    );
 
     let actual_partial_paths = results
         .into_iter()


### PR DESCRIPTION
We already had some nice debugging messages in one of the jump-to-def test cases.  This patch moves them into the library proper, gated behind a new `copious-debugging` feature flag.