### PR TITLE
Use pretty_assertions in test cases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ smallvec = { version="1.6", features=["union"] }
 [dev-dependencies]
 itertools = "0.10"
 maplit = "1.0"
+pretty_assertions = "0.7"

--- a/tests/it/c/can_find_partial_paths_in_file.rs
+++ b/tests/it/c/can_find_partial_paths_in_file.rs
@@ -5,8 +5,9 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
+use pretty_assertions::assert_eq;
 use stack_graphs::c::sg_partial_path_arena;
 use stack_graphs::c::sg_partial_path_arena_find_partial_paths_in_file;
 use stack_graphs::c::sg_partial_path_arena_free;
@@ -122,12 +123,12 @@ fn check_partial_paths_in_file(graph: &TestGraph, file: &str, expected_paths: &[
     let results = results
         .iter()
         .map(|s| s.display(rust_graph, rust_partials).to_string())
-        .collect::<HashSet<_>>();
+        .collect::<BTreeSet<_>>();
     let expected_paths = expected_paths
         .iter()
         .map(|s| s.to_string())
-        .collect::<HashSet<_>>();
-    assert_eq!(results, expected_paths);
+        .collect::<BTreeSet<_>>();
+    assert_eq!(expected_paths, results);
 
     sg_partial_path_list_free(path_list);
     sg_partial_path_arena_free(partials);

--- a/tests/it/c/can_jump_to_definition.rs
+++ b/tests/it/c/can_jump_to_definition.rs
@@ -5,9 +5,9 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
-use crate::c::test_graph::TestGraph;
+use pretty_assertions::assert_eq;
 use stack_graphs::c::sg_path_arena_find_all_complete_paths;
 use stack_graphs::c::sg_path_arena_free;
 use stack_graphs::c::sg_path_arena_new;
@@ -17,6 +17,7 @@ use stack_graphs::c::sg_path_list_new;
 use stack_graphs::c::sg_path_list_paths;
 use stack_graphs::paths::Path;
 
+use crate::c::test_graph::TestGraph;
 use crate::test_graphs;
 
 fn check_jump_to_definition(graph: &TestGraph, expected_paths: &[&str]) {
@@ -45,12 +46,12 @@ fn check_jump_to_definition(graph: &TestGraph, expected_paths: &[&str]) {
     let results = results
         .iter()
         .map(|s| s.display(rust_graph, rust_paths).to_string())
-        .collect::<HashSet<_>>();
+        .collect::<BTreeSet<_>>();
     let expected_paths = expected_paths
         .iter()
         .map(|s| s.to_string())
-        .collect::<HashSet<_>>();
-    assert_eq!(results, expected_paths);
+        .collect::<BTreeSet<_>>();
+    assert_eq!(expected_paths, results);
 
     sg_path_list_free(path_list);
     sg_path_arena_free(paths);

--- a/tests/it/c/can_jump_to_definition_with_phased_partial_path_stitching.rs
+++ b/tests/it/c/can_jump_to_definition_with_phased_partial_path_stitching.rs
@@ -5,8 +5,9 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
+use pretty_assertions::assert_eq;
 use stack_graphs::c::sg_forward_partial_path_stitcher_free;
 use stack_graphs::c::sg_forward_partial_path_stitcher_new;
 use stack_graphs::c::sg_forward_partial_path_stitcher_process_next_phase;
@@ -136,7 +137,7 @@ fn check_jump_to_definition(graph: &TestGraph, file: &str, expected_partial_path
     let rust_stitcher = unsafe { &mut *stitcher };
 
     // Keep processing phases until the stitching algorithm is done.
-    let mut results = HashSet::new();
+    let mut results = BTreeSet::new();
     while rust_stitcher.previous_phase_partial_paths_length > 0 {
         let partial_paths_slice = unsafe {
             std::slice::from_raw_parts(
@@ -222,8 +223,8 @@ fn check_jump_to_definition(graph: &TestGraph, file: &str, expected_partial_path
     let expected_partial_paths = expected_partial_paths
         .iter()
         .map(|s| s.to_string())
-        .collect::<HashSet<_>>();
-    assert_eq!(results, expected_partial_paths);
+        .collect::<BTreeSet<_>>();
+    assert_eq!(expected_partial_paths, results);
 
     sg_forward_partial_path_stitcher_free(stitcher);
     sg_partial_path_database_free(db);

--- a/tests/it/c/can_jump_to_definition_with_phased_path_stitching.rs
+++ b/tests/it/c/can_jump_to_definition_with_phased_path_stitching.rs
@@ -5,8 +5,9 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
+use pretty_assertions::assert_eq;
 use stack_graphs::c::sg_forward_path_stitcher_free;
 use stack_graphs::c::sg_forward_path_stitcher_new;
 use stack_graphs::c::sg_forward_path_stitcher_process_next_phase;
@@ -142,7 +143,7 @@ fn check_jump_to_definition(graph: &TestGraph, file: &str, expected_paths: &[&st
     let rust_stitcher = unsafe { &mut *stitcher };
 
     // Keep processing phases until the stitching algorithm is done.
-    let mut results = HashSet::new();
+    let mut results = BTreeSet::new();
     while rust_stitcher.previous_phase_paths_length > 0 {
         let paths_slice = unsafe {
             std::slice::from_raw_parts(
@@ -201,8 +202,8 @@ fn check_jump_to_definition(graph: &TestGraph, file: &str, expected_paths: &[&st
     let expected_paths = expected_paths
         .iter()
         .map(|s| s.to_string())
-        .collect::<HashSet<_>>();
-    assert_eq!(results, expected_paths);
+        .collect::<BTreeSet<_>>();
+    assert_eq!(expected_paths, results);
 
     sg_forward_path_stitcher_free(stitcher);
     sg_partial_path_database_free(db);

--- a/tests/it/can_find_node_partial_paths_in_database.rs
+++ b/tests/it/can_find_node_partial_paths_in_database.rs
@@ -5,8 +5,9 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
+use pretty_assertions::assert_eq;
 use stack_graphs::arena::Handle;
 use stack_graphs::graph::NodeID;
 use stack_graphs::graph::StackGraph;
@@ -42,12 +43,12 @@ fn check_node_partial_paths(
     let actual_partial_paths = results
         .into_iter()
         .map(|path| database[path].display(graph, &mut partials).to_string())
-        .collect::<HashSet<_>>();
+        .collect::<BTreeSet<_>>();
     let expected_partial_paths = expected_partial_paths
         .iter()
         .map(|s| s.to_string())
-        .collect::<HashSet<_>>();
-    assert_eq!(actual_partial_paths, expected_partial_paths);
+        .collect::<BTreeSet<_>>();
+    assert_eq!(expected_partial_paths, actual_partial_paths);
 }
 
 #[test]

--- a/tests/it/can_find_partial_paths_in_file.rs
+++ b/tests/it/can_find_partial_paths_in_file.rs
@@ -5,8 +5,9 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
+use pretty_assertions::assert_eq;
 use stack_graphs::graph::StackGraph;
 use stack_graphs::partial::PartialPaths;
 
@@ -15,7 +16,7 @@ use crate::test_graphs;
 fn check_partial_paths_in_file(graph: &StackGraph, file: &str, expected_paths: &[&str]) {
     let file = graph.get_file_unchecked(file);
     let mut partials = PartialPaths::new();
-    let mut results = HashSet::new();
+    let mut results = BTreeSet::new();
     partials.find_all_partial_paths_in_file(graph, file, |graph, partials, path| {
         if !path.is_complete_as_possible(graph) {
             return;
@@ -28,8 +29,8 @@ fn check_partial_paths_in_file(graph: &StackGraph, file: &str, expected_paths: &
     let expected_paths = expected_paths
         .iter()
         .map(|s| s.to_string())
-        .collect::<HashSet<_>>();
-    assert_eq!(results, expected_paths);
+        .collect::<BTreeSet<_>>();
+    assert_eq!(expected_paths, results);
 }
 
 #[test]

--- a/tests/it/can_find_root_partial_paths_in_database.rs
+++ b/tests/it/can_find_root_partial_paths_in_database.rs
@@ -5,9 +5,10 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 use controlled_option::ControlledOption;
+use pretty_assertions::assert_eq;
 use stack_graphs::arena::Handle;
 use stack_graphs::graph::StackGraph;
 use stack_graphs::partial::PartialPath;
@@ -57,12 +58,12 @@ fn check_root_partial_paths(
     let actual_partial_paths = results
         .into_iter()
         .map(|path| database[path].display(graph, &mut partials).to_string())
-        .collect::<HashSet<_>>();
+        .collect::<BTreeSet<_>>();
     let expected_partial_paths = expected_partial_paths
         .iter()
         .map(|s| s.to_string())
-        .collect::<HashSet<_>>();
-    assert_eq!(actual_partial_paths, expected_partial_paths);
+        .collect::<BTreeSet<_>>();
+    assert_eq!(expected_partial_paths, actual_partial_paths);
 }
 
 #[test]

--- a/tests/it/can_jump_to_definition.rs
+++ b/tests/it/can_jump_to_definition.rs
@@ -5,8 +5,9 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
+use pretty_assertions::assert_eq;
 use stack_graphs::graph::StackGraph;
 use stack_graphs::paths::Paths;
 
@@ -14,7 +15,7 @@ use crate::test_graphs;
 
 fn check_jump_to_definition(graph: &StackGraph, expected_paths: &[&str]) {
     let mut paths = Paths::new();
-    let mut results = HashSet::new();
+    let mut results = BTreeSet::new();
     let references = graph
         .iter_nodes()
         .filter(|handle| graph[*handle].is_reference());
@@ -26,8 +27,8 @@ fn check_jump_to_definition(graph: &StackGraph, expected_paths: &[&str]) {
     let expected_paths = expected_paths
         .iter()
         .map(|s| s.to_string())
-        .collect::<HashSet<_>>();
-    assert_eq!(results, expected_paths);
+        .collect::<BTreeSet<_>>();
+    assert_eq!(expected_paths, results);
 }
 
 #[test]

--- a/tests/it/can_jump_to_definition_with_forward_partial_path_stitching.rs
+++ b/tests/it/can_jump_to_definition_with_forward_partial_path_stitching.rs
@@ -5,8 +5,9 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
+use pretty_assertions::assert_eq;
 use stack_graphs::graph::StackGraph;
 use stack_graphs::partial::PartialPaths;
 use stack_graphs::stitching::Database;
@@ -43,13 +44,13 @@ fn check_jump_to_definition(graph: &StackGraph, expected_partial_paths: &[&str])
     let results = complete_partial_paths
         .into_iter()
         .map(|partial_path| partial_path.display(graph, &mut partials).to_string())
-        .collect::<HashSet<_>>();
+        .collect::<BTreeSet<_>>();
 
     let expected_partial_paths = expected_partial_paths
         .iter()
         .map(|s| s.to_string())
-        .collect::<HashSet<_>>();
-    assert_eq!(results, expected_partial_paths);
+        .collect::<BTreeSet<_>>();
+    assert_eq!(expected_partial_paths, results);
 }
 
 #[test]

--- a/tests/it/can_jump_to_definition_with_forward_path_stitching.rs
+++ b/tests/it/can_jump_to_definition_with_forward_path_stitching.rs
@@ -5,8 +5,9 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
+use pretty_assertions::assert_eq;
 use stack_graphs::graph::StackGraph;
 use stack_graphs::partial::PartialPaths;
 use stack_graphs::paths::Paths;
@@ -46,13 +47,13 @@ fn check_jump_to_definition(graph: &StackGraph, expected_paths: &[&str]) {
     let results = complete_paths
         .into_iter()
         .map(|path| path.display(graph, &mut paths).to_string())
-        .collect::<HashSet<_>>();
+        .collect::<BTreeSet<_>>();
 
     let expected_paths = expected_paths
         .iter()
         .map(|s| s.to_string())
-        .collect::<HashSet<_>>();
-    assert_eq!(results, expected_paths);
+        .collect::<BTreeSet<_>>();
+    assert_eq!(expected_paths, results);
 }
 
 #[test]


### PR DESCRIPTION
This gives us a nice diff output when the tests fail.  We had to reorder the parameters to the assertions so that “added” lines are values that were produced by the code but that aren't expected.