### PR TITLE
Track lots of position information

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
       - name: Run test suite under valgrind
         # We only need to use valgrind to test the crates that have C bindings.
         run: cargo valgrind test -p stack-graphs
+      - name: Run lsp-positions tests without tree-sitter
+        run: cargo test -p lsp-positions --no-default-features
       - name: Run test suite with copious debugging
         run: cargo test --features copious-debugging
       - name: Run test suite with all optimizations

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
 members = [
+  "lsp-positions",
   "stack-graphs",
 ]

--- a/lsp-positions/Cargo.toml
+++ b/lsp-positions/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "lsp-positions"
+version = "0.1.0"
+description = "LSP-compatible character positions"
+homepage = "https://github.com/github/stack-graphs/lsp-positions"
+repository = "https://github.com/github/stack-graphs/"
+readme = "README.md"
+license = "MIT OR Apache-2.0"
+authors = [
+  "GitHub <opensource+stack-graphs@github.com>",
+  "Douglas Creager <dcreager@dcreager.net>"
+]
+edition = "2018"
+
+[lib]
+# All of our tests are in the tests/it "integration" test executable.
+test = false
+
+[features]
+default = ["tree-sitter"]
+
+[dependencies]
+memchr = "2.4"
+tree-sitter = { version=">= 0.19", optional=true }

--- a/lsp-positions/README.md
+++ b/lsp-positions/README.md
@@ -1,0 +1,42 @@
+# lsp-positions
+
+The `lsp-positions` crate defines LSP-compatible positioning information for
+source code.
+
+When writing a tool that analyzes or operates on source code, there's a good
+chance you need to interoperate with the [Language Server Protocol][lsp].  This
+seemingly simple requirement makes it surprisingly difficult to deal with
+_character locations_.  This is because Rust wants to store Unicode string
+content (i.e., the source code you're analyzing) in UTF-8, while LSP wants to
+specify character locations using [_UTF-16 code points_][lsp-utf16].
+
+That means that we ideally need to keep track of each source code position using
+at least two units: the UTF-8 offset within the file or containing line (to make
+it easy to index into UTF-8 encoded strings), as well as the UTF-16 code point
+offset within the line (to make it possible to generate `Position` values for
+LSP).
+
+[lsp]: https://microsoft.github.io/language-server-protocol/
+[lsp-utf16]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocuments
+
+To use this library, add the following to your `Cargo.toml`:
+
+``` toml
+[dependencies]
+lsp-positions = "0.1"
+```
+
+Check out our [documentation](https://docs.rs/lsp-positions/) for more details
+on how to use this library.
+
+## License
+
+Licensed under either of
+
+  - [Apache License, Version 2.0][apache] ([LICENSE-APACHE](LICENSE-APACHE))
+  - [MIT license][mit] ([LICENSE-MIT](LICENSE-MIT))
+
+at your option.
+
+[apache]: http://www.apache.org/licenses/LICENSE-2.0
+[mit]: http://opensource.org/licenses/MIT

--- a/lsp-positions/README.md
+++ b/lsp-positions/README.md
@@ -6,15 +6,21 @@ source code.
 When writing a tool that analyzes or operates on source code, there's a good
 chance you need to interoperate with the [Language Server Protocol][lsp].  This
 seemingly simple requirement makes it surprisingly difficult to deal with
-_character locations_.  This is because Rust wants to store Unicode string
-content (i.e., the source code you're analyzing) in UTF-8, while LSP wants to
-specify character locations using [_UTF-16 code points_][lsp-utf16].
+_character locations_.  This is because Rust stores Unicode string content
+(i.e., the source code you're analyzing) in UTF-8, while LSP specifies character
+locations using [_UTF-16 code units_][lsp-utf16].
 
-That means that we ideally need to keep track of each source code position using
-at least two units: the UTF-8 offset within the file or containing line (to make
-it easy to index into UTF-8 encoded strings), as well as the UTF-16 code point
-offset within the line (to make it possible to generate `Position` values for
-LSP).
+For some background, Unicode characters, or code points, are encoded as one or
+more code units. In UTF-8 a code unit is 1 byte, and a character is encoded in
+1–4 code units (1–4 bytes).  In UTF-16 a code unit is 2 bytes, and characters
+are encoded in 1–2 code units (2 or 4 bytes). Rust strings are encoded as UTF-8,
+and indexed by byte (which is the same as by code unit). Indices are only valid
+if they point to the first code unit of a code point.
+
+We keep track of each source code position using two units: the UTF-8 byte
+position within the file or containing line, which can be used to index into
+UTF-8 encoded `str` and `[u8]` data, and the UTF-16 code unit position within
+the line, which can be used to generate `Position` values for LSP.
 
 [lsp]: https://microsoft.github.io/language-server-protocol/
 [lsp-utf16]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocuments

--- a/lsp-positions/src/lib.rs
+++ b/lsp-positions/src/lib.rs
@@ -1,0 +1,351 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! Defines LSP-compatible positioning information for source code.
+//!
+//! When writing a tool that analyzes or operates on source code, there's a good chance you need to
+//! interoperate with the [Language Server Protocol][lsp].  This seemingly simple requirement makes
+//! it surprisingly difficult to deal with _character locations_.  This is because Rust wants to
+//! store Unicode string content (i.e., the source code you're analyzing) in UTF-8, while
+//! LSP wants to specify character locations using [_UTF-16 code points_][lsp-utf16].
+//!
+//! That means that we ideally need to keep track of each source code position using at least two
+//! units: the UTF-8 offset within the file or containing line (to make it easy to index into UTF-8
+//! encoded strings), as well as the UTF-16 code point offset within the line (to make it possible
+//! to generate `Position` values for LSP).
+//!
+//! [lsp]: https://microsoft.github.io/language-server-protocol/
+//! [lsp-utf16]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocuments
+
+use std::ops::Range;
+
+use memchr::memchr;
+
+fn utf16_len(string: &str) -> usize {
+    string.chars().map(char::len_utf16).sum()
+}
+
+/// All of the position information that we have about a character in a source file
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
+pub struct Position {
+    /// The 0-indexed line number containing the character
+    pub line: usize,
+    /// The offset of the character within its containing line, expressed as both a UTF-8 byte
+    /// index and a UTF-16 code point index
+    pub column: Offset,
+    /// The UTF-8 byte indexes (within the file) of the start and end of the line containing the
+    /// character
+    pub containing_line: Range<usize>,
+    /// The UTF-8 byte indexes (within the file) of the start and end of the line containing the
+    /// character, with any leading and trailing whitespace removed
+    pub trimmed_line: Range<usize>,
+}
+
+impl Position {
+    /// Returns a tree-sitter [`Point`][Point] for this position.
+    ///
+    /// [Point]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Point.html
+    #[cfg(feature = "tree-sitter")]
+    pub fn as_point(&self) -> tree_sitter::Point {
+        tree_sitter::Point {
+            row: self.line,
+            column: self.column.utf8_offset,
+        }
+    }
+}
+
+impl Ord for Position {
+    fn cmp(&self, other: &Position) -> std::cmp::Ordering {
+        self.line
+            .cmp(&other.line)
+            .then_with(|| self.column.utf8_offset.cmp(&other.column.utf8_offset))
+    }
+}
+
+impl PartialOrd for Position {
+    fn partial_cmp(&self, other: &Position) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[cfg(feature = "tree-sitter")]
+impl PartialEq<tree_sitter::Point> for Position {
+    fn eq(&self, other: &tree_sitter::Point) -> bool {
+        self.line == other.row && self.column.utf8_offset == other.column
+    }
+}
+
+#[cfg(feature = "tree-sitter")]
+impl PartialOrd<tree_sitter::Point> for Position {
+    fn partial_cmp(&self, other: &tree_sitter::Point) -> Option<std::cmp::Ordering> {
+        Some(
+            self.line
+                .cmp(&other.row)
+                .then_with(|| self.column.utf8_offset.cmp(&other.column)),
+        )
+    }
+}
+
+/// All of the position information that we have about a range of content in a source file
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
+pub struct Span {
+    pub start: Position,
+    pub end: Position,
+}
+
+impl Span {
+    pub fn contains(&self, position: Position) -> bool {
+        self.start <= position && self.end > position
+    }
+
+    #[cfg(feature = "tree-sitter")]
+    pub fn contains_point(&self, point: tree_sitter::Point) -> bool {
+        self.start <= point && self.end > point
+    }
+}
+
+impl Ord for Span {
+    fn cmp(&self, other: &Span) -> std::cmp::Ordering {
+        self.start
+            .cmp(&other.start)
+            .then_with(|| self.end.cmp(&other.end))
+    }
+}
+
+impl PartialOrd for Span {
+    fn partial_cmp(&self, other: &Span) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// The offset of a character within a string (typically a line of source code), using several
+/// different units
+///
+/// All offsets are 0-indexed.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Offset {
+    /// The number of UTF-8-encoded bytes appearing before this character in the string
+    pub utf8_offset: usize,
+    /// The number of UTF-16 code units appearing before this character in the string
+    pub utf16_offset: usize,
+}
+
+impl Offset {
+    /// Calculates the length of a string, expressed as the position of the non-existent character
+    /// after the end of the line.
+    pub fn string_length(string: &str) -> Offset {
+        Offset {
+            utf8_offset: string.len(),
+            utf16_offset: utf16_len(string),
+        }
+    }
+
+    /// Calculates the offset of each character within a string.  Typically the string will contain
+    /// a single line of text, in which case the results are column offsets.  (In this case, the
+    /// string should not contain any newlines, though we don't verify this.)
+    ///
+    /// Each character's offset is returned both as the byte offset from the beginning of the line,
+    /// as well as the number of UTF-16 code units before the character in the line.  (This is the
+    /// column unit used by the [Language Server Protocol][lsp-utf16].)
+    ///
+    /// The result is an iterator of offsets, one for each character.  The results will be sorted,
+    /// so you can collect them into a `Vec` and use `binary_search_by_key` to look for particular
+    /// characters.
+    ///
+    /// [lsp-utf16]: https://microsoft.github.io/language-server-protocol/specification#textDocuments
+    pub fn all_chars(line: &str) -> impl Iterator<Item = Offset> + '_ {
+        // We want the output to include an entry for the end of the string — i.e., for the byte
+        // offset immediately after the last character of the string.  To do this, we add a dummy
+        // character to list of actual characters from the string.
+        line.chars()
+            .chain(std::iter::once(' '))
+            .scan(Offset::default(), |offset, ch| {
+                let result = Some(*offset);
+                offset.utf8_offset += ch.len_utf8();
+                offset.utf16_offset += ch.len_utf16();
+                result
+            })
+    }
+}
+
+/// A substring and information about where that substring occurs in a larger string.  (Most often,
+/// this is a “line” and information about where that line occurs within a “file”.)
+#[derive(Clone)]
+pub struct PositionedSubstring<'a> {
+    /// The content of the substring
+    pub content: &'a str,
+    /// The UTF-8 byte offsets of the beginning and end of the substring within the larger string
+    pub utf8_bounds: Range<usize>,
+    /// The number of UTF-16 code points in the substring
+    pub utf16_length: usize,
+}
+
+impl<'a> PositionedSubstring<'a> {
+    /// Constructs a new positioned substring.  You must provide the larger string, and the byte
+    /// range of the desired substring.
+    pub fn from_range(string: &'a str, utf8_bounds: Range<usize>) -> PositionedSubstring<'a> {
+        let substring = &string[utf8_bounds.clone()];
+        PositionedSubstring {
+            content: substring,
+            utf8_bounds,
+            utf16_length: utf16_len(substring),
+        }
+    }
+
+    /// Constructs a new positioned substring for a newline-terminated line within a file.  You
+    /// provide the byte offset of the start of the line, and we automatically find the end of the
+    /// line.
+    pub fn from_line(file: &'a str, line_utf8_offset: usize) -> PositionedSubstring<'a> {
+        // The line's byte index lets us trim all preceding lines in the file.
+        let line_plus_others = &file[line_utf8_offset..];
+
+        // The requested line stops at the first newline, or at the end of the file if there aren't
+        // any newlines.
+        let line = match memchr(b'\n', line_plus_others.as_bytes()) {
+            Some(newline_offset) => &line_plus_others[..newline_offset],
+            None => line_plus_others,
+        };
+
+        let length = Offset::string_length(line);
+        PositionedSubstring {
+            content: line,
+            utf8_bounds: Range {
+                start: line_utf8_offset,
+                end: line_utf8_offset + length.utf8_offset,
+            },
+            utf16_length: length.utf16_offset,
+        }
+    }
+
+    /// Trims ASCII whitespace from both ends of a substring.
+    pub fn trim_whitespace(&mut self) {
+        let leading_whitespace = self
+            .content
+            .bytes()
+            .enumerate()
+            .find(|(_, ch)| !(*ch as char).is_ascii_whitespace())
+            .map(|(index, _)| index)
+            .unwrap_or(self.content.len());
+        let left_whitespace = &self.content[0..leading_whitespace];
+        let trimmed_left = &self.content[leading_whitespace..];
+
+        let trailing_whitespace = trimmed_left
+            .bytes()
+            .enumerate()
+            // Point at the last non-whitespace character
+            .rfind(|(_, ch)| !(*ch as char).is_ascii_whitespace())
+            // Point at the immediately following whitespace character.  Note we are only looking
+            // for _ASCII_ whitespace, so we can assume that the last whitespace character that we
+            // found is 1 byte long.
+            .map(|(index, _)| index + 1)
+            .unwrap_or(0);
+        let trimmed = &trimmed_left[0..trailing_whitespace];
+        let right_whitespace = &trimmed_left[trailing_whitespace..];
+
+        self.content = trimmed;
+        self.utf8_bounds.start += left_whitespace.len();
+        self.utf8_bounds.end -= right_whitespace.len();
+        self.utf16_length -= utf16_len(left_whitespace);
+        self.utf16_length -= utf16_len(right_whitespace);
+    }
+}
+
+/// Automates the construction of [`Span`][] instances for content within a source file.
+pub struct SpanCalculator<'a> {
+    source: &'a str,
+    containing_line: Option<PositionedSubstring<'a>>,
+    trimmed_line: Option<PositionedSubstring<'a>>,
+    columns: Vec<Offset>,
+}
+
+// Note that each time you calculate the position of a node on a _different line_, we have to
+// calculate some information about line.  You'd think that would mean it would be most efficient
+// to use this type if you made to sure group all of your nodes by their rows before asking for us
+// to create Spans for them.  However, it turns out that sorting your nodes to make sure that
+// they're in row order is just as much work as recalculating the UTF16 column offsets if we ever
+// revisit a line!
+
+impl<'a> SpanCalculator<'a> {
+    /// Creates a new span calculator for locations within the given source file.
+    pub fn new(source: &'a str) -> SpanCalculator<'a> {
+        SpanCalculator {
+            source,
+            containing_line: None,
+            trimmed_line: None,
+            columns: Vec::new(),
+        }
+    }
+
+    /// Constructs a [`Position`][] instance for a particular line and column in the source file.
+    /// You must provide the 0-indexed line number, the byte offset of the line within the file,
+    /// and the UTF-8 byte offset of the character within the line.
+    pub fn for_line_and_column(
+        &mut self,
+        line: usize,
+        line_utf8_offset: usize,
+        column_utf8_offset: usize,
+    ) -> Position {
+        self.replace_current_line(line_utf8_offset);
+        Position {
+            line: line,
+            column: Offset {
+                utf8_offset: column_utf8_offset,
+                utf16_offset: self.utf16_offset(column_utf8_offset),
+            },
+            containing_line: self.containing_line.as_ref().unwrap().utf8_bounds.clone(),
+            trimmed_line: self.trimmed_line.as_ref().unwrap().utf8_bounds.clone(),
+        }
+    }
+
+    /// Constructs a [`Span`][] instance for a tree-sitter node.
+    #[cfg(feature = "tree-sitter")]
+    pub fn for_node(&mut self, node: &tree_sitter::Node) -> Span {
+        let start = self.position_for_node(node.start_byte(), node.start_position());
+        let end = self.position_for_node(node.end_byte(), node.end_position());
+        Span { start, end }
+    }
+
+    /// Constructs a [`Position`][] instance for a tree-sitter location.
+    #[cfg(feature = "tree-sitter")]
+    pub fn position_for_node(
+        &mut self,
+        byte_offset: usize,
+        position: tree_sitter::Point,
+    ) -> Position {
+        // Since we know the byte offset of the node within the file, and of the node within the
+        // line, subtracting gives us the offset of the line within the file.
+        let line_utf8_offset = byte_offset - position.column;
+        self.for_line_and_column(position.row, line_utf8_offset, position.column)
+    }
+
+    /// Updates our internal state to represent the information about the line that starts at a
+    /// particular byte offset within the file.
+    fn replace_current_line(&mut self, line_utf8_offset: usize) {
+        if let Some(containing_line) = &self.containing_line {
+            if containing_line.utf8_bounds.start == line_utf8_offset {
+                return;
+            }
+        }
+        let line = PositionedSubstring::from_line(self.source, line_utf8_offset);
+        self.columns.clear();
+        self.columns.extend(Offset::all_chars(line.content));
+        let mut trimmed = line.clone();
+        trimmed.trim_whitespace();
+        self.containing_line = Some(line);
+        self.trimmed_line = Some(trimmed);
+    }
+
+    /// Returns the UTF-16 offset of the character at a particular UTF-8 offset in the line.
+    /// Assumes that you've already called `replace_current_line` for the containing line.
+    fn utf16_offset(&self, utf8_offset: usize) -> usize {
+        let index = self
+            .columns
+            .binary_search_by_key(&utf8_offset, |pos| pos.utf8_offset)
+            .unwrap();
+        self.columns[index].utf16_offset
+    }
+}

--- a/lsp-positions/src/lib.rs
+++ b/lsp-positions/src/lib.rs
@@ -30,6 +30,7 @@ fn utf16_len(string: &str) -> usize {
 }
 
 /// All of the position information that we have about a character in a source file
+#[repr(C)]
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Position {
     /// The 0-indexed line number containing the character
@@ -91,6 +92,7 @@ impl PartialOrd<tree_sitter::Point> for Position {
 }
 
 /// All of the position information that we have about a range of content in a source file
+#[repr(C)]
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Span {
     pub start: Position,

--- a/lsp-positions/tests/it/main.rs
+++ b/lsp-positions/tests/it/main.rs
@@ -1,0 +1,33 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use lsp_positions::Offset;
+
+fn check_utf16_offsets(line: &str) {
+    let offsets = Offset::all_chars(line).collect::<Vec<_>>();
+    assert!(!offsets.is_empty());
+    assert_eq!(offsets.first().unwrap().utf8_offset, 0);
+    assert_eq!(offsets.first().unwrap().utf16_offset, 0);
+    assert_eq!(offsets.last().unwrap().utf8_offset, line.len());
+    assert_eq!(
+        offsets.last().unwrap().utf16_offset,
+        line.encode_utf16().count()
+    );
+    for (index, (utf8_offset, _)) in line.char_indices().enumerate() {
+        let prefix = &line[0..utf8_offset];
+        let utf16_offset = prefix.encode_utf16().count();
+        assert_eq!(offsets[index].utf8_offset, utf8_offset);
+        assert_eq!(offsets[index].utf16_offset, utf16_offset);
+    }
+}
+
+#[test]
+fn can_calculate_column_offsets() {
+    check_utf16_offsets("from a import *");
+    check_utf16_offsets("print '❤️', b, '👨‍👨‍👧', c");
+    check_utf16_offsets("print '✨✨✨', d");
+}

--- a/stack-graphs/Cargo.toml
+++ b/stack-graphs/Cargo.toml
@@ -24,6 +24,7 @@ controlled-option = "0.4"
 either = "1.6"
 fxhash = "0.2"
 libc = "0.2"
+lsp-positions = { version="0.1", path="../lsp-positions" }
 smallvec = { version="1.6", features=["union"] }
 
 [dev-dependencies]

--- a/stack-graphs/src/arena.rs
+++ b/stack-graphs/src/arena.rs
@@ -303,6 +303,17 @@ impl<H, T> SupplementalArena<H, T> {
             .get_mut(handle.as_usize())
             .map(|x| unsafe { &mut *(x.as_mut_ptr()) })
     }
+
+    /// Returns a pointer to this arena's storage.
+    pub(crate) fn as_ptr(&self) -> *const T {
+        self.items.as_ptr() as *const T
+    }
+
+    /// Returns the number of instances stored in this arena.
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
 }
 
 impl<H, T> SupplementalArena<H, T>

--- a/stack-graphs/src/graph.rs
+++ b/stack-graphs/src/graph.rs
@@ -1370,6 +1370,34 @@ impl StackGraph {
 }
 
 //-------------------------------------------------------------------------------------------------
+// Source code
+
+/// Contains information about a range of code in a source code file.
+#[repr(C)]
+#[derive(Default)]
+pub struct SourceInfo {
+    /// The location in its containing file of the source code that this node represents.
+    pub span: lsp_positions::Span,
+    /// The kind of syntax entity this node represents (e.g. `function`, `class`, `method`, etc.).
+    pub syntax_type: Option<Handle<InternedString>>,
+    /// The full content of the line containing this node in its source file.
+    pub containing_line: ControlledOption<Handle<InternedString>>,
+}
+
+impl StackGraph {
+    /// Returns information about the source code that a stack graph node represents.
+    pub fn source_info(&self, node: Handle<Node>) -> Option<&SourceInfo> {
+        self.source_info.get(node)
+    }
+
+    /// Returns a mutable reference to the information about the source code that a stack graph
+    /// node represents.
+    pub fn source_info_mut(&mut self, node: Handle<Node>) -> &mut SourceInfo {
+        &mut self.source_info[node]
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
 // Stack graphs
 
 /// Contains all of the nodes and edges that make up a stack graph.
@@ -1382,6 +1410,7 @@ pub struct StackGraph {
     pub(crate) files: Arena<File>,
     file_handles: FxHashMap<&'static str, Handle<File>>,
     pub(crate) nodes: Arena<Node>,
+    pub(crate) source_info: SupplementalArena<Node, SourceInfo>,
     node_id_handles: NodeIDHandles,
     jump_to_node: Handle<Node>,
     root_node: Handle<Node>,
@@ -1410,6 +1439,7 @@ impl Default for StackGraph {
             files: Arena::new(),
             file_handles: FxHashMap::default(),
             nodes,
+            source_info: SupplementalArena::new(),
             node_id_handles: NodeIDHandles::new(),
             jump_to_node,
             root_node,


### PR DESCRIPTION
This moves over some of our existing logic for dealing with LSP-compatible character positions and lets you start tracking this for stack graph nodes.  All of the position information is stored in a supplemental arena, and is completely optional.

(LSP indexes characters as their [location within the UTF-16 encoding of the string](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocuments), even if the string content is stored in UTF-8.  That means we need to track UTF-8 offsets, so that we can efficiently index into the Rust strings, but also track UTF-16 if we ever want to provide an LSP view of this data.)