### PR TITLE
Add function for unifying partial symbol stacks 

### DIFF
--- a/src/partial.rs
+++ b/src/partial.rs
@@ -377,6 +377,28 @@ impl PartialScopedSymbol {
         Ok(())
     }
 
+    /// Matches this precondition symbol against another, unifying its contents with an existing
+    /// set of bindings.
+    pub fn unify(
+        &mut self,
+        partials: &mut PartialPaths,
+        rhs: PartialScopedSymbol,
+        scope_bindings: &mut PartialScopeStackBindings,
+    ) -> Result<(), PathResolutionError> {
+        if self.symbol != rhs.symbol {
+            return Err(PathResolutionError::SymbolStackUnsatisfied);
+        }
+        match (self.scopes.into_option(), rhs.scopes.into_option()) {
+            (Some(lhs), Some(rhs)) => {
+                let unified = lhs.unify(partials, rhs, scope_bindings)?;
+                self.scopes = ControlledOption::some(unified);
+            }
+            (None, None) => {}
+            _ => return Err(PathResolutionError::SymbolStackUnsatisfied),
+        }
+        Ok(())
+    }
+
     /// Returns whether two partial scoped symbols "match".  The symbols must be identical, and any
     /// attached scopes must also match.
     pub fn matches(self, partials: &mut PartialPaths, postcondition: PartialScopedSymbol) -> bool {
@@ -524,6 +546,12 @@ impl PartialSymbolStack {
         }
     }
 
+    fn prepend(&mut self, partials: &mut PartialPaths, mut head: Deque<PartialScopedSymbol>) {
+        while let Some(head) = head.pop_back(&mut partials.partial_symbol_stacks).copied() {
+            self.push_front(partials, head);
+        }
+    }
+
     /// Pushes a new [`PartialScopedSymbol`][] onto the front of this partial symbol stack.
     pub fn push_front(&mut self, partials: &mut PartialPaths, symbol: PartialScopedSymbol) {
         self.symbols
@@ -629,6 +657,130 @@ impl PartialSymbolStack {
             result.push_front(paths, symbol);
         }
         Ok(result)
+    }
+
+    /// Given two partial symbol stacks, returns the largest possible partial symbol stack such that
+    /// any symbol stack that satisfies the result also satisfies both inputs.  This takes into
+    /// account any existing variable assignments, and updates those variable assignments with
+    /// whatever constraints are necessary to produce a correct result.
+    ///
+    /// Note that this operation is commutative.  (Concatenating partial paths, defined in
+    /// [`PartialPath::concatenate`][], is not.)
+    pub fn unify(
+        self,
+        partials: &mut PartialPaths,
+        mut rhs: PartialSymbolStack,
+        symbol_bindings: &mut PartialSymbolStackBindings,
+        scope_bindings: &mut PartialScopeStackBindings,
+    ) -> Result<PartialSymbolStack, PathResolutionError> {
+        let mut lhs = self;
+
+        // First, look at the shortest common prefix of lhs and rhs, and verify that they match.
+        let mut head = Deque::empty();
+        while lhs.contains_symbols() && rhs.contains_symbols() {
+            let mut lhs_front = lhs.pop_front(partials).unwrap();
+            let rhs_front = rhs.pop_front(partials).unwrap();
+            lhs_front.unify(partials, rhs_front, scope_bindings)?;
+            head.push_back(&mut partials.partial_symbol_stacks, lhs_front);
+        }
+
+        // Now at most one stack still has symbols.  Zero, one, or both of them have variables.
+        // Let's do a case analysis on all of those possibilities.
+
+        // CASE 1:
+        // Both lhs and rhs have no more symbols.  The answer is always yes, and any variables that
+        // are present get bound.  (If both sides have variables, then one variable gets bound to
+        // the other, since both lhs and rhs will match _any other symbol stack_ at this point.  If
+        // only one side has a variable, then the variable gets bound to the empty stack.)
+        //
+        //     lhs           rhs
+        // ============  ============
+        //  ()            ()            => yes either
+        //  ()            () $2         => yes rhs, $2 => ()
+        //  () $1         ()            => yes lhs, $1 => ()
+        //  () $1         () $2         => yes lhs, $2 => $1
+        if !lhs.contains_symbols() && !rhs.contains_symbols() {
+            match (lhs.variable.into_option(), rhs.variable.into_option()) {
+                (None, None) => {
+                    lhs.prepend(partials, head);
+                    return Ok(lhs);
+                }
+                (None, Some(var)) => {
+                    symbol_bindings.add(
+                        partials,
+                        var,
+                        PartialSymbolStack::empty(),
+                        scope_bindings,
+                    )?;
+                    rhs.prepend(partials, head);
+                    return Ok(rhs);
+                }
+                (Some(var), None) => {
+                    symbol_bindings.add(
+                        partials,
+                        var,
+                        PartialSymbolStack::empty(),
+                        scope_bindings,
+                    )?;
+                    lhs.prepend(partials, head);
+                    return Ok(lhs);
+                }
+                (Some(lhs_var), Some(rhs_var)) => {
+                    symbol_bindings.add(
+                        partials,
+                        rhs_var,
+                        PartialSymbolStack::from_variable(lhs_var),
+                        scope_bindings,
+                    )?;
+                    lhs.prepend(partials, head);
+                    return Ok(lhs);
+                }
+            }
+        }
+
+        // CASE 2:
+        // One of the stacks contains symbols and the other doesn't, and the “empty” stack doesn't
+        // have a variable.  Since there's no variable on the empty side to capture the remaining
+        // content on the non-empty side, the answer is always no.
+        //
+        //     lhs           rhs
+        // ============  ============
+        //  ()            (stuff)       => NO
+        //  ()            (stuff) $2    => NO
+        //  (stuff)       ()            => NO
+        //  (stuff) $1    ()            => NO
+        if !lhs.contains_symbols() && lhs.variable.is_none() {
+            return Err(PathResolutionError::SymbolStackUnsatisfied);
+        }
+        if !rhs.contains_symbols() && rhs.variable.is_none() {
+            return Err(PathResolutionError::SymbolStackUnsatisfied);
+        }
+
+        // CASE 3:
+        // One of the stacks contains symbols and the other doesn't, and the “empty” stack _does_
+        // have a variable.  That means the answer is YES, and the “empty” side's variable needs to
+        // capture the entirety of the non-empty side.
+        //
+        //     lhs           rhs
+        // ============  ============
+        //  () $1         (stuff)       => yes rhs,  $1 => rhs
+        //  () $1         (stuff) $2    => yes rhs,  $1 => rhs
+        //  (stuff)       () $2         => yes lhs,  $2 => lhs
+        //  (stuff) $1    () $2         => yes lhs,  $2 => lhs
+        if lhs.contains_symbols() {
+            let rhs_variable = rhs.variable.into_option().unwrap();
+            symbol_bindings.add(partials, rhs_variable, lhs, scope_bindings)?;
+            lhs.prepend(partials, head);
+            return Ok(lhs);
+        }
+        if rhs.contains_symbols() {
+            let lhs_variable = lhs.variable.into_option().unwrap();
+            symbol_bindings.add(partials, lhs_variable, rhs, scope_bindings)?;
+            rhs.prepend(partials, head);
+            return Ok(rhs);
+        }
+
+        unreachable!();
     }
 
     pub fn equals(mut self, partials: &mut PartialPaths, mut other: PartialSymbolStack) -> bool {
@@ -1111,18 +1263,64 @@ impl PartialSymbolStackBindings {
     /// matched.  Returns an error if you try to bind a particular variable more than once.
     pub fn add(
         &mut self,
+        partials: &mut PartialPaths,
         variable: SymbolStackVariable,
-        symbols: PartialSymbolStack,
+        mut symbols: PartialSymbolStack,
+        scope_bindings: &mut PartialScopeStackBindings,
     ) -> Result<(), PathResolutionError> {
         let index = variable.as_usize();
         if self.bindings.len() < index {
             self.bindings.resize_with(index, || None);
         }
-        if self.bindings[index - 1].is_some() {
-            return Err(PathResolutionError::IncompatibleSymbolStackVariables);
+        if let Some(old_binding) = self.bindings[index - 1] {
+            symbols = symbols.unify(partials, old_binding, self, scope_bindings)?;
         }
         self.bindings[index - 1] = Some(symbols);
         Ok(())
+    }
+
+    pub fn display<'a>(
+        &'a mut self,
+        graph: &'a StackGraph,
+        partials: &'a mut PartialPaths,
+    ) -> impl Display + 'a {
+        display_with(self, graph, partials)
+    }
+}
+
+impl<'a> DisplayWithPartialPaths for &'a mut PartialSymbolStackBindings {
+    fn prepare(&mut self, graph: &StackGraph, partials: &mut PartialPaths) {
+        for binding in &mut self.bindings {
+            if let Some(binding) = binding.as_mut() {
+                binding.prepare(graph, partials);
+            }
+        }
+    }
+
+    fn display_with(
+        &self,
+        graph: &StackGraph,
+        partials: &PartialPaths,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        write!(f, "{{")?;
+        let mut first = true;
+        for (idx, binding) in self.bindings.iter().enumerate() {
+            if let Some(binding) = binding.as_ref() {
+                if first {
+                    first = false;
+                } else {
+                    write!(f, ", ")?;
+                }
+                write!(
+                    f,
+                    "%{} => <{}>",
+                    idx + 1,
+                    display_prepared(*binding, graph, partials)
+                )?;
+            }
+        }
+        write!(f, "}}")
     }
 }
 

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -469,7 +469,7 @@ impl DisplayWithPartialPaths for PartialScopedSymbol {
         if let Some(scopes) = self.scopes.into_option() {
             write!(
                 f,
-                "{}/{}",
+                "{}/({})",
                 self.symbol.display(graph),
                 display_prepared(scopes, graph, partials)
             )

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -181,7 +181,7 @@ impl DisplayWithPaths for ScopedSymbol {
         match self.scopes.into_option() {
             Some(scopes) => write!(
                 f,
-                "{}/{}",
+                "{}/({})",
                 self.symbol.display(graph),
                 display_prepared(scopes, graph, paths),
             ),

--- a/tests/it/c/can_find_partial_paths_in_file.rs
+++ b/tests/it/c/can_find_partial_paths_in_file.rs
@@ -153,8 +153,8 @@ fn class_field_through_function_parameter() {
             // we can look for every reference in either `a` or `b`
             "<%1> () [main.py(9) reference A] -> [root] <a.A,%1> ()",
             "<%1> () [main.py(9) reference A] -> [root] <b.A,%1> ()",
-            "<%1> () [main.py(10) reference bar] -> [root] <a.foo()/[main.py(7)].bar,%1> ()",
-            "<%1> () [main.py(10) reference bar] -> [root] <b.foo()/[main.py(7)].bar,%1> ()",
+            "<%1> () [main.py(10) reference bar] -> [root] <a.foo()/([main.py(7)]).bar,%1> ()",
+            "<%1> () [main.py(10) reference bar] -> [root] <b.foo()/([main.py(7)]).bar,%1> ()",
             "<%1> () [main.py(13) reference foo] -> [root] <a.foo,%1> ()",
             "<%1> () [main.py(13) reference foo] -> [root] <b.foo,%1> ()",
             // parameter 0 of function call is `A`, which we can look up in either `a` or `b`
@@ -173,11 +173,11 @@ fn class_field_through_function_parameter() {
             // reference to `x` in function body can resolve to formal parameter
             "<%1> () [a.py(8) reference x] -> [a.py(14) definition x] <%1> ()",
             // result of function is `x`, which is passed in as a formal parameter...
-            "<a.foo()/$2,%1> ($1) [root] -> [a.py(14) definition x] <%1> ()",
+            "<a.foo()/($2),%1> ($1) [root] -> [a.py(14) definition x] <%1> ()",
             // ...which we can look up either the 0th actual positional parameter...
-            "<a.foo()/$2,%1> ($1) [root] -> [jump to scope] <0,%1> ($2)",
+            "<a.foo()/($2),%1> ($1) [root] -> [jump to scope] <0,%1> ($2)",
             // ...or the actual named parameter `x`
-            "<a.foo()/$2,%1> ($1) [root] -> [jump to scope] <x,%1> ($2)",
+            "<a.foo()/($2),%1> ($1) [root] -> [jump to scope] <x,%1> ($2)",
         ],
     );
     check_partial_paths_in_file(
@@ -191,7 +191,7 @@ fn class_field_through_function_parameter() {
             // definition of class member `A.bar`
             "<b.A.bar,%1> ($1) [root] -> [b.py(8) definition bar] <%1> ($1)",
             // `bar` can also be accessed as an instance member
-            "<b.A()/$2.bar,%1> ($1) [root] -> [b.py(8) definition bar] <%1> ($2)",
+            "<b.A()/($2).bar,%1> ($1) [root] -> [b.py(8) definition bar] <%1> ($2)",
         ],
     );
 }

--- a/tests/it/can_find_node_partial_paths_in_database.rs
+++ b/tests/it/can_find_node_partial_paths_in_database.rs
@@ -57,8 +57,8 @@ fn class_field_through_function_parameter() {
         &mut graph,
         ("main.py", 10),
         &[
-            "<%1> () [main.py(10) reference bar] -> [root] <a.foo()/[main.py(7)].bar,%1> ()",
-            "<%1> () [main.py(10) reference bar] -> [root] <b.foo()/[main.py(7)].bar,%1> ()",
+            "<%1> () [main.py(10) reference bar] -> [root] <a.foo()/([main.py(7)]).bar,%1> ()",
+            "<%1> () [main.py(10) reference bar] -> [root] <b.foo()/([main.py(7)]).bar,%1> ()",
         ],
     );
     check_node_partial_paths(

--- a/tests/it/can_find_partial_paths_in_file.rs
+++ b/tests/it/can_find_partial_paths_in_file.rs
@@ -52,8 +52,8 @@ fn class_field_through_function_parameter() {
             // we can look for every reference in either `a` or `b`
             "<%1> () [main.py(9) reference A] -> [root] <a.A,%1> ()",
             "<%1> () [main.py(9) reference A] -> [root] <b.A,%1> ()",
-            "<%1> () [main.py(10) reference bar] -> [root] <a.foo()/[main.py(7)].bar,%1> ()",
-            "<%1> () [main.py(10) reference bar] -> [root] <b.foo()/[main.py(7)].bar,%1> ()",
+            "<%1> () [main.py(10) reference bar] -> [root] <a.foo()/([main.py(7)]).bar,%1> ()",
+            "<%1> () [main.py(10) reference bar] -> [root] <b.foo()/([main.py(7)]).bar,%1> ()",
             "<%1> () [main.py(13) reference foo] -> [root] <a.foo,%1> ()",
             "<%1> () [main.py(13) reference foo] -> [root] <b.foo,%1> ()",
             // parameter 0 of function call is `A`, which we can look up in either `a` or `b`
@@ -72,11 +72,11 @@ fn class_field_through_function_parameter() {
             // reference to `x` in function body can resolve to formal parameter
             "<%1> () [a.py(8) reference x] -> [a.py(14) definition x] <%1> ()",
             // result of function is `x`, which is passed in as a formal parameter...
-            "<a.foo()/$2,%1> ($1) [root] -> [a.py(14) definition x] <%1> ()",
+            "<a.foo()/($2),%1> ($1) [root] -> [a.py(14) definition x] <%1> ()",
             // ...which we can look up either the 0th actual positional parameter...
-            "<a.foo()/$2,%1> ($1) [root] -> [jump to scope] <0,%1> ($2)",
+            "<a.foo()/($2),%1> ($1) [root] -> [jump to scope] <0,%1> ($2)",
             // ...or the actual named parameter `x`
-            "<a.foo()/$2,%1> ($1) [root] -> [jump to scope] <x,%1> ($2)",
+            "<a.foo()/($2),%1> ($1) [root] -> [jump to scope] <x,%1> ($2)",
         ],
     );
     check_partial_paths_in_file(
@@ -90,7 +90,7 @@ fn class_field_through_function_parameter() {
             // definition of class member `A.bar`
             "<b.A.bar,%1> ($1) [root] -> [b.py(8) definition bar] <%1> ($1)",
             // `bar` can also be accessed as an instance member
-            "<b.A()/$2.bar,%1> ($1) [root] -> [b.py(8) definition bar] <%1> ($2)",
+            "<b.A()/($2).bar,%1> ($1) [root] -> [b.py(8) definition bar] <%1> ($2)",
         ],
     );
 }

--- a/tests/it/partial.rs
+++ b/tests/it/partial.rs
@@ -5,18 +5,269 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+use controlled_option::ControlledOption;
 use stack_graphs::graph::NodeID;
 use stack_graphs::graph::StackGraph;
 use stack_graphs::partial::PartialPaths;
 use stack_graphs::partial::PartialScopeStack;
 use stack_graphs::partial::PartialScopeStackBindings;
+use stack_graphs::partial::PartialScopedSymbol;
+use stack_graphs::partial::PartialSymbolStack;
+use stack_graphs::partial::PartialSymbolStackBindings;
 use stack_graphs::partial::ScopeStackVariable;
+use stack_graphs::partial::SymbolStackVariable;
 use stack_graphs::paths::PathResolutionError;
+
+type NiceSymbolStack<'a> = (&'a [NiceScopedSymbol<'a>], Option<SymbolStackVariable>);
+type NiceScopedSymbol<'a> = (&'a str, Option<NiceScopeStack<'a>>);
+type NiceScopeStack<'a> = (&'a [u32], Option<ScopeStackVariable>);
+
+fn create_symbol_stack(
+    graph: &mut StackGraph,
+    partials: &mut PartialPaths,
+    contents: NiceSymbolStack,
+) -> PartialSymbolStack {
+    let mut stack = if let Some(var) = contents.1 {
+        PartialSymbolStack::from_variable(var)
+    } else {
+        PartialSymbolStack::empty()
+    };
+    for scoped_symbol in contents.0 {
+        let symbol = graph.add_symbol(scoped_symbol.0);
+        let scopes = scoped_symbol
+            .1
+            .map(|scopes| create_scope_stack(graph, partials, scopes));
+        let scoped_symbol = PartialScopedSymbol {
+            symbol,
+            scopes: ControlledOption::from_option(scopes),
+        };
+        stack.push_back(partials, scoped_symbol);
+    }
+    stack
+}
+
+#[test]
+fn can_unify_partial_symbol_stacks() -> Result<(), PathResolutionError> {
+    fn verify(
+        lhs: NiceSymbolStack,
+        rhs: NiceSymbolStack,
+        expected_unification: &str,
+        expected_symbol_bindings: &str,
+        expected_scope_bindings: &str,
+    ) -> Result<(), PathResolutionError> {
+        let mut graph = StackGraph::new();
+        let mut partials = PartialPaths::new();
+        let lhs = create_symbol_stack(&mut graph, &mut partials, lhs);
+        let rhs = create_symbol_stack(&mut graph, &mut partials, rhs);
+        let mut symbol_bindings = PartialSymbolStackBindings::new();
+        let mut scope_bindings = PartialScopeStackBindings::new();
+        let unified = lhs.unify(
+            &mut partials,
+            rhs,
+            &mut symbol_bindings,
+            &mut scope_bindings,
+        )?;
+        let unified = unified.display(&graph, &mut partials).to_string();
+        assert_eq!(unified, expected_unification);
+        let symbol_bindings = symbol_bindings.display(&graph, &mut partials).to_string();
+        assert_eq!(symbol_bindings, expected_symbol_bindings);
+        let scope_bindings = scope_bindings.display(&graph, &mut partials).to_string();
+        assert_eq!(scope_bindings, expected_scope_bindings);
+        Ok(())
+    }
+
+    fn verify_not(lhs: NiceSymbolStack, rhs: NiceSymbolStack) -> Result<(), PathResolutionError> {
+        let mut graph = StackGraph::new();
+        let mut partials = PartialPaths::new();
+        let lhs = create_symbol_stack(&mut graph, &mut partials, lhs);
+        let rhs = create_symbol_stack(&mut graph, &mut partials, rhs);
+        let mut symbol_bindings = PartialSymbolStackBindings::new();
+        let mut scope_bindings = PartialScopeStackBindings::new();
+        assert!(lhs
+            .unify(
+                &mut partials,
+                rhs,
+                &mut symbol_bindings,
+                &mut scope_bindings
+            )
+            .is_err());
+        Ok(())
+    }
+
+    let var1 = Some(SymbolStackVariable::new(1).unwrap());
+    let var2 = Some(SymbolStackVariable::new(2).unwrap());
+    let a = ("a", None);
+
+    verify((&[], None), (&[], None), "", "{}", "{}")?;
+    verify((&[], var1), (&[], None), "%1", "{%1 => <>}", "{}")?;
+    verify((&[], None), (&[], var2), "%2", "{%2 => <>}", "{}")?;
+    verify((&[], var1), (&[], var2), "%1", "{%2 => <%1>}", "{}")?;
+
+    verify_not(
+        (&[], None), //
+        (&[a], None),
+    )?;
+    verify(
+        (&[], var1), //
+        (&[a], None),
+        "a",
+        "{%1 => <a>}",
+        "{}",
+    )?;
+    verify_not(
+        (&[], None), //
+        (&[a], var2),
+    )?;
+    verify(
+        (&[], var1), //
+        (&[a], var2),
+        "a,%2",
+        "{%1 => <a,%2>}",
+        "{}",
+    )?;
+
+    verify_not(
+        (&[a], None), //
+        (&[], None),
+    )?;
+    verify_not(
+        (&[a], var1), //
+        (&[], None),
+    )?;
+    verify(
+        (&[a], None), //
+        (&[], var2),
+        "a",
+        "{%2 => <a>}",
+        "{}",
+    )?;
+    verify(
+        (&[a], var1), //
+        (&[], var2),
+        "a,%1",
+        "{%2 => <a,%1>}",
+        "{}",
+    )?;
+
+    verify(
+        (&[a], None), //
+        (&[a], None),
+        "a",
+        "{}",
+        "{}",
+    )?;
+    verify(
+        (&[a], var1), //
+        (&[a], None),
+        "a,%1",
+        "{%1 => <>}",
+        "{}",
+    )?;
+    verify(
+        (&[a], None), //
+        (&[a], var2),
+        "a,%2",
+        "{%2 => <>}",
+        "{}",
+    )?;
+    verify(
+        (&[a], var1), //
+        (&[a], var2),
+        "a,%1",
+        "{%2 => <%1>}",
+        "{}",
+    )?;
+
+    let dot = (".", None);
+    let b = ("b", None);
+
+    verify(
+        (&[a, dot, b], None),
+        (&[a, dot, b], None),
+        "a.b",
+        "{}",
+        "{}",
+    )?;
+    verify(
+        (&[a, dot, b], var1),
+        (&[a, dot, b], None),
+        "a.b,%1",
+        "{%1 => <>}",
+        "{}",
+    )?;
+    verify(
+        (&[a, dot, b], None),
+        (&[a, dot, b], var2),
+        "a.b,%2",
+        "{%2 => <>}",
+        "{}",
+    )?;
+    verify(
+        (&[a, dot, b], var1),
+        (&[a, dot, b], var2),
+        "a.b,%1",
+        "{%2 => <%1>}",
+        "{}",
+    )?;
+
+    verify_not(
+        (&[a], None), //
+        (&[a, dot, b], None),
+    )?;
+    verify_not(
+        (&[a], None), //
+        (&[a, dot, b], var2),
+    )?;
+    verify(
+        (&[a], var1), //
+        (&[a, dot, b], None),
+        "a.b",
+        "{%1 => <.b>}",
+        "{}",
+    )?;
+    verify(
+        (&[a], var1), //
+        (&[a, dot, b], var2),
+        "a.b,%2",
+        "{%1 => <.b,%2>}",
+        "{}",
+    )?;
+
+    let empty_scopes: NiceScopeStack = (&[], None);
+    let a_empty = ("a", Some(empty_scopes));
+
+    let scope_var1 = Some(ScopeStackVariable::new(1).unwrap());
+    let scopes_var1: NiceScopeStack = (&[], scope_var1);
+    let a_var1 = ("a", Some(scopes_var1));
+
+    verify_not((&[a], None), (&[a_empty], None))?;
+    verify_not((&[a_empty], None), (&[a], None))?;
+
+    verify_not((&[a], None), (&[a_var1], None))?;
+    verify_not((&[a_var1], None), (&[a], None))?;
+
+    verify(
+        (&[a_empty], None),
+        (&[a_var1], None),
+        "a/($1)",
+        "{}",
+        "{$1 => ()}",
+    )?;
+    verify(
+        (&[a_var1], None),
+        (&[a_empty], None),
+        "a/($1)",
+        "{}",
+        "{$1 => ()}",
+    )?;
+
+    Ok(())
+}
 
 fn create_scope_stack(
     graph: &mut StackGraph,
     partials: &mut PartialPaths,
-    contents: (&[u32], Option<ScopeStackVariable>),
+    contents: NiceScopeStack,
 ) -> PartialScopeStack {
     let file = graph.get_or_create_file("file");
     let mut stack = if let Some(var) = contents.1 {
@@ -38,8 +289,8 @@ fn create_scope_stack(
 #[test]
 fn can_unify_partial_scope_stacks() -> Result<(), PathResolutionError> {
     fn verify(
-        lhs: (&[u32], Option<ScopeStackVariable>),
-        rhs: (&[u32], Option<ScopeStackVariable>),
+        lhs: NiceScopeStack,
+        rhs: NiceScopeStack,
         expected_unification: &str,
         expected_bindings: &str,
     ) -> Result<(), PathResolutionError> {
@@ -56,10 +307,7 @@ fn can_unify_partial_scope_stacks() -> Result<(), PathResolutionError> {
         Ok(())
     }
 
-    fn verify_not(
-        lhs: (&[u32], Option<ScopeStackVariable>),
-        rhs: (&[u32], Option<ScopeStackVariable>),
-    ) -> Result<(), PathResolutionError> {
+    fn verify_not(lhs: NiceScopeStack, rhs: NiceScopeStack) -> Result<(), PathResolutionError> {
         let mut graph = StackGraph::new();
         let mut partials = PartialPaths::new();
         let lhs = create_scope_stack(&mut graph, &mut partials, lhs);

--- a/tests/it/paths.rs
+++ b/tests/it/paths.rs
@@ -60,7 +60,7 @@ fn can_iterate_symbol_stacks() {
         .into_iter()
         .map(|symbol| symbol.display(&graph, &mut paths).to_string())
         .collect();
-    assert_eq!(rendered, "a.b/[test.py(0)]");
+    assert_eq!(rendered, "a.b/([test.py(0)])");
 }
 
 #[test]


### PR DESCRIPTION
This is very much like the function that we recently addded for unifying partial scope stacks.  There is some extra complexity from having to deal with attached scope stacks.