### PR TITLE
Determine which nodes in a file are “local”

### DIFF
--- a/stack-graphs/Cargo.toml
+++ b/stack-graphs/Cargo.toml
@@ -20,6 +20,7 @@ copious-debugging = []
 test = false
 
 [dependencies]
+bitvec = "0.22"
 controlled-option = "0.4"
 either = "1.6"
 fxhash = "0.2"

--- a/stack-graphs/src/arena.rs
+++ b/stack-graphs/src/arena.rs
@@ -62,7 +62,7 @@ pub struct Handle<T> {
 }
 
 impl<T> Handle<T> {
-    fn new(index: NonZeroU32) -> Handle<T> {
+    pub(crate) fn new(index: NonZeroU32) -> Handle<T> {
         Handle {
             index,
             _phantom: PhantomData,

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -2391,7 +2391,7 @@ impl PartialPaths {
     {
         let mut cycle_detector = CycleDetector::new();
         let mut queue = VecDeque::new();
-        queue.push_back(PartialPath::from_node(graph, self, graph.root_node()).unwrap());
+        queue.push_back(PartialPath::from_node(graph, self, StackGraph::root_node()).unwrap());
         queue.extend(
             graph
                 .nodes_for_file(file)

--- a/stack-graphs/tests/it/c/can_find_local_nodes.rs
+++ b/stack-graphs/tests/it/c/can_find_local_nodes.rs
@@ -1,0 +1,140 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use std::collections::BTreeSet;
+
+use pretty_assertions::assert_eq;
+use stack_graphs::c::sg_partial_path_arena_find_partial_paths_in_file;
+use stack_graphs::c::sg_partial_path_arena_free;
+use stack_graphs::c::sg_partial_path_arena_new;
+use stack_graphs::c::sg_partial_path_database_add_partial_paths;
+use stack_graphs::c::sg_partial_path_database_find_local_nodes;
+use stack_graphs::c::sg_partial_path_database_free;
+use stack_graphs::c::sg_partial_path_database_local_nodes;
+use stack_graphs::c::sg_partial_path_database_new;
+use stack_graphs::c::sg_partial_path_handle;
+use stack_graphs::c::sg_partial_path_list_count;
+use stack_graphs::c::sg_partial_path_list_free;
+use stack_graphs::c::sg_partial_path_list_new;
+use stack_graphs::c::sg_partial_path_list_paths;
+use stack_graphs::c::sg_stack_graph_nodes;
+use stack_graphs::graph::Node;
+
+use crate::c::test_graph::TestGraph;
+use crate::test_graphs;
+
+fn check_local_nodes(graph: &TestGraph, file: &str, expected_local_nodes: &[&str]) {
+    let rust_graph = unsafe { &(*graph.graph).inner };
+    let file = rust_graph.get_file_unchecked(file);
+
+    let partials = sg_partial_path_arena_new();
+    let path_list = sg_partial_path_list_new();
+    sg_partial_path_arena_find_partial_paths_in_file(
+        graph.graph,
+        partials,
+        file.as_u32(),
+        path_list,
+    );
+
+    let db = sg_partial_path_database_new();
+    let path_ptr = sg_partial_path_list_paths(path_list);
+    let path_count = sg_partial_path_list_count(path_list);
+    let mut out: Vec<sg_partial_path_handle> = vec![0; path_count];
+    sg_partial_path_database_add_partial_paths(
+        graph.graph,
+        partials,
+        db,
+        path_count,
+        path_ptr,
+        out.as_mut_ptr(),
+    );
+
+    sg_partial_path_database_find_local_nodes(db);
+    let local_nodes = sg_partial_path_database_local_nodes(db);
+    let local_nodes =
+        unsafe { std::slice::from_raw_parts(local_nodes.elements, local_nodes.length) };
+    fn get_is_local(local_nodes: &[u32], index: usize) -> bool {
+        let element_index = index / 32;
+        if element_index >= local_nodes.len() {
+            return false;
+        }
+        let bit_index = index % 32;
+        let bit_mask = 1 << bit_index;
+        (local_nodes[element_index] & bit_mask) != 0
+    }
+
+    let nodes = sg_stack_graph_nodes(graph.graph);
+    let nodes = unsafe { std::slice::from_raw_parts(nodes.nodes as *const Node, nodes.count) };
+    let results = nodes
+        .iter()
+        .enumerate()
+        .filter(|(idx, _)| get_is_local(&local_nodes, *idx))
+        .map(|(_, node)| node.display(rust_graph).to_string())
+        .collect::<BTreeSet<_>>();
+
+    let expected_local_nodes = expected_local_nodes
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(expected_local_nodes, results);
+
+    sg_partial_path_database_free(db);
+    sg_partial_path_list_free(path_list);
+    sg_partial_path_arena_free(partials);
+}
+
+#[test]
+fn class_field_through_function_parameter() {
+    let graph = test_graphs::class_field_through_function_parameter::new();
+    check_local_nodes(&graph, "main.py", &[]);
+    check_local_nodes(
+        &graph,
+        "a.py",
+        &[
+            "[a.py(8) reference x]", //
+        ],
+    );
+    check_local_nodes(&graph, "b.py", &[]);
+}
+
+#[test]
+fn cyclic_imports_python() {
+    let graph = test_graphs::cyclic_imports_python::new();
+    check_local_nodes(&graph, "main.py", &[]);
+    check_local_nodes(&graph, "a.py", &[]);
+    check_local_nodes(&graph, "b.py", &[]);
+}
+
+#[test]
+fn cyclic_imports_rust() {
+    let graph = test_graphs::cyclic_imports_rust::new();
+    check_local_nodes(
+        &graph,
+        "test.rs",
+        // NOTE: Because everything in this example is local to one file, there aren't any partial
+        // paths involving the root node.
+        &[
+            "[test.rs(101) reference FOO]",
+            "[test.rs(103) reference a]",
+            "[test.rs(201) definition a]",
+            "[test.rs(204) definition BAR]",
+            "[test.rs(206) reference b]",
+            "[test.rs(301) definition b]",
+            "[test.rs(304) definition FOO]",
+            "[test.rs(305) reference BAR]",
+            "[test.rs(307) reference a]",
+        ],
+    );
+}
+
+#[test]
+fn sequenced_import_star() {
+    let graph = test_graphs::sequenced_import_star::new();
+    check_local_nodes(&graph, "main.py", &[]);
+    check_local_nodes(&graph, "a.py", &[]);
+    check_local_nodes(&graph, "b.py", &[]);
+}

--- a/stack-graphs/tests/it/c/mod.rs
+++ b/stack-graphs/tests/it/c/mod.rs
@@ -6,6 +6,7 @@
 // ------------------------------------------------------------------------------------------------
 
 mod can_create_graph;
+mod can_find_local_nodes;
 mod can_find_partial_paths_in_file;
 mod can_jump_to_definition;
 mod can_jump_to_definition_with_phased_partial_path_stitching;

--- a/stack-graphs/tests/it/can_find_local_nodes.rs
+++ b/stack-graphs/tests/it/can_find_local_nodes.rs
@@ -1,0 +1,96 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use std::collections::BTreeSet;
+
+use pretty_assertions::assert_eq;
+use stack_graphs::graph::StackGraph;
+use stack_graphs::partial::PartialPaths;
+use stack_graphs::stitching::Database;
+
+use crate::test_graphs;
+
+fn check_local_nodes(graph: &StackGraph, file: &str, expected_local_nodes: &[&str]) {
+    let file = graph.get_file_unchecked(file);
+    let mut partials = PartialPaths::new();
+    let mut database = Database::new();
+    partials.find_all_partial_paths_in_file(graph, file, |graph, partials, path| {
+        if !path.is_complete_as_possible(graph) {
+            return;
+        }
+        if !path.is_productive(partials) {
+            return;
+        }
+        database.add_partial_path(graph, partials, path);
+    });
+
+    let mut results = BTreeSet::new();
+    database.find_local_nodes();
+    for handle in graph.iter_nodes() {
+        if database.node_is_local(handle) {
+            results.insert(graph[handle].display(graph).to_string());
+        }
+    }
+
+    let expected_local_nodes = expected_local_nodes
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(expected_local_nodes, results);
+}
+
+#[test]
+fn class_field_through_function_parameter() {
+    let graph = test_graphs::class_field_through_function_parameter::new();
+    check_local_nodes(&graph, "main.py", &[]);
+    check_local_nodes(
+        &graph,
+        "a.py",
+        &[
+            "[a.py(8) reference x]", //
+        ],
+    );
+    check_local_nodes(&graph, "b.py", &[]);
+}
+
+#[test]
+fn cyclic_imports_python() {
+    let graph = test_graphs::cyclic_imports_python::new();
+    check_local_nodes(&graph, "main.py", &[]);
+    check_local_nodes(&graph, "a.py", &[]);
+    check_local_nodes(&graph, "b.py", &[]);
+}
+
+#[test]
+fn cyclic_imports_rust() {
+    let graph = test_graphs::cyclic_imports_rust::new();
+    check_local_nodes(
+        &graph,
+        "test.rs",
+        // NOTE: Because everything in this example is local to one file, there aren't any partial
+        // paths involving the root node.
+        &[
+            "[test.rs(101) reference FOO]",
+            "[test.rs(103) reference a]",
+            "[test.rs(201) definition a]",
+            "[test.rs(204) definition BAR]",
+            "[test.rs(206) reference b]",
+            "[test.rs(301) definition b]",
+            "[test.rs(304) definition FOO]",
+            "[test.rs(305) reference BAR]",
+            "[test.rs(307) reference a]",
+        ],
+    );
+}
+
+#[test]
+fn sequenced_import_star() {
+    let graph = test_graphs::sequenced_import_star::new();
+    check_local_nodes(&graph, "main.py", &[]);
+    check_local_nodes(&graph, "a.py", &[]);
+    check_local_nodes(&graph, "b.py", &[]);
+}

--- a/stack-graphs/tests/it/graph.rs
+++ b/stack-graphs/tests/it/graph.rs
@@ -169,7 +169,7 @@ fn can_add_and_remove_edges() {
 #[test]
 fn singleton_nodes_have_correct_ids() {
     let graph = StackGraph::new();
-    let root_handle = graph.root_node();
+    let root_handle = StackGraph::root_node();
     let root = &graph[root_handle];
     assert!(root.is_root());
     assert!(root.id().is_root());

--- a/stack-graphs/tests/it/main.rs
+++ b/stack-graphs/tests/it/main.rs
@@ -10,6 +10,7 @@ pub mod test_graphs;
 mod arena;
 mod c;
 mod can_create_graph;
+mod can_find_local_nodes;
 mod can_find_node_partial_paths_in_database;
 mod can_find_partial_paths_in_file;
 mod can_find_root_partial_paths_in_database;

--- a/stack-graphs/tests/it/test_graphs/mod.rs
+++ b/stack-graphs/tests/it/test_graphs/mod.rs
@@ -101,7 +101,7 @@ impl CreateStackGraph for StackGraph {
     }
 
     fn jump_to_node(&mut self) -> Handle<Node> {
-        StackGraph::jump_to_node(self)
+        StackGraph::jump_to_node()
     }
 
     fn pop_scoped_symbol(
@@ -158,7 +158,7 @@ impl CreateStackGraph for StackGraph {
     }
 
     fn root_node(&mut self) -> Handle<Node> {
-        StackGraph::root_node(self)
+        StackGraph::root_node()
     }
 
     fn symbol(&mut self, value: &str) -> Handle<Symbol> {


### PR DESCRIPTION
A node is local if it cannot possibly participate in a name binding that leaves its file.  In a stack graph, that means that there is no sequence of partial paths that connects the node to the root node.

We have two methods for “setting” the set of local nodes.  The first is meant to be called at index time, and actually analyzes the partial paths in the database to determine which nodes are local.  The second is meant to be called at query time, where you've stored the locality information in your storage layer, and just need to load that back into our internal view of the stack graph.