### PR TITLE
Add explicit symbol stack variables 

### DIFF
--- a/include/stack-graphs.h
+++ b/include/stack-graphs.h
@@ -336,6 +336,9 @@ struct sg_partial_symbol_stack_cells {
     size_t count;
 };
 
+// Represents an unknown list of scoped symbols.
+typedef uint32_t sg_symbol_stack_variable;
+
 // A pattern that might match against a symbol stack.  Consists of a (possibly empty) list of
 // partial scoped symbols.
 //
@@ -349,6 +352,11 @@ struct sg_partial_symbol_stack {
     // list is empty, or 0 if the list is null.
     sg_partial_symbol_stack_cell_handle cells;
     enum sg_deque_direction direction;
+    // The symbol stack variable representing the unknown content of a partial symbol stack, or 0
+    // if the variable is missing.  (If so, this partial symbol stack can only match a symbol
+    // stack with exactly the list of symbols in `cells`, instead of any symbol stack with those
+    // symbols as a prefix.)
+    sg_symbol_stack_variable variable;
 };
 
 // An element of a partial scope stack.
@@ -669,7 +677,8 @@ struct sg_partial_symbol_stack_cells sg_partial_path_arena_partial_symbol_stack_
 // arrays.  The `lengths` array must have `count` elements, and provides the number of symbols in
 // each partial symbol stack.  The `symbols` array contains the contents of each of these partial
 // symbol stacks in one contiguous array.  Its length must be the sum of all of the counts in the
-// `lengths` array.
+// `lengths` array.  The `variables` array must have `count` elements, and provides the optional
+// symbol stack variable for each partial symbol stack.
 //
 // You must also provide an `out` array, which must also have room for `count` elements.  We will
 // fill this array in with the `sg_partial_symbol_stack` instances for each partial symbol stack
@@ -678,6 +687,7 @@ void sg_partial_path_arena_add_partial_symbol_stacks(struct sg_partial_path_aren
                                                      size_t count,
                                                      const struct sg_partial_scoped_symbol *symbols,
                                                      const size_t *lengths,
+                                                     const sg_symbol_stack_variable *variables,
                                                      struct sg_partial_symbol_stack *out);
 
 // Returns a reference to the array of partial scope stack content in a partial path arena.  The

--- a/tests/it/c/can_find_partial_paths_in_file.rs
+++ b/tests/it/c/can_find_partial_paths_in_file.rs
@@ -141,25 +141,25 @@ fn class_field_through_function_parameter() {
         "main.py",
         &[
             // definition of `__main__` module
-            "<__main__> ($1) [root] -> [main.py(0) definition __main__] <> ($1)",
+            "<__main__,%1> ($1) [root] -> [main.py(0) definition __main__] <%1> ($1)",
             // reference to `a` in import statement
-            "<> () [main.py(17) reference a] -> [root] <a> ()",
+            "<%1> () [main.py(17) reference a] -> [root] <a,%1> ()",
             // `from a import *` means we can rewrite any lookup of `__main__.*` → `a.*`
-            "<__main__.> ($1) [root] -> [root] <a.> ($1)",
+            "<__main__.,%1> ($1) [root] -> [root] <a.,%1> ($1)",
             // reference to `b` in import statement
-            "<> () [main.py(15) reference b] -> [root] <b> ()",
+            "<%1> () [main.py(15) reference b] -> [root] <b,%1> ()",
             // `from b import *` means we can rewrite any lookup of `__main__.*` → `b.*`
-            "<__main__.> ($1) [root] -> [root] <b.> ($1)",
+            "<__main__.,%1> ($1) [root] -> [root] <b.,%1> ($1)",
             // we can look for every reference in either `a` or `b`
-            "<> () [main.py(9) reference A] -> [root] <a.A> ()",
-            "<> () [main.py(9) reference A] -> [root] <b.A> ()",
-            "<> () [main.py(10) reference bar] -> [root] <a.foo()/[main.py(7)].bar> ()",
-            "<> () [main.py(10) reference bar] -> [root] <b.foo()/[main.py(7)].bar> ()",
-            "<> () [main.py(13) reference foo] -> [root] <a.foo> ()",
-            "<> () [main.py(13) reference foo] -> [root] <b.foo> ()",
+            "<%1> () [main.py(9) reference A] -> [root] <a.A,%1> ()",
+            "<%1> () [main.py(9) reference A] -> [root] <b.A,%1> ()",
+            "<%1> () [main.py(10) reference bar] -> [root] <a.foo()/[main.py(7)].bar,%1> ()",
+            "<%1> () [main.py(10) reference bar] -> [root] <b.foo()/[main.py(7)].bar,%1> ()",
+            "<%1> () [main.py(13) reference foo] -> [root] <a.foo,%1> ()",
+            "<%1> () [main.py(13) reference foo] -> [root] <b.foo,%1> ()",
             // parameter 0 of function call is `A`, which we can look up in either `a` or `b`
-            "<0> ($1) [main.py(7) exported scope] -> [root] <a.A> ($1)",
-            "<0> ($1) [main.py(7) exported scope] -> [root] <b.A> ($1)",
+            "<0,%1> ($1) [main.py(7) exported scope] -> [root] <a.A,%1> ($1)",
+            "<0,%1> ($1) [main.py(7) exported scope] -> [root] <b.A,%1> ($1)",
         ],
     );
     check_partial_paths_in_file(
@@ -167,17 +167,17 @@ fn class_field_through_function_parameter() {
         "a.py",
         &[
             // definition of `a` module
-            "<a> ($1) [root] -> [a.py(0) definition a] <> ($1)",
+            "<a,%1> ($1) [root] -> [a.py(0) definition a] <%1> ($1)",
             // definition of `foo` function
-            "<a.foo> ($1) [root] -> [a.py(5) definition foo] <> ($1)",
+            "<a.foo,%1> ($1) [root] -> [a.py(5) definition foo] <%1> ($1)",
             // reference to `x` in function body can resolve to formal parameter
-            "<> () [a.py(8) reference x] -> [a.py(14) definition x] <> ()",
+            "<%1> () [a.py(8) reference x] -> [a.py(14) definition x] <%1> ()",
             // result of function is `x`, which is passed in as a formal parameter...
-            "<a.foo()/$2> ($1) [root] -> [a.py(14) definition x] <> ()",
+            "<a.foo()/$2,%1> ($1) [root] -> [a.py(14) definition x] <%1> ()",
             // ...which we can look up either the 0th actual positional parameter...
-            "<a.foo()/$2> ($1) [root] -> [jump to scope] <0> ($2)",
+            "<a.foo()/$2,%1> ($1) [root] -> [jump to scope] <0,%1> ($2)",
             // ...or the actual named parameter `x`
-            "<a.foo()/$2> ($1) [root] -> [jump to scope] <x> ($2)",
+            "<a.foo()/$2,%1> ($1) [root] -> [jump to scope] <x,%1> ($2)",
         ],
     );
     check_partial_paths_in_file(
@@ -185,13 +185,13 @@ fn class_field_through_function_parameter() {
         "b.py",
         &[
             // definition of `b` module
-            "<b> ($1) [root] -> [b.py(0) definition b] <> ($1)",
+            "<b,%1> ($1) [root] -> [b.py(0) definition b] <%1> ($1)",
             // definition of class `A`
-            "<b.A> ($1) [root] -> [b.py(5) definition A] <> ($1)",
+            "<b.A,%1> ($1) [root] -> [b.py(5) definition A] <%1> ($1)",
             // definition of class member `A.bar`
-            "<b.A.bar> ($1) [root] -> [b.py(8) definition bar] <> ($1)",
+            "<b.A.bar,%1> ($1) [root] -> [b.py(8) definition bar] <%1> ($1)",
             // `bar` can also be accessed as an instance member
-            "<b.A()/$2.bar> ($1) [root] -> [b.py(8) definition bar] <> ($2)",
+            "<b.A()/$2.bar,%1> ($1) [root] -> [b.py(8) definition bar] <%1> ($2)",
         ],
     );
 }
@@ -204,13 +204,13 @@ fn cyclic_imports_python() {
         "main.py",
         &[
             // definition of `__main__` module
-            "<__main__> ($1) [root] -> [main.py(0) definition __main__] <> ($1)",
+            "<__main__,%1> ($1) [root] -> [main.py(0) definition __main__] <%1> ($1)",
             // reference to `a` in import statement
-            "<> () [main.py(8) reference a] -> [root] <a> ()",
+            "<%1> () [main.py(8) reference a] -> [root] <a,%1> ()",
             // `from a import *` means we can rewrite any lookup of `__main__.*` → `a.*`
-            "<__main__.> ($1) [root] -> [root] <a.> ($1)",
+            "<__main__.,%1> ($1) [root] -> [root] <a.,%1> ($1)",
             // reference to `foo` becomes `a.foo` because of import statement
-            "<> () [main.py(6) reference foo] -> [root] <a.foo> ()",
+            "<%1> () [main.py(6) reference foo] -> [root] <a.foo,%1> ()",
         ],
     );
     check_partial_paths_in_file(
@@ -218,11 +218,11 @@ fn cyclic_imports_python() {
         "a.py",
         &[
             // definition of `a` module
-            "<a> ($1) [root] -> [a.py(0) definition a] <> ($1)",
+            "<a,%1> ($1) [root] -> [a.py(0) definition a] <%1> ($1)",
             // reference to `b` in import statement
-            "<> () [a.py(6) reference b] -> [root] <b> ()",
+            "<%1> () [a.py(6) reference b] -> [root] <b,%1> ()",
             // `from b import *` means we can rewrite any lookup of `a.*` → `b.*`
-            "<a.> ($1) [root] -> [root] <b.> ($1)",
+            "<a.,%1> ($1) [root] -> [root] <b.,%1> ($1)",
         ],
     );
     check_partial_paths_in_file(
@@ -230,13 +230,13 @@ fn cyclic_imports_python() {
         "b.py",
         &[
             // definition of `b` module
-            "<b> ($1) [root] -> [b.py(0) definition b] <> ($1)",
+            "<b,%1> ($1) [root] -> [b.py(0) definition b] <%1> ($1)",
             // reference to `a` in import statement
-            "<> () [b.py(8) reference a] -> [root] <a> ()",
+            "<%1> () [b.py(8) reference a] -> [root] <a,%1> ()",
             // `from a import *` means we can rewrite any lookup of `b.*` → `a.*`
-            "<b.> ($1) [root] -> [root] <a.> ($1)",
+            "<b.,%1> ($1) [root] -> [root] <a.,%1> ($1)",
             // definition of `foo`
-            "<b.foo> ($1) [root] -> [b.py(6) definition foo] <> ($1)",
+            "<b.foo,%1> ($1) [root] -> [b.py(6) definition foo] <%1> ($1)",
         ],
     );
 }
@@ -251,16 +251,16 @@ fn cyclic_imports_rust() {
         // paths involving the root node.
         &[
             // reference to `a` in `main` function
-            "<> () [test.rs(103) reference a] -> [test.rs(201) definition a] <> ()",
+            "<%1> () [test.rs(103) reference a] -> [test.rs(201) definition a] <%1> ()",
             // reference to `a` in `b` function
-            "<> () [test.rs(307) reference a] -> [test.rs(201) definition a] <> ()",
+            "<%1> () [test.rs(307) reference a] -> [test.rs(201) definition a] <%1> ()",
             // reference to `b` in `a` function
-            "<> () [test.rs(206) reference b] -> [test.rs(301) definition b] <> ()",
+            "<%1> () [test.rs(206) reference b] -> [test.rs(301) definition b] <%1> ()",
             // reference to `FOO` in `main` can resolve either to `a::BAR` or `b::FOO`
-            "<> () [test.rs(101) reference FOO] -> [test.rs(204) definition BAR] <> ()",
-            "<> () [test.rs(101) reference FOO] -> [test.rs(304) definition FOO] <> ()",
+            "<%1> () [test.rs(101) reference FOO] -> [test.rs(204) definition BAR] <%1> ()",
+            "<%1> () [test.rs(101) reference FOO] -> [test.rs(304) definition FOO] <%1> ()",
             // reference to `BAR` in `b` resolves _only_ to `a::BAR`
-            "<> () [test.rs(305) reference BAR] -> [test.rs(204) definition BAR] <> ()",
+            "<%1> () [test.rs(305) reference BAR] -> [test.rs(204) definition BAR] <%1> ()",
         ],
     );
 }
@@ -273,13 +273,13 @@ fn sequenced_import_star() {
         "main.py",
         &[
             // definition of `__main__` module
-            "<__main__> ($1) [root] -> [main.py(0) definition __main__] <> ($1)",
+            "<__main__,%1> ($1) [root] -> [main.py(0) definition __main__] <%1> ($1)",
             // reference to `a` in import statement
-            "<> () [main.py(8) reference a] -> [root] <a> ()",
+            "<%1> () [main.py(8) reference a] -> [root] <a,%1> ()",
             // `from a import *` means we can rewrite any lookup of `__main__.*` → `a.*`
-            "<__main__.> ($1) [root] -> [root] <a.> ($1)",
+            "<__main__.,%1> ($1) [root] -> [root] <a.,%1> ($1)",
             // reference to `foo` becomes `a.foo` because of import statement
-            "<> () [main.py(6) reference foo] -> [root] <a.foo> ()",
+            "<%1> () [main.py(6) reference foo] -> [root] <a.foo,%1> ()",
         ],
     );
     check_partial_paths_in_file(
@@ -287,11 +287,11 @@ fn sequenced_import_star() {
         "a.py",
         &[
             // definition of `a` module
-            "<a> ($1) [root] -> [a.py(0) definition a] <> ($1)",
+            "<a,%1> ($1) [root] -> [a.py(0) definition a] <%1> ($1)",
             // reference to `b` in import statement
-            "<> () [a.py(6) reference b] -> [root] <b> ()",
+            "<%1> () [a.py(6) reference b] -> [root] <b,%1> ()",
             // `from b import *` means we can rewrite any lookup of `a.*` → `b.*`
-            "<a.> ($1) [root] -> [root] <b.> ($1)",
+            "<a.,%1> ($1) [root] -> [root] <b.,%1> ($1)",
         ],
     );
     check_partial_paths_in_file(
@@ -299,9 +299,9 @@ fn sequenced_import_star() {
         "b.py",
         &[
             // definition of `b` module
-            "<b> ($1) [root] -> [b.py(0) definition b] <> ($1)",
+            "<b,%1> ($1) [root] -> [b.py(0) definition b] <%1> ($1)",
             // definition of `foo` inside of `b` module
-            "<b.foo> ($1) [root] -> [b.py(5) definition foo] <> ($1)",
+            "<b.foo,%1> ($1) [root] -> [b.py(5) definition foo] <%1> ($1)",
         ],
     );
 }

--- a/tests/it/c/partial.rs
+++ b/tests/it/c/partial.rs
@@ -179,6 +179,7 @@ fn can_create_partial_symbol_stacks() {
         partial_scoped_symbol(b, empty_partial_scope_stack()),
     ];
     let lengths = [symbols0.len(), symbols1.len(), symbols2.len()];
+    let variables = [0, 0, 1];
     let mut symbolses = Vec::new();
     symbolses.extend_from_slice(&symbols0);
     symbolses.extend_from_slice(&symbols1);
@@ -189,6 +190,7 @@ fn can_create_partial_symbol_stacks() {
         lengths.len(),
         symbolses.as_slice().as_ptr(),
         lengths.as_ptr(),
+        variables.as_ptr(),
         stacks.as_mut_ptr(),
     );
 
@@ -197,6 +199,10 @@ fn can_create_partial_symbol_stacks() {
     assert!(partial_symbol_stack_contains(&cells, &stacks[0], &symbols0));
     assert!(partial_symbol_stack_contains(&cells, &stacks[1], &symbols1));
     assert!(partial_symbol_stack_contains(&cells, &stacks[2], &symbols2));
+
+    assert_eq!(stacks[0].variable, variables[0]);
+    assert_eq!(stacks[1].variable, variables[1]);
+    assert_eq!(stacks[2].variable, variables[2]);
 
     // Verify that each stack is available in both directions.
     assert!(partial_symbol_stack_available_in_both_directions(

--- a/tests/it/can_find_node_partial_paths_in_database.rs
+++ b/tests/it/can_find_node_partial_paths_in_database.rs
@@ -57,14 +57,14 @@ fn class_field_through_function_parameter() {
         &mut graph,
         ("main.py", 10),
         &[
-            "<> () [main.py(10) reference bar] -> [root] <a.foo()/[main.py(7)].bar> ()",
-            "<> () [main.py(10) reference bar] -> [root] <b.foo()/[main.py(7)].bar> ()",
+            "<%1> () [main.py(10) reference bar] -> [root] <a.foo()/[main.py(7)].bar,%1> ()",
+            "<%1> () [main.py(10) reference bar] -> [root] <b.foo()/[main.py(7)].bar,%1> ()",
         ],
     );
     check_node_partial_paths(
         &mut graph,
         ("a.py", 8),
-        &["<> () [a.py(8) reference x] -> [a.py(14) definition x] <> ()"],
+        &["<%1> () [a.py(8) reference x] -> [a.py(14) definition x] <%1> ()"],
     );
     // no references in b.py
 }
@@ -75,17 +75,17 @@ fn cyclic_imports_python() {
     check_node_partial_paths(
         &mut graph,
         ("main.py", 6),
-        &["<> () [main.py(6) reference foo] -> [root] <a.foo> ()"],
+        &["<%1> () [main.py(6) reference foo] -> [root] <a.foo,%1> ()"],
     );
     check_node_partial_paths(
         &mut graph,
         ("a.py", 6),
-        &["<> () [a.py(6) reference b] -> [root] <b> ()"],
+        &["<%1> () [a.py(6) reference b] -> [root] <b,%1> ()"],
     );
     check_node_partial_paths(
         &mut graph,
         ("b.py", 8),
-        &["<> () [b.py(8) reference a] -> [root] <a> ()"],
+        &["<%1> () [b.py(8) reference a] -> [root] <a,%1> ()"],
     );
 }
 
@@ -96,14 +96,14 @@ fn cyclic_imports_rust() {
         &mut graph,
         ("test.rs", 101),
         &[
-            "<> () [test.rs(101) reference FOO] -> [test.rs(204) definition BAR] <> ()",
-            "<> () [test.rs(101) reference FOO] -> [test.rs(304) definition FOO] <> ()",
+            "<%1> () [test.rs(101) reference FOO] -> [test.rs(204) definition BAR] <%1> ()",
+            "<%1> () [test.rs(101) reference FOO] -> [test.rs(304) definition FOO] <%1> ()",
         ],
     );
     check_node_partial_paths(
         &mut graph,
         ("test.rs", 305),
-        &["<> () [test.rs(305) reference BAR] -> [test.rs(204) definition BAR] <> ()"],
+        &["<%1> () [test.rs(305) reference BAR] -> [test.rs(204) definition BAR] <%1> ()"],
     );
 }
 
@@ -113,12 +113,12 @@ fn sequenced_import_star() {
     check_node_partial_paths(
         &mut graph,
         ("main.py", 6),
-        &["<> () [main.py(6) reference foo] -> [root] <a.foo> ()"],
+        &["<%1> () [main.py(6) reference foo] -> [root] <a.foo,%1> ()"],
     );
     check_node_partial_paths(
         &mut graph,
         ("a.py", 6),
-        &["<> () [a.py(6) reference b] -> [root] <b> ()"],
+        &["<%1> () [a.py(6) reference b] -> [root] <b,%1> ()"],
     );
     // no references in b.py
 }

--- a/tests/it/can_find_partial_paths_in_file.rs
+++ b/tests/it/can_find_partial_paths_in_file.rs
@@ -40,25 +40,25 @@ fn class_field_through_function_parameter() {
         "main.py",
         &[
             // definition of `__main__` module
-            "<__main__> ($1) [root] -> [main.py(0) definition __main__] <> ($1)",
+            "<__main__,%1> ($1) [root] -> [main.py(0) definition __main__] <%1> ($1)",
             // reference to `a` in import statement
-            "<> () [main.py(17) reference a] -> [root] <a> ()",
+            "<%1> () [main.py(17) reference a] -> [root] <a,%1> ()",
             // `from a import *` means we can rewrite any lookup of `__main__.*` → `a.*`
-            "<__main__.> ($1) [root] -> [root] <a.> ($1)",
+            "<__main__.,%1> ($1) [root] -> [root] <a.,%1> ($1)",
             // reference to `b` in import statement
-            "<> () [main.py(15) reference b] -> [root] <b> ()",
+            "<%1> () [main.py(15) reference b] -> [root] <b,%1> ()",
             // `from b import *` means we can rewrite any lookup of `__main__.*` → `b.*`
-            "<__main__.> ($1) [root] -> [root] <b.> ($1)",
+            "<__main__.,%1> ($1) [root] -> [root] <b.,%1> ($1)",
             // we can look for every reference in either `a` or `b`
-            "<> () [main.py(9) reference A] -> [root] <a.A> ()",
-            "<> () [main.py(9) reference A] -> [root] <b.A> ()",
-            "<> () [main.py(10) reference bar] -> [root] <a.foo()/[main.py(7)].bar> ()",
-            "<> () [main.py(10) reference bar] -> [root] <b.foo()/[main.py(7)].bar> ()",
-            "<> () [main.py(13) reference foo] -> [root] <a.foo> ()",
-            "<> () [main.py(13) reference foo] -> [root] <b.foo> ()",
+            "<%1> () [main.py(9) reference A] -> [root] <a.A,%1> ()",
+            "<%1> () [main.py(9) reference A] -> [root] <b.A,%1> ()",
+            "<%1> () [main.py(10) reference bar] -> [root] <a.foo()/[main.py(7)].bar,%1> ()",
+            "<%1> () [main.py(10) reference bar] -> [root] <b.foo()/[main.py(7)].bar,%1> ()",
+            "<%1> () [main.py(13) reference foo] -> [root] <a.foo,%1> ()",
+            "<%1> () [main.py(13) reference foo] -> [root] <b.foo,%1> ()",
             // parameter 0 of function call is `A`, which we can look up in either `a` or `b`
-            "<0> ($1) [main.py(7) exported scope] -> [root] <a.A> ($1)",
-            "<0> ($1) [main.py(7) exported scope] -> [root] <b.A> ($1)",
+            "<0,%1> ($1) [main.py(7) exported scope] -> [root] <a.A,%1> ($1)",
+            "<0,%1> ($1) [main.py(7) exported scope] -> [root] <b.A,%1> ($1)",
         ],
     );
     check_partial_paths_in_file(
@@ -66,17 +66,17 @@ fn class_field_through_function_parameter() {
         "a.py",
         &[
             // definition of `a` module
-            "<a> ($1) [root] -> [a.py(0) definition a] <> ($1)",
+            "<a,%1> ($1) [root] -> [a.py(0) definition a] <%1> ($1)",
             // definition of `foo` function
-            "<a.foo> ($1) [root] -> [a.py(5) definition foo] <> ($1)",
+            "<a.foo,%1> ($1) [root] -> [a.py(5) definition foo] <%1> ($1)",
             // reference to `x` in function body can resolve to formal parameter
-            "<> () [a.py(8) reference x] -> [a.py(14) definition x] <> ()",
+            "<%1> () [a.py(8) reference x] -> [a.py(14) definition x] <%1> ()",
             // result of function is `x`, which is passed in as a formal parameter...
-            "<a.foo()/$2> ($1) [root] -> [a.py(14) definition x] <> ()",
+            "<a.foo()/$2,%1> ($1) [root] -> [a.py(14) definition x] <%1> ()",
             // ...which we can look up either the 0th actual positional parameter...
-            "<a.foo()/$2> ($1) [root] -> [jump to scope] <0> ($2)",
+            "<a.foo()/$2,%1> ($1) [root] -> [jump to scope] <0,%1> ($2)",
             // ...or the actual named parameter `x`
-            "<a.foo()/$2> ($1) [root] -> [jump to scope] <x> ($2)",
+            "<a.foo()/$2,%1> ($1) [root] -> [jump to scope] <x,%1> ($2)",
         ],
     );
     check_partial_paths_in_file(
@@ -84,13 +84,13 @@ fn class_field_through_function_parameter() {
         "b.py",
         &[
             // definition of `b` module
-            "<b> ($1) [root] -> [b.py(0) definition b] <> ($1)",
+            "<b,%1> ($1) [root] -> [b.py(0) definition b] <%1> ($1)",
             // definition of class `A`
-            "<b.A> ($1) [root] -> [b.py(5) definition A] <> ($1)",
+            "<b.A,%1> ($1) [root] -> [b.py(5) definition A] <%1> ($1)",
             // definition of class member `A.bar`
-            "<b.A.bar> ($1) [root] -> [b.py(8) definition bar] <> ($1)",
+            "<b.A.bar,%1> ($1) [root] -> [b.py(8) definition bar] <%1> ($1)",
             // `bar` can also be accessed as an instance member
-            "<b.A()/$2.bar> ($1) [root] -> [b.py(8) definition bar] <> ($2)",
+            "<b.A()/$2.bar,%1> ($1) [root] -> [b.py(8) definition bar] <%1> ($2)",
         ],
     );
 }
@@ -103,13 +103,13 @@ fn cyclic_imports_python() {
         "main.py",
         &[
             // definition of `__main__` module
-            "<__main__> ($1) [root] -> [main.py(0) definition __main__] <> ($1)",
+            "<__main__,%1> ($1) [root] -> [main.py(0) definition __main__] <%1> ($1)",
             // reference to `a` in import statement
-            "<> () [main.py(8) reference a] -> [root] <a> ()",
+            "<%1> () [main.py(8) reference a] -> [root] <a,%1> ()",
             // `from a import *` means we can rewrite any lookup of `__main__.*` → `a.*`
-            "<__main__.> ($1) [root] -> [root] <a.> ($1)",
+            "<__main__.,%1> ($1) [root] -> [root] <a.,%1> ($1)",
             // reference to `foo` becomes `a.foo` because of import statement
-            "<> () [main.py(6) reference foo] -> [root] <a.foo> ()",
+            "<%1> () [main.py(6) reference foo] -> [root] <a.foo,%1> ()",
         ],
     );
     check_partial_paths_in_file(
@@ -117,11 +117,11 @@ fn cyclic_imports_python() {
         "a.py",
         &[
             // definition of `a` module
-            "<a> ($1) [root] -> [a.py(0) definition a] <> ($1)",
+            "<a,%1> ($1) [root] -> [a.py(0) definition a] <%1> ($1)",
             // reference to `b` in import statement
-            "<> () [a.py(6) reference b] -> [root] <b> ()",
+            "<%1> () [a.py(6) reference b] -> [root] <b,%1> ()",
             // `from b import *` means we can rewrite any lookup of `a.*` → `b.*`
-            "<a.> ($1) [root] -> [root] <b.> ($1)",
+            "<a.,%1> ($1) [root] -> [root] <b.,%1> ($1)",
         ],
     );
     check_partial_paths_in_file(
@@ -129,13 +129,13 @@ fn cyclic_imports_python() {
         "b.py",
         &[
             // definition of `b` module
-            "<b> ($1) [root] -> [b.py(0) definition b] <> ($1)",
+            "<b,%1> ($1) [root] -> [b.py(0) definition b] <%1> ($1)",
             // reference to `a` in import statement
-            "<> () [b.py(8) reference a] -> [root] <a> ()",
+            "<%1> () [b.py(8) reference a] -> [root] <a,%1> ()",
             // `from a import *` means we can rewrite any lookup of `b.*` → `a.*`
-            "<b.> ($1) [root] -> [root] <a.> ($1)",
+            "<b.,%1> ($1) [root] -> [root] <a.,%1> ($1)",
             // definition of `foo`
-            "<b.foo> ($1) [root] -> [b.py(6) definition foo] <> ($1)",
+            "<b.foo,%1> ($1) [root] -> [b.py(6) definition foo] <%1> ($1)",
         ],
     );
 }
@@ -150,16 +150,16 @@ fn cyclic_imports_rust() {
         // paths involving the root node.
         &[
             // reference to `a` in `main` function
-            "<> () [test.rs(103) reference a] -> [test.rs(201) definition a] <> ()",
+            "<%1> () [test.rs(103) reference a] -> [test.rs(201) definition a] <%1> ()",
             // reference to `a` in `b` function
-            "<> () [test.rs(307) reference a] -> [test.rs(201) definition a] <> ()",
+            "<%1> () [test.rs(307) reference a] -> [test.rs(201) definition a] <%1> ()",
             // reference to `b` in `a` function
-            "<> () [test.rs(206) reference b] -> [test.rs(301) definition b] <> ()",
+            "<%1> () [test.rs(206) reference b] -> [test.rs(301) definition b] <%1> ()",
             // reference to `FOO` in `main` can resolve either to `a::BAR` or `b::FOO`
-            "<> () [test.rs(101) reference FOO] -> [test.rs(204) definition BAR] <> ()",
-            "<> () [test.rs(101) reference FOO] -> [test.rs(304) definition FOO] <> ()",
+            "<%1> () [test.rs(101) reference FOO] -> [test.rs(204) definition BAR] <%1> ()",
+            "<%1> () [test.rs(101) reference FOO] -> [test.rs(304) definition FOO] <%1> ()",
             // reference to `BAR` in `b` resolves _only_ to `a::BAR`
-            "<> () [test.rs(305) reference BAR] -> [test.rs(204) definition BAR] <> ()",
+            "<%1> () [test.rs(305) reference BAR] -> [test.rs(204) definition BAR] <%1> ()",
         ],
     );
 }
@@ -172,13 +172,13 @@ fn sequenced_import_star() {
         "main.py",
         &[
             // definition of `__main__` module
-            "<__main__> ($1) [root] -> [main.py(0) definition __main__] <> ($1)",
+            "<__main__,%1> ($1) [root] -> [main.py(0) definition __main__] <%1> ($1)",
             // reference to `a` in import statement
-            "<> () [main.py(8) reference a] -> [root] <a> ()",
+            "<%1> () [main.py(8) reference a] -> [root] <a,%1> ()",
             // `from a import *` means we can rewrite any lookup of `__main__.*` → `a.*`
-            "<__main__.> ($1) [root] -> [root] <a.> ($1)",
+            "<__main__.,%1> ($1) [root] -> [root] <a.,%1> ($1)",
             // reference to `foo` becomes `a.foo` because of import statement
-            "<> () [main.py(6) reference foo] -> [root] <a.foo> ()",
+            "<%1> () [main.py(6) reference foo] -> [root] <a.foo,%1> ()",
         ],
     );
     check_partial_paths_in_file(
@@ -186,11 +186,11 @@ fn sequenced_import_star() {
         "a.py",
         &[
             // definition of `a` module
-            "<a> ($1) [root] -> [a.py(0) definition a] <> ($1)",
+            "<a,%1> ($1) [root] -> [a.py(0) definition a] <%1> ($1)",
             // reference to `b` in import statement
-            "<> () [a.py(6) reference b] -> [root] <b> ()",
+            "<%1> () [a.py(6) reference b] -> [root] <b,%1> ()",
             // `from b import *` means we can rewrite any lookup of `a.*` → `b.*`
-            "<a.> ($1) [root] -> [root] <b.> ($1)",
+            "<a.,%1> ($1) [root] -> [root] <b.,%1> ($1)",
         ],
     );
     check_partial_paths_in_file(
@@ -198,9 +198,9 @@ fn sequenced_import_star() {
         "b.py",
         &[
             // definition of `b` module
-            "<b> ($1) [root] -> [b.py(0) definition b] <> ($1)",
+            "<b,%1> ($1) [root] -> [b.py(0) definition b] <%1> ($1)",
             // definition of `foo` inside of `b` module
-            "<b.foo> ($1) [root] -> [b.py(5) definition foo] <> ($1)",
+            "<b.foo,%1> ($1) [root] -> [b.py(5) definition foo] <%1> ($1)",
         ],
     );
 }

--- a/tests/it/can_find_root_partial_paths_in_database.rs
+++ b/tests/it/can_find_root_partial_paths_in_database.rs
@@ -77,22 +77,22 @@ fn class_field_through_function_parameter() {
         "main.py",
         &["__main__", ".", "baz"],
         &[
-            "<__main__.> ($1) [root] -> [root] <a.> ($1)",
-            "<__main__.> ($1) [root] -> [root] <b.> ($1)",
-            "<__main__> ($1) [root] -> [main.py(0) definition __main__] <> ($1)",
+            "<__main__.,%1> ($1) [root] -> [root] <a.,%1> ($1)",
+            "<__main__.,%1> ($1) [root] -> [root] <b.,%1> ($1)",
+            "<__main__,%1> ($1) [root] -> [main.py(0) definition __main__] <%1> ($1)",
         ],
     );
     check_root_partial_paths(
         &mut graph,
         "a.py",
         &["a", ".", "baz"],
-        &["<a> ($1) [root] -> [a.py(0) definition a] <> ($1)"],
+        &["<a,%1> ($1) [root] -> [a.py(0) definition a] <%1> ($1)"],
     );
     check_root_partial_paths(
         &mut graph,
         "b.py",
         &["b", ".", "baz"],
-        &["<b> ($1) [root] -> [b.py(0) definition b] <> ($1)"],
+        &["<b,%1> ($1) [root] -> [b.py(0) definition b] <%1> ($1)"],
     );
 }
 
@@ -104,8 +104,8 @@ fn cyclic_imports_python() {
         "main.py",
         &["__main__", ".", "baz"],
         &[
-            "<__main__> ($1) [root] -> [main.py(0) definition __main__] <> ($1)",
-            "<__main__.> ($1) [root] -> [root] <a.> ($1)",
+            "<__main__,%1> ($1) [root] -> [main.py(0) definition __main__] <%1> ($1)",
+            "<__main__.,%1> ($1) [root] -> [root] <a.,%1> ($1)",
         ],
     );
     check_root_partial_paths(
@@ -113,8 +113,8 @@ fn cyclic_imports_python() {
         "a.py",
         &["a", ".", "baz"],
         &[
-            "<a> ($1) [root] -> [a.py(0) definition a] <> ($1)",
-            "<a.> ($1) [root] -> [root] <b.> ($1)",
+            "<a,%1> ($1) [root] -> [a.py(0) definition a] <%1> ($1)",
+            "<a.,%1> ($1) [root] -> [root] <b.,%1> ($1)",
         ],
     );
     check_root_partial_paths(
@@ -122,8 +122,8 @@ fn cyclic_imports_python() {
         "b.py",
         &["b", ".", "baz"],
         &[
-            "<b> ($1) [root] -> [b.py(0) definition b] <> ($1)",
-            "<b.> ($1) [root] -> [root] <a.> ($1)",
+            "<b,%1> ($1) [root] -> [b.py(0) definition b] <%1> ($1)",
+            "<b.,%1> ($1) [root] -> [root] <a.,%1> ($1)",
         ],
     );
 }
@@ -149,8 +149,8 @@ fn sequenced_import_star() {
         "main.py",
         &["__main__", ".", "baz"],
         &[
-            "<__main__> ($1) [root] -> [main.py(0) definition __main__] <> ($1)",
-            "<__main__.> ($1) [root] -> [root] <a.> ($1)",
+            "<__main__,%1> ($1) [root] -> [main.py(0) definition __main__] <%1> ($1)",
+            "<__main__.,%1> ($1) [root] -> [root] <a.,%1> ($1)",
         ],
     );
     check_root_partial_paths(
@@ -158,14 +158,14 @@ fn sequenced_import_star() {
         "a.py",
         &["a", ".", "baz"],
         &[
-            "<a> ($1) [root] -> [a.py(0) definition a] <> ($1)",
-            "<a.> ($1) [root] -> [root] <b.> ($1)",
+            "<a,%1> ($1) [root] -> [a.py(0) definition a] <%1> ($1)",
+            "<a.,%1> ($1) [root] -> [root] <b.,%1> ($1)",
         ],
     );
     check_root_partial_paths(
         &mut graph,
         "b.py",
         &["b", ".", "baz"],
-        &["<b> ($1) [root] -> [b.py(0) definition b] <> ($1)"],
+        &["<b,%1> ($1) [root] -> [b.py(0) definition b] <%1> ($1)"],
     );
 }


### PR DESCRIPTION
We had several comments that talked about how we used an “implicit” symbol stack variable in our partial symbol stacks.  As we move towards a path-stitching algorithm that operates entirely on partial stacks, it's more important to have consistency between the implementations of the two stacks.  So this patch adds in symbol stack variables as a first-class type in the data model.