### PR TITLE
Don't remember paths that we don't process

### DIFF
--- a/src/cycles.rs
+++ b/src/cycles.rs
@@ -106,12 +106,12 @@ where
     {
         let key = path.key();
         let paths_with_same_nodes = self.paths.entry(key).or_default();
-        match paths_with_same_nodes.binary_search_by(cmp) {
+        let index = match paths_with_same_nodes.binary_search_by(cmp) {
             // We've already seen this exact path before; no need to process it again.
             Ok(_) => return false,
             // Otherwise add it to the list.
-            Err(index) => paths_with_same_nodes.insert(index, path.clone()),
-        }
+            Err(index) => index,
+        };
 
         // Count how many paths we've already processed that have the same endpoints and are
         // "shorter".
@@ -119,6 +119,11 @@ where
             .iter()
             .filter(|similar_path| similar_path.is_shorter_than(path))
             .count();
-        return similar_path_count <= MAX_SIMILAR_PATH_COUNT;
+        if similar_path_count > MAX_SIMILAR_PATH_COUNT {
+            return false;
+        }
+
+        paths_with_same_nodes.insert(index, path.clone());
+        true
     }
 }

--- a/src/partial.rs
+++ b/src/partial.rs
@@ -1942,7 +1942,6 @@ impl PartialPath {
             && self
                 .scope_stack_postcondition
                 .equals(partials, other.scope_stack_postcondition)
-            && self.edges.equals(partials, other.edges)
     }
 
     pub fn cmp(
@@ -1973,7 +1972,6 @@ impl PartialPath {
                 self.scope_stack_postcondition
                     .cmp(partials, other.scope_stack_postcondition)
             })
-            .then_with(|| self.edges.cmp(partials, other.edges))
     }
 
     /// Returns whether a partial path represents the start of a name binding from a reference to a


### PR DESCRIPTION
This is an easy memory usage win, since any path that we don't process can't affect whether we need to process any other paths.