### PR TITLE
Add `InternedStrings`

### DIFF
--- a/stack-graphs/include/stack-graphs.h
+++ b/stack-graphs/include/stack-graphs.h
@@ -9,6 +9,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+// The null value for all of our handles.
+#define SG_NULL_HANDLE 0
+
 // The handle of an empty list.
 #define SG_LIST_EMPTY_HANDLE 4294967295
 

--- a/stack-graphs/src/c.rs
+++ b/stack-graphs/src/c.rs
@@ -122,6 +122,9 @@ pub extern "C" fn sg_partial_path_database_free(db: *mut sg_partial_path_databas
     drop(unsafe { Box::from_raw(db) })
 }
 
+/// The null value for all of our handles.
+pub const SG_NULL_HANDLE: u32 = 0;
+
 /// The handle of an empty list.
 pub const SG_LIST_EMPTY_HANDLE: u32 = 0xffffffff;
 

--- a/stack-graphs/src/c.rs
+++ b/stack-graphs/src/c.rs
@@ -15,6 +15,7 @@ use libc::c_char;
 
 use crate::arena::Handle;
 use crate::graph::File;
+use crate::graph::InternedString;
 use crate::graph::Node;
 use crate::graph::NodeID;
 use crate::graph::StackGraph;
@@ -215,6 +216,81 @@ pub extern "C" fn sg_stack_graph_add_symbols(
             Err(_) => None,
         };
         unsafe { symbols = symbols.add(lengths[i]) };
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Interned strings
+
+/// Arbitrary string content associated with some part of a stack graph.
+#[repr(C)]
+pub struct sg_string {
+    pub content: *const c_char,
+    pub length: usize,
+}
+
+/// A handle to an interned string in a stack graph.  A zero handle represents a missing string.
+///
+/// We deduplicate strings in a stack graph — that is, we ensure that there are never multiple
+/// `struct sg_string` instances with the same content.  That means that you can compare string
+/// handles using simple equality, without having to dereference them.
+pub type sg_string_handle = u32;
+
+/// An array of all of the interned strings in a stack graph.  String handles are indices into this
+/// array. There will never be a valid string at index 0; a handle with the value 0 represents a
+/// missing string.
+#[repr(C)]
+pub struct sg_strings {
+    pub strings: *const sg_string,
+    pub count: usize,
+}
+
+/// Returns a reference to the array of string data in this stack graph.  The resulting array
+/// pointer is only valid until the next call to any function that mutates the stack graph.
+#[no_mangle]
+pub extern "C" fn sg_stack_graph_strings(graph: *const sg_stack_graph) -> sg_strings {
+    let graph = unsafe { &(*graph).inner };
+    sg_strings {
+        strings: graph.strings.as_ptr() as *const sg_string,
+        count: graph.strings.len(),
+    }
+}
+
+/// Adds new strings to the stack graph.  You provide all of the string content concatenated
+/// together into a single string, and an array of the lengths of each string.  You also provide an
+/// output array, which must have the same size as `lengths`.  We will place each string's handle
+/// in the output array.
+///
+/// We ensure that there is only ever one copy of a particular string stored in the graph — we
+/// guarantee that identical strings will have the same handles, meaning that you can compare the
+/// handles using simple integer equality.
+///
+/// We copy the string data into the stack graph.  The string content you pass in does not need to
+/// outlive the call to this function.
+///
+/// Each string must be a valid UTF-8 string.  If any string isn't valid UTF-8, it won't be added
+/// to the stack graph, and the corresponding entry in the output array will be the null handle.
+#[no_mangle]
+pub extern "C" fn sg_stack_graph_add_strings(
+    graph: *mut sg_stack_graph,
+    count: usize,
+    strings: *const c_char,
+    lengths: *const usize,
+    handles_out: *mut sg_string_handle,
+) {
+    let graph = unsafe { &mut (*graph).inner };
+    let mut strings = strings as *const u8;
+    let lengths = unsafe { std::slice::from_raw_parts(lengths, count) };
+    let handles_out = unsafe {
+        std::slice::from_raw_parts_mut(handles_out as *mut Option<Handle<InternedString>>, count)
+    };
+    for i in 0..count {
+        let string = unsafe { std::slice::from_raw_parts(strings, lengths[i]) };
+        handles_out[i] = match std::str::from_utf8(string) {
+            Ok(string) => Some(graph.add_string(string)),
+            Err(_) => None,
+        };
+        unsafe { strings = strings.add(lengths[i]) };
     }
 }
 

--- a/stack-graphs/tests/it/c/can_find_partial_paths_in_file.rs
+++ b/stack-graphs/tests/it/c/can_find_partial_paths_in_file.rs
@@ -23,6 +23,7 @@ use stack_graphs::c::sg_partial_path_list_paths;
 use stack_graphs::c::sg_partial_scope_stack;
 use stack_graphs::c::sg_partial_symbol_stack;
 use stack_graphs::c::SG_LIST_EMPTY_HANDLE;
+use stack_graphs::c::SG_NULL_HANDLE;
 use stack_graphs::partial::PartialPath;
 
 use crate::c::test_graph::TestGraph;
@@ -39,7 +40,7 @@ fn partial_symbol_stack_available_in_both_directions(
         return true;
     }
     let cell = &cells[head as usize];
-    cell.reversed != 0
+    cell.reversed != SG_NULL_HANDLE
 }
 
 fn partial_scope_stack_available_in_both_directions(
@@ -53,7 +54,7 @@ fn partial_scope_stack_available_in_both_directions(
         return true;
     }
     let cell = &cells[head as usize];
-    cell.reversed != 0
+    cell.reversed != SG_NULL_HANDLE
 }
 
 fn partial_path_edge_list_available_in_both_directions(
@@ -67,7 +68,7 @@ fn partial_path_edge_list_available_in_both_directions(
         return true;
     }
     let cell = &cells[head as usize];
-    cell.reversed != 0
+    cell.reversed != SG_NULL_HANDLE
 }
 
 fn check_partial_paths_in_file(graph: &TestGraph, file: &str, expected_paths: &[&str]) {

--- a/stack-graphs/tests/it/c/files.rs
+++ b/stack-graphs/tests/it/c/files.rs
@@ -14,6 +14,7 @@ use stack_graphs::c::sg_stack_graph_add_files;
 use stack_graphs::c::sg_stack_graph_files;
 use stack_graphs::c::sg_stack_graph_free;
 use stack_graphs::c::sg_stack_graph_new;
+use stack_graphs::c::SG_NULL_HANDLE;
 use stack_graphs::graph::File;
 
 fn lengths(data: &[&'static str]) -> Vec<usize> {
@@ -75,5 +76,5 @@ fn verify_null_file_representation() {
     let mut rust: ControlledOption<Handle<File>> = unsafe { std::mem::transmute(bytes) };
     rust = ControlledOption::none();
     let c: sg_file_handle = unsafe { std::mem::transmute(rust) };
-    assert_eq!(c, 0);
+    assert_eq!(c, SG_NULL_HANDLE);
 }

--- a/stack-graphs/tests/it/c/partial.rs
+++ b/stack-graphs/tests/it/c/partial.rs
@@ -38,13 +38,14 @@ use stack_graphs::c::sg_stack_graph_get_or_create_nodes;
 use stack_graphs::c::sg_stack_graph_new;
 use stack_graphs::c::sg_symbol_handle;
 use stack_graphs::c::SG_LIST_EMPTY_HANDLE;
+use stack_graphs::c::SG_NULL_HANDLE;
 use stack_graphs::partial::PartialPathEdgeList;
 use stack_graphs::partial::PartialScopeStack;
 use stack_graphs::partial::PartialSymbolStack;
 
 fn add_file(graph: *mut sg_stack_graph, filename: &str) -> sg_file_handle {
     let lengths = [filename.len()];
-    let mut handles: [sg_file_handle; 1] = [0; 1];
+    let mut handles: [sg_file_handle; 1] = [SG_NULL_HANDLE; 1];
     sg_stack_graph_add_files(
         graph,
         1,
@@ -52,13 +53,13 @@ fn add_file(graph: *mut sg_stack_graph, filename: &str) -> sg_file_handle {
         lengths.as_ptr(),
         handles.as_mut_ptr(),
     );
-    assert!(handles[0] != 0);
+    assert!(handles[0] != SG_NULL_HANDLE);
     handles[0]
 }
 
 fn add_symbol(graph: *mut sg_stack_graph, value: &str) -> sg_symbol_handle {
     let lengths = [value.len()];
-    let mut handles: [sg_symbol_handle; 1] = [0; 1];
+    let mut handles: [sg_symbol_handle; 1] = [SG_NULL_HANDLE; 1];
     sg_stack_graph_add_symbols(
         graph,
         1,
@@ -66,7 +67,7 @@ fn add_symbol(graph: *mut sg_stack_graph, value: &str) -> sg_symbol_handle {
         lengths.as_ptr(),
         handles.as_mut_ptr(),
     );
-    assert!(handles[0] != 0);
+    assert!(handles[0] != SG_NULL_HANDLE);
     handles[0]
 }
 
@@ -78,12 +79,12 @@ fn add_exported_scope(
     let node = sg_node {
         kind: sg_node_kind::SG_NODE_KIND_EXPORTED_SCOPE,
         id: sg_node_id { file, local_id },
-        symbol: 0,
+        symbol: SG_NULL_HANDLE,
         is_clickable: false,
         scope: sg_node_id::default(),
     };
     let nodes = [node];
-    let mut handles: [sg_node_handle; 1] = [0; 1];
+    let mut handles: [sg_node_handle; 1] = [SG_NULL_HANDLE; 1];
     sg_stack_graph_get_or_create_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     handles[0]
 }
@@ -93,7 +94,7 @@ fn add_exported_scope(
 
 fn empty_partial_scope_stack() -> sg_partial_scope_stack {
     sg_partial_scope_stack {
-        cells: 0,
+        cells: SG_NULL_HANDLE,
         direction: sg_deque_direction::SG_DEQUE_FORWARDS,
         length: 0,
         variable: 0,
@@ -142,7 +143,7 @@ fn partial_symbol_stack_available_in_both_directions(
         return true;
     }
     let cell = &cells[head as usize];
-    cell.reversed != 0
+    cell.reversed != SG_NULL_HANDLE
 }
 
 #[test]
@@ -227,7 +228,7 @@ fn verify_null_partial_symbol_stack_representation() {
     let mut rust: ControlledOption<PartialSymbolStack> = unsafe { std::mem::transmute(bytes) };
     rust = ControlledOption::none();
     let c: sg_partial_symbol_stack = unsafe { std::mem::transmute(rust) };
-    assert_eq!(c.cells, 0);
+    assert_eq!(c.cells, SG_NULL_HANDLE);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -268,7 +269,7 @@ fn partial_scope_stack_available_in_both_directions(
         return true;
     }
     let cell = &cells[head as usize];
-    cell.reversed != 0
+    cell.reversed != SG_NULL_HANDLE
 }
 
 #[test]
@@ -333,7 +334,7 @@ fn verify_null_partial_scope_stack_representation() {
     let mut rust: ControlledOption<PartialScopeStack> = unsafe { std::mem::transmute(bytes) };
     rust = ControlledOption::none();
     let c: sg_partial_scope_stack = unsafe { std::mem::transmute(rust) };
-    assert_eq!(c.cells, 0);
+    assert_eq!(c.cells, SG_NULL_HANDLE);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -382,7 +383,7 @@ fn partial_path_edge_list_available_in_both_directions(
         return true;
     }
     let cell = &cells[head as usize];
-    cell.reversed != 0
+    cell.reversed != SG_NULL_HANDLE
 }
 
 #[test]
@@ -441,5 +442,5 @@ fn verify_null_partial_path_edge_list_representation() {
     let mut rust: ControlledOption<PartialPathEdgeList> = unsafe { std::mem::transmute(bytes) };
     rust = ControlledOption::none();
     let c: sg_partial_path_edge_list = unsafe { std::mem::transmute(rust) };
-    assert_eq!(c.cells, 0);
+    assert_eq!(c.cells, SG_NULL_HANDLE);
 }

--- a/stack-graphs/tests/it/c/paths.rs
+++ b/stack-graphs/tests/it/c/paths.rs
@@ -38,13 +38,14 @@ use stack_graphs::c::sg_symbol_handle;
 use stack_graphs::c::sg_symbol_stack;
 use stack_graphs::c::sg_symbol_stack_cells;
 use stack_graphs::c::SG_LIST_EMPTY_HANDLE;
+use stack_graphs::c::SG_NULL_HANDLE;
 use stack_graphs::paths::PathEdgeList;
 use stack_graphs::paths::ScopeStack;
 use stack_graphs::paths::SymbolStack;
 
 fn add_file(graph: *mut sg_stack_graph, filename: &str) -> sg_file_handle {
     let lengths = [filename.len()];
-    let mut handles: [sg_file_handle; 1] = [0; 1];
+    let mut handles: [sg_file_handle; 1] = [SG_NULL_HANDLE; 1];
     sg_stack_graph_add_files(
         graph,
         1,
@@ -52,13 +53,13 @@ fn add_file(graph: *mut sg_stack_graph, filename: &str) -> sg_file_handle {
         lengths.as_ptr(),
         handles.as_mut_ptr(),
     );
-    assert!(handles[0] != 0);
+    assert!(handles[0] != SG_NULL_HANDLE);
     handles[0]
 }
 
 fn add_symbol(graph: *mut sg_stack_graph, value: &str) -> sg_symbol_handle {
     let lengths = [value.len()];
-    let mut handles: [sg_symbol_handle; 1] = [0; 1];
+    let mut handles: [sg_symbol_handle; 1] = [SG_NULL_HANDLE; 1];
     sg_stack_graph_add_symbols(
         graph,
         1,
@@ -66,7 +67,7 @@ fn add_symbol(graph: *mut sg_stack_graph, value: &str) -> sg_symbol_handle {
         lengths.as_ptr(),
         handles.as_mut_ptr(),
     );
-    assert!(handles[0] != 0);
+    assert!(handles[0] != SG_NULL_HANDLE);
     handles[0]
 }
 
@@ -78,12 +79,12 @@ fn add_exported_scope(
     let node = sg_node {
         kind: sg_node_kind::SG_NODE_KIND_EXPORTED_SCOPE,
         id: sg_node_id { file, local_id },
-        symbol: 0,
+        symbol: SG_NULL_HANDLE,
         is_clickable: false,
         scope: sg_node_id::default(),
     };
     let nodes = [node];
-    let mut handles: [sg_node_handle; 1] = [0; 1];
+    let mut handles: [sg_node_handle; 1] = [SG_NULL_HANDLE; 1];
     sg_stack_graph_get_or_create_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     handles[0]
 }
@@ -93,7 +94,7 @@ fn add_exported_scope(
 
 fn empty_scope_stack() -> sg_scope_stack {
     sg_scope_stack {
-        cells: 0,
+        cells: SG_NULL_HANDLE,
         length: 0,
     }
 }
@@ -185,7 +186,7 @@ fn verify_null_symbol_stack_representation() {
     let mut rust: ControlledOption<SymbolStack> = unsafe { std::mem::transmute(bytes) };
     rust = ControlledOption::none();
     let c: sg_symbol_stack = unsafe { std::mem::transmute(rust) };
-    assert_eq!(c.cells, 0);
+    assert_eq!(c.cells, SG_NULL_HANDLE);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -256,7 +257,7 @@ fn verify_null_scope_stack_representation() {
     let mut rust: ControlledOption<ScopeStack> = unsafe { std::mem::transmute(bytes) };
     rust = ControlledOption::none();
     let c: sg_scope_stack = unsafe { std::mem::transmute(rust) };
-    assert_eq!(c.cells, 0);
+    assert_eq!(c.cells, SG_NULL_HANDLE);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -305,7 +306,7 @@ fn path_edge_list_available_in_both_directions(
         return true;
     }
     let cell = &cells[head as usize];
-    cell.reversed != 0
+    cell.reversed != SG_NULL_HANDLE
 }
 
 #[test]
@@ -364,5 +365,5 @@ fn verify_null_path_edge_list_representation() {
     let mut rust: ControlledOption<PathEdgeList> = unsafe { std::mem::transmute(bytes) };
     rust = ControlledOption::none();
     let c: sg_path_edge_list = unsafe { std::mem::transmute(rust) };
-    assert_eq!(c.cells, 0);
+    assert_eq!(c.cells, SG_NULL_HANDLE);
 }

--- a/stack-graphs/tests/it/c/strings.rs
+++ b/stack-graphs/tests/it/c/strings.rs
@@ -1,0 +1,79 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use controlled_option::ControlledOption;
+use libc::c_char;
+use stack_graphs::arena::Handle;
+use stack_graphs::c::sg_stack_graph_add_strings;
+use stack_graphs::c::sg_stack_graph_free;
+use stack_graphs::c::sg_stack_graph_new;
+use stack_graphs::c::sg_stack_graph_strings;
+use stack_graphs::c::sg_string_handle;
+use stack_graphs::c::sg_strings;
+use stack_graphs::graph::InternedString;
+
+fn lengths(data: &[&'static str]) -> Vec<usize> {
+    data.iter().map(|s| s.len()).collect()
+}
+
+fn get_string(arena: &sg_strings, handle: Handle<InternedString>) -> &str {
+    let slice = unsafe { std::slice::from_raw_parts(arena.strings, arena.count) };
+    let string = &slice[handle.as_usize()];
+    unsafe {
+        let bytes = std::slice::from_raw_parts(string.content as *const u8, string.length);
+        std::str::from_utf8_unchecked(bytes)
+    }
+}
+
+#[test]
+fn can_create_strings() {
+    let graph = sg_stack_graph_new();
+
+    let string_data = ["a", "a", "b", "c"];
+    let mut handles: [Option<Handle<InternedString>>; 4] = [None; 4];
+    sg_stack_graph_add_strings(
+        graph,
+        string_data.len(),
+        string_data.join("").as_ptr() as *const c_char,
+        lengths(&string_data).as_ptr(),
+        handles.as_mut_ptr() as *mut sg_string_handle,
+    );
+
+    // All of the strings should have been created successfully
+    assert!(handles.as_ref().iter().all(|h| h.is_some()));
+
+    // The handles should be comparable.
+    let a1 = handles[0].unwrap();
+    let a2 = handles[1].unwrap();
+    let b = handles[2].unwrap();
+    let c = handles[3].unwrap();
+    assert_eq!(a1, a2);
+    assert_ne!(a1, b);
+    assert_ne!(a1, c);
+    assert_ne!(a2, b);
+    assert_ne!(a2, c);
+    assert_ne!(b, c);
+
+    // We should be able to dereference into the strings arena to get the string content.
+    let string_arena = sg_stack_graph_strings(graph);
+    assert_eq!(get_string(&string_arena, a1), "a");
+    assert_eq!(get_string(&string_arena, a2), "a");
+    assert_eq!(get_string(&string_arena, b), "b");
+    assert_eq!(get_string(&string_arena, c), "c");
+
+    sg_stack_graph_free(graph);
+}
+
+#[test]
+#[allow(unused_assignments)]
+fn verify_null_string_representation() {
+    let bytes = [0x55u8; std::mem::size_of::<Handle<InternedString>>()];
+    let mut rust: ControlledOption<Handle<InternedString>> = unsafe { std::mem::transmute(bytes) };
+    rust = ControlledOption::none();
+    let c: sg_string_handle = unsafe { std::mem::transmute(rust) };
+    assert_eq!(c, 0);
+}

--- a/stack-graphs/tests/it/c/strings.rs
+++ b/stack-graphs/tests/it/c/strings.rs
@@ -14,6 +14,7 @@ use stack_graphs::c::sg_stack_graph_new;
 use stack_graphs::c::sg_stack_graph_strings;
 use stack_graphs::c::sg_string_handle;
 use stack_graphs::c::sg_strings;
+use stack_graphs::c::SG_NULL_HANDLE;
 use stack_graphs::graph::InternedString;
 
 fn lengths(data: &[&'static str]) -> Vec<usize> {
@@ -75,5 +76,5 @@ fn verify_null_string_representation() {
     let mut rust: ControlledOption<Handle<InternedString>> = unsafe { std::mem::transmute(bytes) };
     rust = ControlledOption::none();
     let c: sg_string_handle = unsafe { std::mem::transmute(rust) };
-    assert_eq!(c, 0);
+    assert_eq!(c, SG_NULL_HANDLE);
 }

--- a/stack-graphs/tests/it/c/symbols.rs
+++ b/stack-graphs/tests/it/c/symbols.rs
@@ -14,6 +14,7 @@ use stack_graphs::c::sg_stack_graph_new;
 use stack_graphs::c::sg_stack_graph_symbols;
 use stack_graphs::c::sg_symbol_handle;
 use stack_graphs::c::sg_symbols;
+use stack_graphs::c::SG_NULL_HANDLE;
 use stack_graphs::graph::Symbol;
 
 fn lengths(data: &[&'static str]) -> Vec<usize> {
@@ -75,5 +76,5 @@ fn verify_null_symbol_representation() {
     let mut rust: ControlledOption<Handle<Symbol>> = unsafe { std::mem::transmute(bytes) };
     rust = ControlledOption::none();
     let c: sg_symbol_handle = unsafe { std::mem::transmute(rust) };
-    assert_eq!(c, 0);
+    assert_eq!(c, SG_NULL_HANDLE);
 }

--- a/stack-graphs/tests/it/c/test_graph.rs
+++ b/stack-graphs/tests/it/c/test_graph.rs
@@ -21,6 +21,7 @@ use stack_graphs::c::sg_stack_graph_get_or_create_nodes;
 use stack_graphs::c::sg_stack_graph_new;
 use stack_graphs::c::sg_symbol_handle;
 use stack_graphs::c::SG_JUMP_TO_NODE_HANDLE;
+use stack_graphs::c::SG_NULL_HANDLE;
 use stack_graphs::c::SG_ROOT_NODE_HANDLE;
 
 use crate::test_graphs::CreateStackGraph;
@@ -45,7 +46,7 @@ impl Drop for TestGraph {
 impl TestGraph {
     fn add_node(&mut self, node: sg_node) -> sg_node_handle {
         let nodes = [node];
-        let mut handles: [sg_node_handle; 1] = [0; 1];
+        let mut handles: [sg_node_handle; 1] = [SG_NULL_HANDLE; 1];
         sg_stack_graph_get_or_create_nodes(
             self.graph,
             nodes.len(),
@@ -80,7 +81,7 @@ impl CreateStackGraph for TestGraph {
         self.add_node(sg_node {
             kind: sg_node_kind::SG_NODE_KIND_DROP_SCOPES,
             id: sg_node_id { file, local_id },
-            symbol: 0,
+            symbol: SG_NULL_HANDLE,
             is_clickable: false,
             scope: sg_node_id::default(),
         })
@@ -100,7 +101,7 @@ impl CreateStackGraph for TestGraph {
         self.add_node(sg_node {
             kind: sg_node_kind::SG_NODE_KIND_EXPORTED_SCOPE,
             id: sg_node_id { file, local_id },
-            symbol: 0,
+            symbol: SG_NULL_HANDLE,
             is_clickable: false,
             scope: sg_node_id::default(),
         })
@@ -108,7 +109,7 @@ impl CreateStackGraph for TestGraph {
 
     fn file(&mut self, name: &str) -> sg_file_handle {
         let lengths = [name.len()];
-        let mut handles: [sg_file_handle; 1] = [0; 1];
+        let mut handles: [sg_file_handle; 1] = [SG_NULL_HANDLE; 1];
         sg_stack_graph_add_files(
             self.graph,
             1,
@@ -123,7 +124,7 @@ impl CreateStackGraph for TestGraph {
         self.add_node(sg_node {
             kind: sg_node_kind::SG_NODE_KIND_INTERNAL_SCOPE,
             id: sg_node_id { file, local_id },
-            symbol: 0,
+            symbol: SG_NULL_HANDLE,
             is_clickable: false,
             scope: sg_node_id::default(),
         })
@@ -220,7 +221,7 @@ impl CreateStackGraph for TestGraph {
 
     fn symbol(&mut self, value: &str) -> sg_symbol_handle {
         let lengths = [value.len()];
-        let mut handles: [sg_symbol_handle; 1] = [0; 1];
+        let mut handles: [sg_symbol_handle; 1] = [SG_NULL_HANDLE; 1];
         sg_stack_graph_add_symbols(
             self.graph,
             1,

--- a/stack-graphs/tests/it/graph.rs
+++ b/stack-graphs/tests/it/graph.rs
@@ -68,6 +68,61 @@ fn can_display_symbols() {
 }
 
 #[test]
+fn can_create_strings() {
+    let mut graph = StackGraph::new();
+    let a1 = graph.add_string("a");
+    let a2 = graph.add_string("a");
+    let b = graph.add_string("b");
+    let c = graph.add_string("c");
+    let empty1 = graph.add_string("");
+    // The content of each string be comparable
+    assert_eq!(graph[a1], graph[a2]);
+    assert_ne!(graph[a1], graph[b]);
+    assert_ne!(graph[a1], graph[c]);
+    assert_ne!(graph[a2], graph[b]);
+    assert_ne!(graph[a2], graph[c]);
+    assert_ne!(graph[b], graph[c]);
+    assert_ne!(graph[empty1], graph[a1]);
+    // and because we deduplicate strings, the handles should be comparable too.
+    assert_eq!(a1, a2);
+    assert_ne!(a1, b);
+    assert_ne!(a1, c);
+    assert_ne!(a2, b);
+    assert_ne!(a2, c);
+    assert_ne!(b, c);
+    assert_ne!(empty1, a1);
+}
+
+#[test]
+fn can_iterate_strings() {
+    let mut graph = StackGraph::new();
+    graph.add_string("a");
+    graph.add_string("b");
+    graph.add_string("c");
+    // We should get all of the strings that we've created — though there's no guarantee in which
+    // order they'll come out of the iterator.
+    let strings = graph
+        .iter_strings()
+        .map(|string| &graph[string])
+        .collect::<HashSet<_>>();
+    assert_eq!(strings, hashset! {"a", "b", "c"});
+}
+
+#[test]
+fn can_display_strings() {
+    let mut graph = StackGraph::new();
+    graph.add_string("a");
+    graph.add_string("b");
+    graph.add_string("c");
+    let mut strings = graph
+        .iter_strings()
+        .map(|string| string.display(&graph).to_string())
+        .collect::<Vec<_>>();
+    strings.sort();
+    assert_eq!(strings, vec!["a", "b", "c"]);
+}
+
+#[test]
 fn can_iterate_nodes() {
     let mut graph = StackGraph::new();
     let file = graph.get_or_create_file("test.py");


### PR DESCRIPTION
This lets you add arbitrary string content to a stack graph, which will be interned and deduplicated just like we're already doing for symbols and filenames.  We're going to use this soon for some supplemental information about stack graph nodes that are associated with a range of content in a source file.