### PR TITLE
Create stack graphs using tree-sitter-graph

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,5 @@
 members = [
   "lsp-positions",
   "stack-graphs",
+  "tree-sitter-stack-graphs",
 ]

--- a/stack-graphs/Cargo.toml
+++ b/stack-graphs/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 
 [features]
 copious-debugging = []
+json = ["serde", "serde_json", "thiserror"]
 
 [lib]
 # All of our tests are in the tests/it "integration" test executable.
@@ -26,7 +27,10 @@ either = "1.6"
 fxhash = "0.2"
 libc = "0.2"
 lsp-positions = { version="0.1", path="../lsp-positions" }
+serde = { version="1.0", optional=true }
+serde_json = { version="1.0", optional=true }
 smallvec = { version="1.6", features=["union"] }
+thiserror = { version="1.0", optional=true }
 
 [dev-dependencies]
 itertools = "0.10"

--- a/stack-graphs/include/stack-graphs.h
+++ b/stack-graphs/include/stack-graphs.h
@@ -31,12 +31,6 @@ enum sg_deque_direction {
 enum sg_node_kind {
     // Removes everything from the current scope stack.
     SG_NODE_KIND_DROP_SCOPES,
-    // A node that can be referred to on the scope stack, which allows "jump to" nodes in any
-    // other part of the graph can jump back here.
-    SG_NODE_KIND_EXPORTED_SCOPE,
-    // A node internal to a single file.  This node has no effect on the symbol or scope stacks;
-    // it's just used to add structure to the graph.
-    SG_NODE_KIND_INTERNAL_SCOPE,
     // The singleton "jump to" node, which allows a name binding path to jump back to another part
     // of the graph.
     SG_NODE_KIND_JUMP_TO,
@@ -53,6 +47,10 @@ enum sg_node_kind {
     SG_NODE_KIND_PUSH_SYMBOL,
     // The singleton root node, which allows a name binding path to cross between files.
     SG_NODE_KIND_ROOT,
+    // A node that adds structure to the graph. If the node is exported, it can be
+    // referred to on the scope stack, which allows "jump to" nodes in any other
+    // part of the graph can jump back here.
+    SG_NODE_KIND_SCOPE,
 };
 
 // Manages the state of a collection of partial paths to be used in the path-stitching algorithm.
@@ -176,10 +174,11 @@ struct sg_node {
     // attached to the symbol before it's pushed onto the symbol stack.  For all other node types,
     // this will be null.
     struct sg_node_id scope;
-    // Whether this node is "clickable".  For push nodes, this indicates that the node represents
+    // Whether this node is an endpoint.  For push nodes, this indicates that the node represents
     // a reference in the source.  For pop nodes, this indicates that the node represents a
-    // definition in the source.  For all other node types, this field will be unused.
-    bool is_clickable;
+    // definition in the source.  For scopes, this indicates that the scope is exported. For all
+    // other node types, this field will be unused.
+    bool is_endpoint;
 };
 
 // An array of all of the nodes in a stack graph.  Node handles are indices into this array.

--- a/stack-graphs/src/c.rs
+++ b/stack-graphs/src/c.rs
@@ -429,10 +429,11 @@ pub struct sg_node {
     /// attached to the symbol before it's pushed onto the symbol stack.  For all other node types,
     /// this will be null.
     pub scope: sg_node_id,
-    /// Whether this node is "clickable".  For push nodes, this indicates that the node represents
+    /// Whether this node is an endpoint.  For push nodes, this indicates that the node represents
     /// a reference in the source.  For pop nodes, this indicates that the node represents a
-    /// definition in the source.  For all other node types, this field will be unused.
-    pub is_clickable: bool,
+    /// definition in the source.  For scopes, this indicates that the scope is exported. For all
+    /// other node types, this field will be unused.
+    pub is_endpoint: bool,
 }
 
 impl Into<Node> for sg_node {
@@ -447,12 +448,6 @@ impl Into<Node> for sg_node {
 pub enum sg_node_kind {
     /// Removes everything from the current scope stack.
     SG_NODE_KIND_DROP_SCOPES,
-    /// A node that can be referred to on the scope stack, which allows "jump to" nodes in any
-    /// other part of the graph can jump back here.
-    SG_NODE_KIND_EXPORTED_SCOPE,
-    /// A node internal to a single file.  This node has no effect on the symbol or scope stacks;
-    /// it's just used to add structure to the graph.
-    SG_NODE_KIND_INTERNAL_SCOPE,
     /// The singleton "jump to" node, which allows a name binding path to jump back to another part
     /// of the graph.
     SG_NODE_KIND_JUMP_TO,
@@ -469,6 +464,10 @@ pub enum sg_node_kind {
     SG_NODE_KIND_PUSH_SYMBOL,
     /// The singleton root node, which allows a name binding path to cross between files.
     SG_NODE_KIND_ROOT,
+    /// A node that adds structure to the graph. If the node is exported, it can be
+    /// referred to on the scope stack, which allows "jump to" nodes in any other
+    /// part of the graph can jump back here.
+    SG_NODE_KIND_SCOPE,
 }
 
 /// A handle to a node in a stack graph.  A zero handle represents a missing node.

--- a/stack-graphs/src/graph.rs
+++ b/stack-graphs/src/graph.rs
@@ -170,7 +170,7 @@ pub struct Symbol {
 }
 
 impl Symbol {
-    fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> &str {
         self.content.as_str()
     }
 }
@@ -426,8 +426,8 @@ impl Handle<File> {
 #[repr(C)]
 #[derive(Clone, Copy, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct NodeID {
-    file: ControlledOption<Handle<File>>,
-    local_id: u32,
+    pub(crate) file: ControlledOption<Handle<File>>,
+    pub(crate) local_id: u32,
 }
 
 const ROOT_NODE_ID: u32 = 1;

--- a/stack-graphs/src/json.rs
+++ b/stack-graphs/src/json.rs
@@ -1,0 +1,494 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2022, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use lsp_positions::Offset;
+use lsp_positions::Position;
+use lsp_positions::Span;
+use serde::ser::Serialize;
+use serde::ser::SerializeSeq;
+use serde::ser::SerializeStruct;
+use serde::ser::Serializer;
+use std::ops::Index;
+use thiserror::Error;
+
+use crate::arena::Handle;
+use crate::graph::Edge;
+use crate::graph::File;
+use crate::graph::Node;
+use crate::graph::NodeID;
+use crate::graph::SourceInfo;
+use crate::graph::StackGraph;
+use crate::graph::Symbol;
+use crate::paths::Path;
+use crate::paths::PathEdge;
+use crate::paths::PathEdgeList;
+use crate::paths::Paths;
+use crate::paths::ScopeStack;
+use crate::paths::ScopedSymbol;
+use crate::paths::SymbolStack;
+
+#[derive(Debug, Error)]
+#[error(transparent)]
+pub struct JsonError(#[from] serde_json::error::Error);
+
+//-----------------------------------------------------------------------------
+// InStackGraph
+
+struct InStackGraph<'a, T>(T, &'a StackGraph);
+
+impl<'a, T> InStackGraph<'a, T> {
+    fn with<U>(&'a self, u: U) -> InStackGraph<'a, U> {
+        InStackGraph(u, self.1)
+    }
+
+    fn with_idx<Idx: Copy, U: ?Sized>(&'a self, idx: Idx) -> InStackGraph<'a, (Idx, &U)>
+    where
+        StackGraph: Index<Idx, Output = U>,
+    {
+        InStackGraph((idx, &self.1[idx]), self.1)
+    }
+}
+
+//-----------------------------------------------------------------------------
+// StackGraph
+
+impl StackGraph {
+    pub fn to_json_string(&self) -> Result<String, JsonError> {
+        Ok(serde_json::to_string(self)?)
+    }
+
+    pub fn to_json_string_pretty(&self) -> Result<String, JsonError> {
+        Ok(serde_json::to_string_pretty(self)?)
+    }
+}
+
+impl Serialize for StackGraph {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut ser = serializer.serialize_struct("stack_graph", 2)?;
+        ser.serialize_field("files", &InStackGraph(&Files, self))?;
+        ser.serialize_field("nodes", &InStackGraph(&Nodes, self))?;
+        ser.serialize_field("edges", &InStackGraph(&Edges, self))?;
+        ser.end()
+    }
+}
+
+//-----------------------------------------------------------------------------
+// Files
+
+struct Files;
+
+impl Serialize for InStackGraph<'_, &Files> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let graph = self.1;
+
+        let mut ser = serializer.serialize_seq(None)?;
+        for file in graph.iter_files() {
+            ser.serialize_element(&self.with_idx(file))?;
+        }
+        ser.end()
+    }
+}
+
+impl Serialize for InStackGraph<'_, (Handle<File>, &File)> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let file = self.0 .1;
+        serializer.serialize_str(file.name())
+    }
+}
+
+//-----------------------------------------------------------------------------
+// Nodes
+
+struct Nodes;
+
+impl Serialize for InStackGraph<'_, &Nodes> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut nodes = serializer.serialize_seq(None)?;
+        for node in self.1.iter_nodes() {
+            nodes.serialize_element(&self.with_idx(node))?;
+        }
+        nodes.end()
+    }
+}
+
+impl Serialize for InStackGraph<'_, (Handle<Node>, &Node)> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let graph = self.1;
+        let handle = self.0 .0;
+        let node = self.0 .1;
+        let source_info = graph.source_info(handle);
+
+        let mut len = 2;
+        if source_info.is_some() {
+            len += 1;
+        }
+
+        let mut ser = match node {
+            Node::DropScopes(_node) => {
+                let mut ser = serializer.serialize_struct("node", len + 1)?;
+                ser.serialize_field("type", "drop_scopes")?;
+                ser
+            }
+            Node::JumpTo(_node) => {
+                let mut ser = serializer.serialize_struct("node", len + 1)?;
+                ser.serialize_field("type", "jump_to_scope")?;
+                ser
+            }
+            Node::PopScopedSymbol(node) => {
+                let mut ser = serializer.serialize_struct("node", len + 3)?;
+                ser.serialize_field("type", "pop_scoped_symbol")?;
+                ser.serialize_field("symbol", &graph[node.symbol])?;
+                ser.serialize_field("is_definition", &node.is_definition)?;
+                ser
+            }
+            Node::PopSymbol(node) => {
+                let mut ser = serializer.serialize_struct("node", len + 3)?;
+                ser.serialize_field("type", "pop_symbol")?;
+                ser.serialize_field("symbol", &graph[node.symbol])?;
+                ser.serialize_field("is_definition", &node.is_definition)?;
+                ser
+            }
+            Node::PushScopedSymbol(node) => {
+                let mut ser = serializer.serialize_struct("node", len + 4)?;
+                ser.serialize_field("type", "push_symbol")?;
+                ser.serialize_field("symbol", &graph[node.symbol])?;
+                ser.serialize_field("scope", &graph[node.symbol])?;
+                ser.serialize_field("is_reference", &node.is_reference)?;
+                ser
+            }
+            Node::PushSymbol(node) => {
+                let mut ser = serializer.serialize_struct("node", len + 3)?;
+                ser.serialize_field("type", "push_scoped_symbol")?;
+                ser.serialize_field("symbol", &graph[node.symbol])?;
+                ser.serialize_field("is_reference", &node.is_reference)?;
+                ser
+            }
+            Node::Root(_node) => {
+                let mut ser = serializer.serialize_struct("node", len + 1)?;
+                ser.serialize_field("type", "root")?;
+                ser
+            }
+            Node::Scope(node) => {
+                let mut ser = serializer.serialize_struct("node", len + 2)?;
+                ser.serialize_field("type", "scope")?;
+                ser.serialize_field("is_exported", &node.is_exported)?;
+                ser
+            }
+        };
+
+        ser.serialize_field("id", &self.with(&node.id()))?;
+        if let Some(source_info) = source_info {
+            ser.serialize_field("source_info", &self.with(source_info))?;
+        }
+
+        ser.end()
+    }
+}
+
+impl Serialize for InStackGraph<'_, &NodeID> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let node_id = self.0;
+
+        let len = 1 + node_id.file.into_option().map(|_| 1).unwrap_or(0);
+        let mut ser = serializer.serialize_struct("node_id", len)?;
+        if let Some(file) = node_id.file.into_option() {
+            ser.serialize_field("file", &self.with_idx(file))?;
+        }
+        ser.serialize_field("local_id", &node_id.local_id)?;
+        ser.end()
+    }
+}
+
+impl Serialize for InStackGraph<'_, &Symbol> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let symbol = self.0;
+        serializer.serialize_str(symbol.as_str())
+    }
+}
+
+impl Serialize for InStackGraph<'_, &SourceInfo> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let graph = self.1;
+        let source_info = self.0;
+
+        let mut len = 1;
+        if source_info.syntax_type.is_some() {
+            len += 1;
+        }
+
+        let mut ser = serializer.serialize_struct("source_info", len)?;
+        ser.serialize_field("span", &self.with(&source_info.span))?;
+        if let Some(syntax_type) = source_info.syntax_type {
+            ser.serialize_field("syntax_type", &graph[syntax_type])?;
+        }
+        ser.end()
+    }
+}
+
+//-----------------------------------------------------------------------------
+// Edges
+
+struct Edges;
+
+impl Serialize for InStackGraph<'_, &Edges> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut ser = serializer.serialize_seq(None)?;
+        for source in self.1.iter_nodes() {
+            for edge in self.1.outgoing_edges(source) {
+                ser.serialize_element(&self.with(&edge))?;
+            }
+        }
+        ser.end()
+    }
+}
+
+impl Serialize for InStackGraph<'_, &Edge> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let graph = self.1;
+        let edge = self.0;
+
+        let mut ser = serializer.serialize_struct("edge", 3)?;
+        ser.serialize_field("source", &self.with(&graph[edge.source].id()))?;
+        ser.serialize_field("sink", &self.with(&graph[edge.sink].id()))?;
+        ser.serialize_field("precedence", &edge.precedence)?;
+        ser.end()
+    }
+}
+
+//-----------------------------------------------------------------------------
+// Span, Position, Offset
+
+impl Serialize for InStackGraph<'_, &Span> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut ser = serializer.serialize_struct("span", 2)?;
+        ser.serialize_field("start", &self.with(&self.0.start))?;
+        ser.serialize_field("end", &self.with(&self.0.end))?;
+        ser.end()
+    }
+}
+
+impl Serialize for InStackGraph<'_, &Position> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let position = self.0;
+
+        let mut ser = serializer.serialize_struct("position", 2)?;
+        ser.serialize_field("line", &position.line)?;
+        ser.serialize_field("column", &self.with(&position.column))?;
+        ser.end()
+    }
+}
+
+impl Serialize for InStackGraph<'_, &Offset> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let offset = self.0;
+
+        let mut ser = serializer.serialize_struct("offset", 3)?;
+        ser.serialize_field("utf8_offset", &offset.utf8_offset)?;
+        ser.serialize_field("utf16_offset", &offset.utf16_offset)?;
+        ser.serialize_field("grapheme_offset", &offset.grapheme_offset)?;
+        ser.end()
+    }
+}
+
+//-----------------------------------------------------------------------------
+// InPaths
+
+struct InPaths<'a, T>(T, &'a Paths, &'a StackGraph);
+
+impl<'a, T> InPaths<'a, T> {
+    fn with<U>(&'a self, u: U) -> InPaths<'a, U> {
+        InPaths(u, self.1, self.2)
+    }
+
+    fn in_stack_graph(&'a self) -> InStackGraph<'a, T>
+    where
+        T: Copy,
+    {
+        InStackGraph(self.0, self.2)
+    }
+}
+
+//-----------------------------------------------------------------------------
+// Paths
+
+impl Paths {
+    pub fn to_json_string(&mut self, graph: &StackGraph) -> Result<String, JsonError> {
+        let paths = self.to_path_vec(graph);
+        Ok(serde_json::to_string(&InPaths(&paths, self, graph))?)
+    }
+
+    pub fn to_json_string_pretty(&mut self, graph: &StackGraph) -> Result<String, JsonError> {
+        let paths = self.to_path_vec(graph);
+        Ok(serde_json::to_string_pretty(&InPaths(&paths, self, graph))?)
+    }
+
+    fn to_path_vec(&mut self, graph: &StackGraph) -> Vec<Path> {
+        let mut paths = Vec::new();
+        self.find_all_paths(graph, graph.iter_nodes(), |_g, _ps, p| {
+            paths.push(p);
+        });
+        paths
+    }
+}
+
+impl Serialize for InPaths<'_, &Vec<Path>> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let paths = self.0;
+
+        let mut ser = serializer.serialize_seq(paths.len().into())?;
+        for path in paths {
+            ser.serialize_element(&self.with(path))?;
+        }
+        ser.end()
+    }
+}
+
+impl Serialize for InPaths<'_, &Path> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let path = self.0;
+
+        let mut ser = serializer.serialize_struct("path", 5)?;
+        ser.serialize_field(
+            "start_node",
+            &self.in_stack_graph().with_idx(path.start_node),
+        )?;
+        ser.serialize_field("end_node", &self.in_stack_graph().with_idx(path.end_node))?;
+        ser.serialize_field("symbol_stack", &self.with(&path.symbol_stack))?;
+        ser.serialize_field("scope_stack", &self.with(&path.scope_stack))?;
+        ser.serialize_field("edges", &self.with(&path.edges))?;
+        ser.end()
+    }
+}
+
+impl Serialize for InPaths<'_, &SymbolStack> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let symbol_stack = self.0;
+        let paths = self.1;
+
+        let mut ser = serializer.serialize_seq(symbol_stack.len().into())?;
+        for scoped_symbol in symbol_stack.iter(paths) {
+            ser.serialize_element(&self.with(&scoped_symbol))?;
+        }
+        ser.end()
+    }
+}
+
+impl Serialize for InPaths<'_, &ScopedSymbol> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let scoped_symbol = self.0;
+        let graph = self.2;
+
+        let mut len = 1;
+        if scoped_symbol.scopes.is_some() {
+            len += 1;
+        }
+
+        let mut ser = serializer.serialize_struct("scoped_symbol", len)?;
+        ser.serialize_field("symbol", &graph[scoped_symbol.symbol])?;
+        if let Some(scope_stack) = scoped_symbol.scopes.into_option() {
+            ser.serialize_field("scoped_stack", &self.with(&scope_stack))?;
+        }
+        ser.end()
+    }
+}
+
+impl Serialize for InPaths<'_, &ScopeStack> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let scoped_stack = self.0;
+        let paths = self.1;
+
+        let mut ser = serializer.serialize_seq(scoped_stack.len().into())?;
+        for node in scoped_stack.iter(paths) {
+            ser.serialize_element(&self.in_stack_graph().with_idx(node))?;
+        }
+        ser.end()
+    }
+}
+
+impl Serialize for InPaths<'_, &PathEdgeList> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let edge_list = self.0;
+        let paths = self.1;
+
+        let mut ser = serializer.serialize_seq(edge_list.len().into())?;
+        for edge in edge_list.iter_unordered(paths) {
+            ser.serialize_element(&self.with(&edge))?;
+        }
+        ser.end()
+    }
+}
+
+impl Serialize for InPaths<'_, &PathEdge> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let edge = self.0;
+
+        let mut ser = serializer.serialize_struct("path_edge", 2)?;
+        ser.serialize_field("source", &self.in_stack_graph().with(&edge.source_node_id))?;
+        ser.serialize_field("precedence", &edge.precedence)?;
+        ser.end()
+    }
+}

--- a/stack-graphs/src/lib.rs
+++ b/stack-graphs/src/lib.rs
@@ -61,6 +61,8 @@ pub mod cycles;
 #[macro_use]
 mod debugging;
 pub mod graph;
+#[cfg(feature = "json")]
+pub mod json;
 pub mod partial;
 pub mod paths;
 pub mod stitching;

--- a/stack-graphs/tests/it/arena.rs
+++ b/stack-graphs/tests/it/arena.rs
@@ -51,7 +51,7 @@ fn can_create_lists() {
 
     let mut arena = List::new_arena();
     let mut list = List::empty();
-    assert_eq!(collect(&list, &arena), vec![]);
+    assert_eq!(collect(&list, &arena), vec![] as Vec<u32>);
     list.push_front(&mut arena, 1);
     assert_eq!(collect(&list, &arena), vec![1]);
     list.push_front(&mut arena, 2);
@@ -95,7 +95,7 @@ fn can_create_reversible_lists() {
 
     let mut arena = ReversibleList::new_arena();
     let mut list = ReversibleList::empty();
-    assert_eq!(collect(&list, &arena), vec![]);
+    assert_eq!(collect(&list, &arena), vec![] as Vec<u32>);
     list.push_front(&mut arena, 1);
     assert_eq!(collect(&list, &arena), vec![1]);
     list.push_front(&mut arena, 2);
@@ -158,8 +158,8 @@ fn can_create_deques() {
 
     let mut arena = Deque::new_arena();
     let mut deque = Deque::empty();
-    assert_eq!(collect(&deque, &mut arena), vec![]);
-    assert_eq!(collect_rev(&deque, &mut arena), vec![]);
+    assert_eq!(collect(&deque, &mut arena), vec![] as Vec<u32>);
+    assert_eq!(collect_rev(&deque, &mut arena), vec![] as Vec<u32>);
     deque.push_front(&mut arena, 1);
     assert_eq!(collect(&deque, &mut arena), vec![1]);
     assert_eq!(collect_rev(&deque, &mut arena), vec![1]);

--- a/stack-graphs/tests/it/c/nodes.rs
+++ b/stack-graphs/tests/it/c/nodes.rs
@@ -107,7 +107,7 @@ fn jump_to_node() -> sg_node {
             local_id: SG_JUMP_TO_NODE_ID,
         },
         symbol: SG_NULL_HANDLE,
-        is_clickable: false,
+        is_endpoint: false,
         scope: sg_node_id::default(),
     }
 }
@@ -120,7 +120,7 @@ fn root_node() -> sg_node {
             local_id: SG_ROOT_NODE_ID,
         },
         symbol: SG_NULL_HANDLE,
-        is_clickable: false,
+        is_endpoint: false,
         scope: sg_node_id::default(),
     }
 }
@@ -175,7 +175,7 @@ fn drop_scopes(file: sg_file_handle, local_id: u32) -> sg_node {
         kind: sg_node_kind::SG_NODE_KIND_DROP_SCOPES,
         id: sg_node_id { file, local_id },
         symbol: SG_NULL_HANDLE,
-        is_clickable: false,
+        is_endpoint: false,
         scope: sg_node_id::default(),
     }
 }
@@ -237,10 +237,10 @@ fn drop_scopes_cannot_have_scope() {
 
 fn exported_scope(file: sg_file_handle, local_id: u32) -> sg_node {
     sg_node {
-        kind: sg_node_kind::SG_NODE_KIND_EXPORTED_SCOPE,
+        kind: sg_node_kind::SG_NODE_KIND_SCOPE,
         id: sg_node_id { file, local_id },
         symbol: SG_NULL_HANDLE,
-        is_clickable: false,
+        is_endpoint: true,
         scope: sg_node_id::default(),
     }
 }
@@ -255,7 +255,8 @@ fn can_add_exported_scope_node() {
     sg_stack_graph_get_or_create_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     let node_arena = sg_stack_graph_nodes(graph);
     let node = get_node(&node_arena, handles[0]);
-    assert!(matches!(node, Node::ExportedScope(_)));
+    assert!(matches!(node, Node::Scope(_)));
+    assert!(node.is_exported());
     assert!(node.id() == node_id(file, 42));
     // Make sure that we get the same handle if we add the node again.
     let mut new_handles: [sg_node_handle; 1] = [SG_NULL_HANDLE; 1];
@@ -302,10 +303,10 @@ fn exported_scope_cannot_have_scope() {
 
 fn internal_scope(file: sg_file_handle, local_id: u32) -> sg_node {
     sg_node {
-        kind: sg_node_kind::SG_NODE_KIND_INTERNAL_SCOPE,
+        kind: sg_node_kind::SG_NODE_KIND_SCOPE,
         id: sg_node_id { file, local_id },
         symbol: SG_NULL_HANDLE,
-        is_clickable: false,
+        is_endpoint: false,
         scope: sg_node_id::default(),
     }
 }
@@ -320,7 +321,8 @@ fn can_add_internal_scope_node() {
     sg_stack_graph_get_or_create_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     let node_arena = sg_stack_graph_nodes(graph);
     let node = get_node(&node_arena, handles[0]);
-    assert!(matches!(node, Node::InternalScope(_)));
+    assert!(matches!(node, Node::Scope(_)));
+    assert!(!node.is_exported());
     assert!(node.id() == node_id(file, 42));
     // Make sure that we get the same handle if we add the node again.
     let mut new_handles: [sg_node_handle; 1] = [SG_NULL_HANDLE; 1];
@@ -370,7 +372,7 @@ fn pop_scoped_symbol(file: sg_file_handle, local_id: u32, symbol: sg_symbol_hand
         kind: sg_node_kind::SG_NODE_KIND_POP_SCOPED_SYMBOL,
         id: sg_node_id { file, local_id },
         symbol,
-        is_clickable: true,
+        is_endpoint: true,
         scope: sg_node_id::default(),
     }
 }
@@ -437,7 +439,7 @@ fn pop_symbol(file: sg_file_handle, local_id: u32, symbol: sg_symbol_handle) -> 
         kind: sg_node_kind::SG_NODE_KIND_POP_SYMBOL,
         id: sg_node_id { file, local_id },
         symbol,
-        is_clickable: true,
+        is_endpoint: true,
         scope: sg_node_id::default(),
     }
 }
@@ -514,7 +516,7 @@ fn push_scoped_symbol(
         kind: sg_node_kind::SG_NODE_KIND_PUSH_SCOPED_SYMBOL,
         id: sg_node_id { file, local_id },
         symbol,
-        is_clickable: true,
+        is_endpoint: true,
         scope,
     }
 }
@@ -590,7 +592,7 @@ fn push_symbol(file: sg_file_handle, local_id: u32, symbol: sg_symbol_handle) ->
         kind: sg_node_kind::SG_NODE_KIND_PUSH_SYMBOL,
         id: sg_node_id { file, local_id },
         symbol,
-        is_clickable: true,
+        is_endpoint: true,
         scope: sg_node_id::default(),
     }
 }

--- a/stack-graphs/tests/it/c/partial.rs
+++ b/stack-graphs/tests/it/c/partial.rs
@@ -77,10 +77,10 @@ fn add_exported_scope(
     local_id: u32,
 ) -> sg_node_handle {
     let node = sg_node {
-        kind: sg_node_kind::SG_NODE_KIND_EXPORTED_SCOPE,
+        kind: sg_node_kind::SG_NODE_KIND_SCOPE,
         id: sg_node_id { file, local_id },
         symbol: SG_NULL_HANDLE,
-        is_clickable: false,
+        is_endpoint: true,
         scope: sg_node_id::default(),
     };
     let nodes = [node];

--- a/stack-graphs/tests/it/c/paths.rs
+++ b/stack-graphs/tests/it/c/paths.rs
@@ -77,10 +77,10 @@ fn add_exported_scope(
     local_id: u32,
 ) -> sg_node_handle {
     let node = sg_node {
-        kind: sg_node_kind::SG_NODE_KIND_EXPORTED_SCOPE,
+        kind: sg_node_kind::SG_NODE_KIND_SCOPE,
         id: sg_node_id { file, local_id },
         symbol: SG_NULL_HANDLE,
-        is_clickable: false,
+        is_endpoint: true,
         scope: sg_node_id::default(),
     };
     let nodes = [node];

--- a/stack-graphs/tests/it/c/test_graph.rs
+++ b/stack-graphs/tests/it/c/test_graph.rs
@@ -72,7 +72,7 @@ impl CreateStackGraph for TestGraph {
             kind: sg_node_kind::SG_NODE_KIND_POP_SYMBOL,
             id: sg_node_id { file, local_id },
             symbol,
-            is_clickable: true,
+            is_endpoint: true,
             scope: sg_node_id::default(),
         })
     }
@@ -82,7 +82,7 @@ impl CreateStackGraph for TestGraph {
             kind: sg_node_kind::SG_NODE_KIND_DROP_SCOPES,
             id: sg_node_id { file, local_id },
             symbol: SG_NULL_HANDLE,
-            is_clickable: false,
+            is_endpoint: false,
             scope: sg_node_id::default(),
         })
     }
@@ -99,10 +99,10 @@ impl CreateStackGraph for TestGraph {
 
     fn exported_scope(&mut self, file: sg_file_handle, local_id: u32) -> sg_node_handle {
         self.add_node(sg_node {
-            kind: sg_node_kind::SG_NODE_KIND_EXPORTED_SCOPE,
+            kind: sg_node_kind::SG_NODE_KIND_SCOPE,
             id: sg_node_id { file, local_id },
             symbol: SG_NULL_HANDLE,
-            is_clickable: false,
+            is_endpoint: true,
             scope: sg_node_id::default(),
         })
     }
@@ -122,10 +122,10 @@ impl CreateStackGraph for TestGraph {
 
     fn internal_scope(&mut self, file: sg_file_handle, local_id: u32) -> sg_node_handle {
         self.add_node(sg_node {
-            kind: sg_node_kind::SG_NODE_KIND_INTERNAL_SCOPE,
+            kind: sg_node_kind::SG_NODE_KIND_SCOPE,
             id: sg_node_id { file, local_id },
             symbol: SG_NULL_HANDLE,
-            is_clickable: false,
+            is_endpoint: false,
             scope: sg_node_id::default(),
         })
     }
@@ -144,7 +144,7 @@ impl CreateStackGraph for TestGraph {
             kind: sg_node_kind::SG_NODE_KIND_POP_SCOPED_SYMBOL,
             id: sg_node_id { file, local_id },
             symbol,
-            is_clickable: false,
+            is_endpoint: false,
             scope: sg_node_id::default(),
         })
     }
@@ -159,7 +159,7 @@ impl CreateStackGraph for TestGraph {
             kind: sg_node_kind::SG_NODE_KIND_POP_SYMBOL,
             id: sg_node_id { file, local_id },
             symbol,
-            is_clickable: false,
+            is_endpoint: false,
             scope: sg_node_id::default(),
         })
     }
@@ -180,7 +180,7 @@ impl CreateStackGraph for TestGraph {
             kind: sg_node_kind::SG_NODE_KIND_PUSH_SCOPED_SYMBOL,
             id: sg_node_id { file, local_id },
             symbol,
-            is_clickable: false,
+            is_endpoint: false,
             scope,
         })
     }
@@ -195,7 +195,7 @@ impl CreateStackGraph for TestGraph {
             kind: sg_node_kind::SG_NODE_KIND_PUSH_SYMBOL,
             id: sg_node_id { file, local_id },
             symbol,
-            is_clickable: false,
+            is_endpoint: false,
             scope: sg_node_id::default(),
         })
     }
@@ -210,7 +210,7 @@ impl CreateStackGraph for TestGraph {
             kind: sg_node_kind::SG_NODE_KIND_PUSH_SYMBOL,
             id: sg_node_id { file, local_id },
             symbol,
-            is_clickable: true,
+            is_endpoint: true,
             scope: sg_node_id::default(),
         })
     }

--- a/stack-graphs/tests/it/partial.rs
+++ b/stack-graphs/tests/it/partial.rs
@@ -337,7 +337,7 @@ fn create_scope_stack(
         let node_id = NodeID::new_in_file(file, *scope);
         let node = match graph.node_for_id(node_id) {
             Some(node) => node,
-            None => graph.add_exported_scope_node(node_id).unwrap(),
+            None => graph.add_scope_node(node_id, true).unwrap(),
         };
         stack.push_back(partials, node);
     }

--- a/stack-graphs/tests/it/test_graphs/mod.rs
+++ b/stack-graphs/tests/it/test_graphs/mod.rs
@@ -87,7 +87,7 @@ impl CreateStackGraph for StackGraph {
     }
 
     fn exported_scope(&mut self, file: Handle<File>, local_id: u32) -> Handle<Node> {
-        self.add_exported_scope_node(NodeID::new_in_file(file, local_id))
+        self.add_scope_node(NodeID::new_in_file(file, local_id), true)
             .expect("Duplicate node ID")
     }
 
@@ -96,7 +96,7 @@ impl CreateStackGraph for StackGraph {
     }
 
     fn internal_scope(&mut self, file: Handle<File>, local_id: u32) -> Handle<Node> {
-        self.add_internal_scope_node(NodeID::new_in_file(file, local_id))
+        self.add_scope_node(NodeID::new_in_file(file, local_id), false)
             .expect("Duplicate node ID")
     }
 

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -17,6 +17,7 @@ edition = "2018"
 test = false
 
 [dependencies]
+anyhow = "1.0"
 controlled-option = ">=0.4"
 lazy_static = "1.4"
 lsp-positions = { version="0.1", path="../lsp-positions" }
@@ -24,7 +25,9 @@ regex = "1"
 stack-graphs = { version="0.4", path="../stack-graphs" }
 thiserror = "1.0"
 tree-sitter = ">= 0.19"
+tree-sitter-config = "0.19"
 tree-sitter-graph = "0.3"
+tree-sitter-loader = "0.20"
 
 [dev-dependencies]
 pretty_assertions = "0.7"

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "tree-sitter-stack-graphs"
+version = "0.0.0"
+description = "Create stack graphs using tree-sitter parsers"
+homepage = "https://github.com/github/stack-graphs/tree-sitter-stack-graphs"
+repository = "https://github.com/github/stack-graphs/"
+readme = "README.md"
+license = "MIT OR Apache-2.0"
+authors = [
+  "GitHub <opensource+stack-graphs@github.com>",
+  "Douglas Creager <dcreager@dcreager.net>"
+]
+edition = "2018"
+
+[lib]
+# All of our tests are in the tests/it "integration" test executable.
+test = false
+
+[dependencies]
+stack-graphs = { version="0.4", path="../stack-graphs" }
+tree-sitter-graph = "0.3"

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -18,7 +18,9 @@ test = false
 
 [dependencies]
 controlled-option = ">=0.4"
+lazy_static = "1.4"
 lsp-positions = { version="0.1", path="../lsp-positions" }
+regex = "1"
 stack-graphs = { version="0.4", path="../stack-graphs" }
 thiserror = "1.0"
 tree-sitter = ">= 0.19"

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -17,5 +17,12 @@ edition = "2018"
 test = false
 
 [dependencies]
+lsp-positions = { version="0.1", path="../lsp-positions" }
 stack-graphs = { version="0.4", path="../stack-graphs" }
+thiserror = "1.0"
+tree-sitter = ">= 0.19"
 tree-sitter-graph = "0.3"
+
+[dev-dependencies]
+pretty_assertions = "0.7"
+tree-sitter-python = "0.19.1"

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -17,6 +17,7 @@ edition = "2018"
 test = false
 
 [dependencies]
+controlled-option = ">=0.4"
 lsp-positions = { version="0.1", path="../lsp-positions" }
 stack-graphs = { version="0.4", path="../stack-graphs" }
 thiserror = "1.0"

--- a/tree-sitter-stack-graphs/README.md
+++ b/tree-sitter-stack-graphs/README.md
@@ -1,0 +1,28 @@
+# tree-sitter-stack-graphs
+
+The `tree-sitter-stack-graphs` crate lets you create stack graphs using the
+[tree-sitter][] grammar for a language.
+
+[tree-sitter]: https://tree-sitter.github.io/
+
+To use this library, add the following to your `Cargo.toml`:
+
+``` toml
+[dependencies]
+tree-sitter-stack-graphs = "0.0"
+```
+
+Check out our [documentation](https://docs.rs/tree-sitter-stack-graphs/*/) for
+more details on how to use this library.
+
+## License
+
+Licensed under either of
+
+  - [Apache License, Version 2.0][apache] ([LICENSE-APACHE](LICENSE-APACHE))
+  - [MIT license][mit] ([LICENSE-MIT](LICENSE-MIT))
+
+at your option.
+
+[apache]: http://www.apache.org/licenses/LICENSE-2.0
+[mit]: http://opensource.org/licenses/MIT

--- a/tree-sitter-stack-graphs/src/assert.rs
+++ b/tree-sitter-stack-graphs/src/assert.rs
@@ -1,0 +1,289 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use std::collections::BTreeSet;
+use std::fmt;
+use std::slice;
+
+use lazy_static::lazy_static;
+use lsp_positions::Offset;
+use lsp_positions::Position;
+use lsp_positions::PositionedSubstring;
+use lsp_positions::SpanCalculator;
+use regex::Regex;
+use stack_graphs::arena::Handle;
+use stack_graphs::graph::File;
+use stack_graphs::graph::StackGraph;
+use stack_graphs::paths::Paths;
+use thiserror::Error;
+
+lazy_static! {
+    static ref ASSERTION_REGEX: Regex =
+        Regex::new(r#"(\^)\s*defined:(\s*\d+(?:\s*,\s*\d+)*)?"#).unwrap();
+    static ref LINE_NUMBER_REGEX: Regex = Regex::new(r#"\d+"#).unwrap();
+}
+
+/// An error that can occur while parsing and executing assertions
+#[derive(Debug, Error)]
+pub enum ParseError {
+    #[error("Assertion cannot appear on first line")]
+    AssertionOnFirstLine,
+    #[error("Assertion on line {0} refers to missing column {1} on line {2}")]
+    InvalidColumn(usize, usize, usize),
+}
+
+#[derive(Debug, Clone)]
+pub struct Assertions {
+    file: Handle<File>,
+    values: Vec<Assertion>,
+}
+
+#[derive(Debug, Clone)]
+pub enum Assertion {
+    Defined(Position, LineNumbers),
+}
+
+impl Assertions {
+    pub fn from_source(file: Handle<File>, source: &str) -> std::result::Result<Self, ParseError> {
+        let mut result = Assertions {
+            file,
+            values: Vec::new(),
+        };
+
+        let source_length = Offset::string_length(source);
+        let mut next_line_utf8_offset = 0;
+        let mut next_line_number = 0;
+        let mut current_line_span_calculator = SpanCalculator::new(source);
+        let mut last_regular_line = None;
+        let mut last_regular_line_number = None;
+        let mut last_regular_line_span_calculator = SpanCalculator::new(source);
+        while next_line_utf8_offset < source_length.utf8_offset {
+            let current_line = PositionedSubstring::from_line(source, next_line_utf8_offset);
+            let current_line_number = next_line_number;
+            // FIXME Line bounds are without newline, therefore we add 1 (assuming a single `\n` newline).
+            //       Should a line include its newline, should there be a method returning the full line including
+            //       newline, or should lsp-positions provide a more convenient way to iterate over lines (in which
+            //       case lines can be without newline, but the user does not have to think about that)?
+            next_line_utf8_offset = current_line.utf8_bounds.end + 1;
+            next_line_number += 1;
+
+            let mut matches = ASSERTION_REGEX
+                .captures_iter(current_line.content)
+                .peekable();
+            if matches.peek().is_none() {
+                // regular source line
+                last_regular_line = Some(current_line);
+                last_regular_line_number = Some(current_line_number);
+            } else {
+                // assertion line
+                let last_regular_line = last_regular_line
+                    .as_ref()
+                    .ok_or_else(|| ParseError::AssertionOnFirstLine)?;
+                let last_regular_line_number = last_regular_line_number.unwrap();
+
+                while let Some(m) = matches.next() {
+                    let carret_match = m.get(1).unwrap();
+                    let line_numbers_match = m.get(2);
+
+                    let column_utf8_offset = carret_match.start();
+                    let column_grapheme_offset = current_line_span_calculator
+                        .for_line_and_column(
+                            current_line_number,
+                            current_line.utf8_bounds.start,
+                            column_utf8_offset,
+                        )
+                        .column
+                        .grapheme_offset;
+                    if column_grapheme_offset >= last_regular_line.grapheme_length {
+                        return Err(ParseError::InvalidColumn(
+                            current_line_number + 1,
+                            column_grapheme_offset + 1,
+                            last_regular_line_number + 1,
+                        ));
+                    }
+                    let position = last_regular_line_span_calculator.for_line_and_grapheme(
+                        last_regular_line_number,
+                        last_regular_line.utf8_bounds.start,
+                        column_grapheme_offset,
+                    );
+
+                    let mut line_numbers = LineNumbers::new();
+                    for l in LINE_NUMBER_REGEX
+                        .find_iter(line_numbers_match.map(|m| m.as_str()).unwrap_or(""))
+                    {
+                        line_numbers.insert(l.as_str().parse::<usize>().unwrap() - 1);
+                    }
+
+                    result
+                        .values
+                        .push(Assertion::Defined(position, line_numbers));
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    pub fn count(&self) -> usize {
+        self.values.len()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LineNumbers(BTreeSet<usize>);
+
+impl LineNumbers {
+    fn new() -> Self {
+        Self(BTreeSet::new())
+    }
+
+    fn insert(&mut self, line_number: usize) {
+        self.0.insert(line_number);
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl fmt::Display for LineNumbers {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut first = true;
+        for line_number in &self.0 {
+            if first {
+                first = false;
+                write!(f, "{}", line_number + 1)?;
+            } else {
+                write!(f, ", {}", line_number + 1)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct Results {
+    pub values: Vec<Result>,
+    pub success_count: usize,
+    pub failure_count: usize,
+}
+
+#[derive(Debug)]
+pub enum Result {
+    Success,
+    Failure(AssertError),
+}
+
+#[derive(Debug, Error)]
+pub enum AssertError {
+    #[error("{0}:{1}:{2}: no references found")]
+    NoReferencesFound(String, usize, usize),
+    #[error("{0}:{1}:{2}: expected {3}, but found {4}")]
+    WrongDefinitions(String, usize, usize, String, String),
+}
+
+impl Results {
+    fn add_success(&mut self) {
+        self.values.push(Result::Success);
+        self.success_count += 1;
+    }
+
+    fn add_failure(&mut self, reason: AssertError) {
+        self.values.push(Result::Failure(reason));
+        self.failure_count += 1;
+    }
+
+    pub fn success_count(&self) -> usize {
+        self.success_count
+    }
+
+    pub fn failure_count(&self) -> usize {
+        self.failure_count
+    }
+}
+
+impl IntoIterator for Results {
+    type Item = Result;
+    type IntoIter = std::vec::IntoIter<Result>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.values.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a Results {
+    type Item = &'a Result;
+    type IntoIter = slice::Iter<'a, Result>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.values.iter()
+    }
+}
+
+impl Assertions {
+    pub fn run(&self, graph: &StackGraph, paths: &mut Paths) -> Results {
+        let mut result = Results {
+            values: Vec::new(),
+            success_count: 0,
+            failure_count: 0,
+        };
+
+        for assertion in &self.values {
+            match assertion {
+                Assertion::Defined(position, expected_line_numbers) => {
+                    let references = graph
+                        .nodes_for_file(self.file)
+                        .filter(|n| {
+                            graph[*n].is_reference()
+                                && graph
+                                    .source_info(*n)
+                                    .map(|s| s.span.contains(position.clone()))
+                                    .unwrap_or(false)
+                        })
+                        .collect::<Vec<_>>();
+                    if references.is_empty() {
+                        result.add_failure(AssertError::NoReferencesFound(
+                            graph[self.file].to_string(),
+                            position.line + 1,
+                            position.column.grapheme_offset + 1,
+                        ));
+                    } else {
+                        let mut actual_line_numbers = LineNumbers::new();
+                        paths.find_all_paths(graph, references.clone(), |g, _ps, p| {
+                            if p.is_complete(g) {
+                                let si = graph.source_info(p.end_node).unwrap();
+                                actual_line_numbers.insert(si.span.start.line);
+                            }
+                        });
+                        if *expected_line_numbers == actual_line_numbers {
+                            result.add_success();
+                        } else {
+                            let reference = graph[references[0]].symbol().unwrap().display(&graph);
+                            result.add_failure(AssertError::WrongDefinitions(
+                                graph[self.file].to_string(),
+                                position.line + 1,
+                                position.column.grapheme_offset + 1,
+                                if expected_line_numbers.is_empty() {
+                                    format!("no definitions for '{}'", reference,)
+                                } else {
+                                    format!(
+                                        "definitions for '{}' on lines {}",
+                                        reference, *expected_line_numbers,
+                                    )
+                                },
+                                if actual_line_numbers.is_empty() {
+                                    format!("no definitions")
+                                } else {
+                                    format!("definitions on lines {}", actual_line_numbers,)
+                                },
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        result
+    }
+}

--- a/tree-sitter-stack-graphs/src/functions.rs
+++ b/tree-sitter-stack-graphs/src/functions.rs
@@ -1,0 +1,101 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use tree_sitter_graph::functions::Functions;
+
+pub fn add_path_functions(functions: &mut Functions) {
+    functions.add("normalize-path".into(), path::NormalizePath);
+    functions.add("resolve-path".into(), path::ResolvePath);
+}
+
+pub mod path {
+    use std::path::Component;
+    use std::path::Path;
+    use std::path::PathBuf;
+    use tree_sitter_graph::functions::Function;
+    use tree_sitter_graph::functions::Parameters;
+    use tree_sitter_graph::graph::Graph;
+    use tree_sitter_graph::graph::Value;
+    use tree_sitter_graph::ExecutionError;
+
+    pub struct NormalizePath;
+
+    impl Function for NormalizePath {
+        fn call(
+            &mut self,
+            _graph: &mut Graph,
+            _source: &str,
+            parameters: &mut dyn Parameters,
+        ) -> Result<Value, ExecutionError> {
+            let path = parameters.param()?.into_string()?;
+            parameters.finish()?;
+
+            let path = Path::new(&path);
+            let path = normalize_path(&path.to_path_buf());
+
+            Ok(path.to_str().unwrap().into())
+        }
+    }
+
+    pub struct ResolvePath;
+
+    impl Function for ResolvePath {
+        fn call(
+            &mut self,
+            _graph: &mut Graph,
+            _source: &str,
+            parameters: &mut dyn Parameters,
+        ) -> Result<Value, ExecutionError> {
+            let base_path = parameters.param()?.into_string()?;
+            let path = parameters.param()?.into_string()?;
+            parameters.finish()?;
+
+            // FIXME .parent() assumes this is a file path, this API needs some thought
+            let path = Path::new(&base_path).parent().unwrap().join(path);
+
+            Ok(path.to_str().unwrap().into())
+        }
+    }
+
+    /// Normalize a path, removing things like `.` and `..`.
+    ///
+    /// CAUTION: This does not resolve symlinks (unlike
+    /// [`std::fs::canonicalize`]). This may cause incorrect or surprising
+    /// behavior at times. This should be used carefully. Unfortunately,
+    /// [`std::fs::canonicalize`] can be hard to use correctly, since it can often
+    /// fail, or on Windows returns annoying device paths. This is a problem Cargo
+    /// needs to improve on.
+    // Copied from Cargo
+    // https://github.com/rust-lang/cargo/blob/e515c3277bf0681bfc79a9e763861bfe26bb05db/crates/cargo-util/src/paths.rs#L73-L106
+    // Licensed under MIT license & Apache License (Version 2.0)
+    pub fn normalize_path(path: &PathBuf) -> PathBuf {
+        let mut components = path.components().peekable();
+        let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
+            components.next();
+            PathBuf::from(c.as_os_str())
+        } else {
+            PathBuf::new()
+        };
+
+        for component in components {
+            match component {
+                Component::Prefix(..) => unreachable!(),
+                Component::RootDir => {
+                    ret.push(component.as_os_str());
+                }
+                Component::CurDir => {}
+                Component::ParentDir => {
+                    ret.pop();
+                }
+                Component::Normal(c) => {
+                    ret.push(c);
+                }
+            }
+        }
+        ret
+    }
+}

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -4,3 +4,260 @@
 // Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
+
+use stack_graphs::arena::Handle;
+use stack_graphs::graph::File;
+use stack_graphs::graph::Node;
+use stack_graphs::graph::NodeID;
+use stack_graphs::graph::StackGraph;
+use thiserror::Error;
+use tree_sitter::Parser;
+use tree_sitter_graph::functions::Functions;
+use tree_sitter_graph::graph::Graph;
+use tree_sitter_graph::graph::GraphNode;
+use tree_sitter_graph::graph::GraphNodeRef;
+use tree_sitter_graph::Variables;
+
+/// Holds information about how to construct stack graphs for a particular language
+pub struct StackGraphLanguage<'a> {
+    parser: Parser,
+    tsg: tree_sitter_graph::ast::File,
+    functions: Functions,
+    globals: Variables<'a>,
+}
+
+impl StackGraphLanguage<'_> {
+    /// Creates a new stack graph language, loading in the TSG graph construction rules from a
+    /// string.
+    pub fn new(
+        language: tree_sitter::Language,
+        tsg_source: &str,
+    ) -> Result<StackGraphLanguage, LanguageError> {
+        let mut parser = Parser::new();
+        parser.set_language(language)?;
+        let tsg = tree_sitter_graph::ast::File::from_str(language, tsg_source)?;
+        let functions = Functions::stdlib();
+        let globals = Variables::new();
+        Ok(StackGraphLanguage {
+            parser,
+            tsg,
+            functions,
+            globals,
+        })
+    }
+}
+
+/// An error that can occur while loading in the TSG stack graph construction rules for a language
+#[derive(Debug, Error)]
+pub enum LanguageError {
+    #[error(transparent)]
+    LanguageError(#[from] tree_sitter::LanguageError),
+    #[error(transparent)]
+    ParseError(#[from] tree_sitter_graph::ParseError),
+}
+
+impl StackGraphLanguage<'_> {
+    /// Executes the graph construction rules for this language against a source file, creating new
+    /// nodes and edges in `stack_graph`.  Any new nodes that we create will belong to `file`.
+    /// (The source file must be implemented in this language, otherwise you'll probably get a
+    /// parse error.)
+    pub fn load_stack_graph(
+        &mut self,
+        stack_graph: &mut StackGraph,
+        file: Handle<File>,
+        source: &str,
+    ) -> Result<(), LoadError> {
+        let tree = self
+            .parser
+            .parse(source, None)
+            .ok_or(LoadError::ParseError)?;
+        let graph = self
+            .tsg
+            .execute(&tree, source, &mut self.functions, &mut self.globals)?;
+        let mut loader = StackGraphLoader {
+            stack_graph,
+            file,
+            graph: &graph,
+        };
+        loader.load()
+    }
+}
+
+/// An error that can occur while loading a stack graph from a TSG file
+#[derive(Debug, Error)]
+pub enum LoadError {
+    #[error("Missing ‘type’ attribute on graph node")]
+    MissingNodeType(GraphNodeRef),
+    #[error("Missing ‘symbol’ attribute on graph node")]
+    MissingSymbol(GraphNodeRef),
+    #[error("Unknown node type {0}")]
+    UnknownNodeType(String),
+    #[error(transparent)]
+    ExecutionError(#[from] tree_sitter_graph::ExecutionError),
+    #[error("Error parsing source")]
+    ParseError,
+}
+
+struct StackGraphLoader<'a> {
+    stack_graph: &'a mut StackGraph,
+    file: Handle<File>,
+    graph: &'a Graph<'a>,
+}
+
+impl<'a> StackGraphLoader<'a> {
+    fn load(&mut self) -> Result<(), LoadError> {
+        for node_ref in self.graph.iter_nodes() {
+            let node = &self.graph[node_ref];
+            match get_node_type(node)? {
+                NodeType::Definition => self.load_definition(node, node_ref)?,
+                NodeType::DropScopes => self.load_drop_scopes(node_ref),
+                NodeType::ExportedScope => self.load_exported_scope(node_ref),
+                NodeType::InternalScope => self.load_internal_scope(node_ref),
+                NodeType::PopSymbol => self.load_pop_symbol(node, node_ref)?,
+                NodeType::PushSymbol => self.load_push_symbol(node, node_ref)?,
+                NodeType::Reference => self.load_reference(node, node_ref)?,
+            };
+        }
+        Ok(())
+    }
+}
+
+enum NodeType {
+    Definition,
+    DropScopes,
+    ExportedScope,
+    InternalScope,
+    PopSymbol,
+    PushSymbol,
+    Reference,
+}
+
+fn get_node_type(node: &GraphNode) -> Result<NodeType, LoadError> {
+    let node_type = match node.attributes.get("type") {
+        Some(node_type) => node_type.as_str()?,
+        None => return Ok(NodeType::InternalScope),
+    };
+    if node_type == "definition" {
+        return Ok(NodeType::Definition);
+    } else if node_type == "drop" {
+        return Ok(NodeType::DropScopes);
+    } else if node_type == "exported" || node_type == "endpoint" {
+        return Ok(NodeType::ExportedScope);
+    } else if node_type == "internal" {
+        return Ok(NodeType::InternalScope);
+    } else if node_type == "pop" {
+        return Ok(NodeType::PopSymbol);
+    } else if node_type == "push" {
+        return Ok(NodeType::PushSymbol);
+    } else if node_type == "reference" {
+        return Ok(NodeType::Reference);
+    } else {
+        return Err(LoadError::UnknownNodeType(format!("{:?}", node_type)));
+    }
+}
+
+impl<'a> StackGraphLoader<'a> {
+    fn node_id_for_graph_node(&self, node_ref: GraphNodeRef) -> NodeID {
+        let index = node_ref.index();
+        NodeID::new_in_file(self.file, index as u32)
+    }
+
+    fn load_definition(
+        &mut self,
+        node: &GraphNode,
+        node_ref: GraphNodeRef,
+    ) -> Result<Handle<Node>, LoadError> {
+        let symbol = match node.attributes.get("symbol") {
+            Some(symbol) => symbol.as_str()?,
+            None => return Err(LoadError::MissingSymbol(node_ref)),
+        };
+        let symbol = self.stack_graph.add_symbol(symbol);
+        let id = self.node_id_for_graph_node(node_ref);
+        Ok(self
+            .stack_graph
+            .add_pop_symbol_node(id, symbol, true)
+            .unwrap())
+    }
+
+    fn load_drop_scopes(&mut self, node_ref: GraphNodeRef) -> Handle<Node> {
+        let id = self.node_id_for_graph_node(node_ref);
+        self.stack_graph.add_drop_scopes_node(id).unwrap()
+    }
+
+    fn load_exported_scope(&mut self, node_ref: GraphNodeRef) -> Handle<Node> {
+        let id = self.node_id_for_graph_node(node_ref);
+        self.stack_graph.add_scope_node(id, true).unwrap()
+    }
+
+    fn load_internal_scope(&mut self, node_ref: GraphNodeRef) -> Handle<Node> {
+        let id = self.node_id_for_graph_node(node_ref);
+        self.stack_graph.add_scope_node(id, false).unwrap()
+    }
+
+    fn load_pop_symbol(
+        &mut self,
+        node: &GraphNode,
+        node_ref: GraphNodeRef,
+    ) -> Result<Handle<Node>, LoadError> {
+        let symbol = match node.attributes.get("symbol") {
+            Some(symbol) => symbol.as_str()?,
+            None => return Err(LoadError::MissingSymbol(node_ref)),
+        };
+        let symbol = self.stack_graph.add_symbol(symbol);
+        let id = self.node_id_for_graph_node(node_ref);
+        if let Some(scoped) = node.attributes.get("scoped") {
+            if scoped.as_boolean()? {
+                return Ok(self
+                    .stack_graph
+                    .add_pop_scoped_symbol_node(id, symbol, false)
+                    .unwrap());
+            }
+        }
+        Ok(self
+            .stack_graph
+            .add_pop_symbol_node(id, symbol, false)
+            .unwrap())
+    }
+
+    fn load_push_symbol(
+        &mut self,
+        node: &GraphNode,
+        node_ref: GraphNodeRef,
+    ) -> Result<Handle<Node>, LoadError> {
+        let symbol = match node.attributes.get("symbol") {
+            Some(symbol) => symbol.as_str()?,
+            None => return Err(LoadError::MissingSymbol(node_ref)),
+        };
+        let symbol = self.stack_graph.add_symbol(symbol);
+        let id = self.node_id_for_graph_node(node_ref);
+        if let Some(scope) = node.attributes.get("scope") {
+            let scope = scope.as_graph_node_ref()?;
+            let scope = self.node_id_for_graph_node(scope);
+            return Ok(self
+                .stack_graph
+                .add_push_scoped_symbol_node(id, symbol, scope, false)
+                .unwrap());
+        }
+        Ok(self
+            .stack_graph
+            .add_push_symbol_node(id, symbol, false)
+            .unwrap())
+    }
+
+    fn load_reference(
+        &mut self,
+        node: &GraphNode,
+        node_ref: GraphNodeRef,
+    ) -> Result<Handle<Node>, LoadError> {
+        let symbol = match node.attributes.get("symbol") {
+            Some(symbol) => symbol.as_str()?,
+            None => return Err(LoadError::MissingSymbol(node_ref)),
+        };
+        let symbol = self.stack_graph.add_symbol(symbol);
+        let id = self.node_id_for_graph_node(node_ref);
+        Ok(self
+            .stack_graph
+            .add_push_symbol_node(id, symbol, true)
+            .unwrap())
+    }
+}

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -252,6 +252,7 @@ use tree_sitter_graph::graph::Value;
 use tree_sitter_graph::Variables;
 
 pub mod assert;
+pub mod functions;
 pub mod loader;
 
 // Node type values

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -251,6 +251,8 @@ use tree_sitter_graph::graph::GraphNodeRef;
 use tree_sitter_graph::graph::Value;
 use tree_sitter_graph::Variables;
 
+pub mod assert;
+
 // Node type values
 static DROP_SCOPES_TYPE: &'static str = "drop_scopes";
 static POP_SCOPED_SYMBOL_TYPE: &'static str = "pop_scoped_symbol";

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -1,0 +1,6 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -252,6 +252,7 @@ use tree_sitter_graph::graph::Value;
 use tree_sitter_graph::Variables;
 
 pub mod assert;
+pub mod loader;
 
 // Node type values
 static DROP_SCOPES_TYPE: &'static str = "drop_scopes";

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -1,0 +1,153 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use anyhow::Context as _;
+use std::path::Path;
+use std::path::PathBuf;
+use thiserror::Error;
+use tree_sitter::Language;
+use tree_sitter_graph::ast::File;
+use tree_sitter_graph::functions::Functions;
+use tree_sitter_loader::LanguageConfiguration;
+use tree_sitter_loader::Loader as TSLoader;
+
+use crate::StackGraphLanguage;
+
+pub struct Loader {
+    tsg: Option<PathBuf>,
+    scope: Option<String>,
+    loader: TSLoader,
+    cache: Vec<(Language, StackGraphLanguage)>,
+}
+
+impl Loader {
+    pub fn new(tsg: Option<PathBuf>, scope: Option<String>, loader: TSLoader) -> Self {
+        Loader {
+            tsg,
+            scope,
+            loader,
+            cache: Vec::new(),
+        }
+    }
+
+    pub fn load_for_source_path(
+        &mut self,
+        source_path: &Path,
+    ) -> Result<&mut StackGraphLanguage, LoadError> {
+        let current_dir = std::env::current_dir().map_err(LoadError::other)?;
+        let scope = self.scope.clone();
+        let (language, path) = self.select_language(source_path, &current_dir, scope.as_deref())?;
+        // the borrow checker is a hard master...
+        let index = self.cache.iter().position(|e| &e.0 == &language);
+        let index = match index {
+            Some(index) => index,
+            None => {
+                let functions = Functions::stdlib();
+                let tsg = self.load_tsg_for_language(language, &path)?;
+                let sgl =
+                    StackGraphLanguage::new(language, tsg, functions).map_err(LoadError::other)?;
+                self.cache.push((language, sgl));
+                self.cache.len() - 1
+            }
+        };
+        let sgl = &mut self.cache[index].1;
+        Ok(sgl)
+    }
+
+    // This is a modified version of tree_sitter_loader::Loader::select_language that also returns the language path.
+    // TODO: Some version of this should be upstreamed to tree-sitter-loader
+    fn select_language(
+        &mut self,
+        path: &Path,
+        current_dir: &Path,
+        scope: Option<&str>,
+    ) -> Result<(Language, PathBuf), LoadError> {
+        if let Some(scope) = scope {
+            if let Some((lang, config)) = self
+                .loader
+                .language_configuration_for_scope(scope)
+                .with_context(|| format!("Failed to load language for scope '{}'", scope))?
+            {
+                Ok((lang, config.root_path.clone()))
+            } else {
+                return Err(LoadError::UnknownLanguageScope(scope.to_string()));
+            }
+        } else if let Some((lang, config)) = self
+            .loader
+            .language_configuration_for_file_name(path)
+            .with_context(|| format!("Failed to load language for file name {}", &path.display()))?
+        {
+            Ok((lang, config.root_path.clone()))
+        } else if let Some((lang, config)) = self
+            .language_configurations_at_path(&current_dir)
+            .with_context(|| "Failed to load language in current directory")?
+            .first()
+            .cloned()
+        {
+            Ok((lang, config.root_path.clone()))
+        } else {
+            Err(LoadError::NoLanguageFound)
+        }
+    }
+
+    // This is a stand in for a missing tree_sitter_loader::Loader::languages_at_path method
+    // TODO: Some version of this should be upstreamed to tree-sitter-loader
+    fn language_configurations_at_path(
+        &mut self,
+        path: &Path,
+    ) -> Result<Vec<(Language, &LanguageConfiguration<'_>)>, LoadError> {
+        let languages = self.loader.languages_at_path(path)?;
+        let configurations = self.loader.find_language_configurations_at_path(path)?;
+        let result = languages
+            .iter()
+            .cloned()
+            .zip(configurations.iter())
+            .into_iter()
+            .collect();
+        Ok(result)
+    }
+
+    fn load_tsg_for_language(&self, language: Language, path: &Path) -> Result<File, LoadError> {
+        let lang_tsg_path = path.join("queries/stack-graphs.tsg");
+        let tsg_path = if let Some(path) = &self.tsg {
+            path
+        } else if lang_tsg_path.exists() {
+            &lang_tsg_path
+        } else {
+            return Err(LoadError::NoTsgFound);
+        };
+
+        let tsg_source = std::fs::read(tsg_path)
+            .with_context(|| format!("Failed to read {}", tsg_path.display()))?;
+        let tsg_source = String::from_utf8(tsg_source).map_err(LoadError::other)?;
+        let tsg = File::from_str(language, &tsg_source)
+            .with_context(|| format!("Failed to parse {}", tsg_path.display()))?;
+
+        Ok(tsg)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum LoadError {
+    #[error("No language found")]
+    NoLanguageFound,
+    #[error("No TSG file found")]
+    NoTsgFound,
+    #[error("Unknown language scope {0}")]
+    UnknownLanguageScope(String),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+impl LoadError {
+    fn other<E>(error: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        Self::Other(error.into())
+    }
+}

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -46,7 +46,8 @@ impl Loader {
         let index = match index {
             Some(index) => index,
             None => {
-                let functions = Functions::stdlib();
+                let mut functions = Functions::stdlib();
+                crate::functions::add_path_functions(&mut functions);
                 let tsg = self.load_tsg_for_language(language, &path)?;
                 let sgl =
                     StackGraphLanguage::new(language, tsg, functions).map_err(LoadError::other)?;

--- a/tree-sitter-stack-graphs/tests/it/assert.rs
+++ b/tree-sitter-stack-graphs/tests/it/assert.rs
@@ -1,0 +1,114 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use pretty_assertions::assert_eq;
+use stack_graphs::arena::Handle;
+use stack_graphs::graph::File;
+use stack_graphs::graph::StackGraph;
+use stack_graphs::paths::Paths;
+use tree_sitter_graph::functions::Functions;
+use tree_sitter_graph::Variables;
+use tree_sitter_stack_graphs::assert::Assertions;
+use tree_sitter_stack_graphs::LoadError;
+use tree_sitter_stack_graphs::StackGraphLanguage;
+
+fn build_stack_graph_into(
+    graph: &mut StackGraph,
+    file: Handle<File>,
+    python_source: &str,
+    tsg_source: &str,
+) -> Result<(), LoadError> {
+    let functions = Functions::stdlib();
+    let mut language =
+        StackGraphLanguage::from_str(tree_sitter_python::language(), tsg_source, functions)
+            .unwrap();
+    let mut globals = Variables::new();
+    language.build_stack_graph_into(graph, file, python_source, &mut globals)?;
+    Ok(())
+}
+
+fn check_assertions(
+    python_source: &str,
+    tsg_source: &str,
+    expected_successes: usize,
+    expected_failures: usize,
+) {
+    let mut graph = StackGraph::new();
+    let file = graph.get_or_create_file("test.py");
+    let assertions =
+        Assertions::from_source(file, python_source).expect("Could not parse assertions");
+    assert_eq!(
+        expected_successes + expected_failures,
+        assertions.count(),
+        "expected {} assertions, got {}",
+        expected_successes + expected_failures,
+        assertions.count()
+    );
+    build_stack_graph_into(&mut graph, file, python_source, tsg_source)
+        .expect("Could not load stack graph");
+    let mut paths = Paths::new();
+    let results = assertions.run(&graph, &mut paths);
+    assert_eq!(
+        expected_successes,
+        results.success_count(),
+        "expected {} successes, got {}",
+        expected_successes,
+        results.success_count()
+    );
+    assert_eq!(
+        expected_failures,
+        results.failure_count(),
+        "expected {} failures, got {}",
+        expected_failures,
+        results.failure_count()
+    );
+}
+
+#[test]
+fn aligns_correctly_with_unicode() {
+    let python = r#"
+      x = 1;
+      m = {};
+
+      # multi code unit character in assertion line
+      m[" "] = x;
+      #  §   # ^ defined: 2
+
+      # multi code point character in source line
+      m["§"] = x;
+      #      # ^ defined: 2
+
+      # multi code point character in assertion line
+      m[" "] = x;
+      #  g̈   # ^ defined: 2
+
+      # multi code point character in source line
+      m["g̈"] = x;
+      #      # ^ defined: 2
+    "#;
+    let tsg = r#"
+      (module (_)@stmt) {
+          node @stmt.lexical_in
+          node @stmt.lexical_out
+          edge @stmt.lexical_out -> @stmt.lexical_in
+      }
+      (module (_)@left . (_)@right) {
+          edge @right.lexical_in -> @left.lexical_out
+      }
+      (expression_statement (assignment left:(identifier)@name))@stmt {
+          node @name.def
+          attr (@name.def) type = "pop_symbol", symbol = (source-text @name), source_node = @name, is_definition
+          edge @stmt.lexical_out -> @name.def
+      }
+      (expression_statement (assignment right:(identifier)@name))@stmt {
+          node @name.ref
+          attr (@name.ref) type = "push_symbol", symbol = (source-text @name), source_node = @name, is_reference
+          edge @name.ref -> @stmt.lexical_in
+      }
+    "#;
+    check_assertions(python, tsg, 4, 0);
+}

--- a/tree-sitter-stack-graphs/tests/it/edges.rs
+++ b/tree-sitter-stack-graphs/tests/it/edges.rs
@@ -51,9 +51,9 @@ fn can_create_edges() {
     let tsg = r#"
       (identifier) @id {
          node source
-         attr (source) type = "definition", symbol = (source-text @id)
+         attr (source) type = "pop_symbol", symbol = (source-text @id), is_definition
          node sink
-         attr (sink) type = "reference", symbol = (source-text @id)
+         attr (sink) type = "push_symbol", symbol = (source-text @id), is_reference
          edge source -> sink
       }
     "#;
@@ -72,9 +72,9 @@ fn can_create_edges_with_precedence() {
     let tsg = r#"
       (identifier) @id {
          node source
-         attr (source) type = "definition", symbol = (source-text @id)
+         attr (source) type = "pop_symbol", symbol = (source-text @id), is_definition
          node sink
-         attr (sink) type = "reference", symbol = (source-text @id)
+         attr (sink) type = "push_symbol", symbol = (source-text @id), is_reference
          edge source -> sink
          attr (source -> sink) precedence = 17
       }
@@ -94,7 +94,7 @@ fn can_create_edges_to_singleton_nodes() {
     let tsg = r#"
       (identifier) @id {
          node source
-         attr (source) type = "reference", symbol = (source-text @id)
+         attr (source) type = "push_symbol", symbol = (source-text @id), is_reference
          edge source -> ROOT_NODE
          attr (source -> ROOT_NODE) precedence = 6
          edge source -> JUMP_TO_SCOPE_NODE
@@ -103,7 +103,7 @@ fn can_create_edges_to_singleton_nodes() {
 
       (identifier) @id {
          node sink
-         attr (sink) type = "definition", symbol = (source-text @id)
+         attr (sink) type = "pop_symbol", symbol = (source-text @id), is_definition
          edge ROOT_NODE -> sink
          attr (ROOT_NODE -> sink) precedence = 12
          edge JUMP_TO_SCOPE_NODE -> sink

--- a/tree-sitter-stack-graphs/tests/it/edges.rs
+++ b/tree-sitter-stack-graphs/tests/it/edges.rs
@@ -1,0 +1,118 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use std::collections::BTreeSet;
+
+use pretty_assertions::assert_eq;
+use stack_graphs::graph::StackGraph;
+use tree_sitter_stack_graphs::LoadError;
+use tree_sitter_stack_graphs::StackGraphLanguage;
+
+fn load_stack_graph(python_source: &str, tsg_source: &str) -> Result<StackGraph, LoadError> {
+    let mut language = StackGraphLanguage::new(tree_sitter_python::language(), tsg_source).unwrap();
+    let mut graph = StackGraph::new();
+    let file = graph.get_or_create_file("test.py");
+    language.load_stack_graph(&mut graph, file, python_source)?;
+    Ok(graph)
+}
+
+fn check_stack_graph_edges(python_source: &str, tsg_source: &str, expected_edges: &[&str]) {
+    let graph = load_stack_graph(python_source, tsg_source).expect("Could not load stack graph");
+    let mut actual_edges = BTreeSet::new();
+    for source in graph.iter_nodes() {
+        for edge in graph.outgoing_edges(source) {
+            actual_edges.insert(format!(
+                "{} -{}-> {}",
+                graph[source].display(&graph),
+                edge.precedence,
+                graph[edge.sink].display(&graph),
+            ));
+        }
+    }
+    let expected_edges = expected_edges
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(expected_edges, actual_edges);
+}
+
+#[test]
+fn can_create_edges() {
+    let tsg = r#"
+      (identifier) @id {
+         node source
+         attr (source) type = "definition", symbol = (source-text @id)
+         node sink
+         attr (sink) type = "reference", symbol = (source-text @id)
+         edge source -> sink
+      }
+    "#;
+    let python = "a";
+    check_stack_graph_edges(
+        python,
+        tsg,
+        &[
+            "[test.py(0) definition a] -0-> [test.py(1) reference a]", //
+        ],
+    );
+}
+
+#[test]
+fn can_create_edges_with_precedence() {
+    let tsg = r#"
+      (identifier) @id {
+         node source
+         attr (source) type = "definition", symbol = (source-text @id)
+         node sink
+         attr (sink) type = "reference", symbol = (source-text @id)
+         edge source -> sink
+         attr (source -> sink) precedence = 17
+      }
+    "#;
+    let python = "a";
+    check_stack_graph_edges(
+        python,
+        tsg,
+        &[
+            "[test.py(0) definition a] -17-> [test.py(1) reference a]", //
+        ],
+    );
+}
+
+#[test]
+fn can_create_edges_to_singleton_nodes() {
+    let tsg = r#"
+      (identifier) @id {
+         node source
+         attr (source) type = "reference", symbol = (source-text @id)
+         edge source -> ROOT_NODE
+         attr (source -> ROOT_NODE) precedence = 6
+         edge source -> JUMP_TO_SCOPE_NODE
+         attr (source -> JUMP_TO_SCOPE_NODE) precedence = 6
+      }
+
+      (identifier) @id {
+         node sink
+         attr (sink) type = "definition", symbol = (source-text @id)
+         edge ROOT_NODE -> sink
+         attr (ROOT_NODE -> sink) precedence = 12
+         edge JUMP_TO_SCOPE_NODE -> sink
+         attr (JUMP_TO_SCOPE_NODE -> sink) precedence = 12
+      }
+    "#;
+    let python = "a";
+    check_stack_graph_edges(
+        python,
+        tsg,
+        &[
+            "[test.py(0) reference a] -6-> [jump to scope]", //
+            "[test.py(0) reference a] -6-> [root]",
+            "[jump to scope] -12-> [test.py(1) definition a]",
+            "[root] -12-> [test.py(1) definition a]",
+        ],
+    );
+}

--- a/tree-sitter-stack-graphs/tests/it/main.rs
+++ b/tree-sitter-stack-graphs/tests/it/main.rs
@@ -5,5 +5,6 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+mod assert;
 mod edges;
 mod nodes;

--- a/tree-sitter-stack-graphs/tests/it/main.rs
+++ b/tree-sitter-stack-graphs/tests/it/main.rs
@@ -4,3 +4,5 @@
 // Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
+
+mod nodes;

--- a/tree-sitter-stack-graphs/tests/it/main.rs
+++ b/tree-sitter-stack-graphs/tests/it/main.rs
@@ -5,4 +5,5 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+mod edges;
 mod nodes;

--- a/tree-sitter-stack-graphs/tests/it/main.rs
+++ b/tree-sitter-stack-graphs/tests/it/main.rs
@@ -1,0 +1,6 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------

--- a/tree-sitter-stack-graphs/tests/it/nodes.rs
+++ b/tree-sitter-stack-graphs/tests/it/nodes.rs
@@ -1,0 +1,249 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use pretty_assertions::assert_eq;
+use stack_graphs::graph::StackGraph;
+use tree_sitter_stack_graphs::LoadError;
+use tree_sitter_stack_graphs::StackGraphLanguage;
+
+fn load_stack_graph(python_source: &str, tsg_source: &str) -> Result<StackGraph, LoadError> {
+    let mut language = StackGraphLanguage::new(tree_sitter_python::language(), tsg_source).unwrap();
+    let mut graph = StackGraph::new();
+    let file = graph.get_or_create_file("test.py");
+    language.load_stack_graph(&mut graph, file, python_source)?;
+    Ok(graph)
+}
+
+fn check_stack_graph_node(python_source: &str, tsg_source: &str, expected_nodes: &[&str]) {
+    let graph = load_stack_graph(python_source, tsg_source).expect("Could not load stack graph");
+    let actual_nodes = graph
+        .iter_nodes()
+        .skip(2) // skip root and jump-to-scope nodes
+        .map(|handle| graph[handle].display(&graph).to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(expected_nodes, actual_nodes);
+}
+
+#[test]
+fn can_create_definition_node() {
+    let tsg = r#"
+      (identifier) @id {
+         node result
+         attr (result) type = "definition", symbol = (source-text @id)
+      }
+    "#;
+    let python = "a";
+    check_stack_graph_node(python, tsg, &["[test.py(0) definition a]"]);
+}
+
+#[test]
+fn cannot_create_definition_node_without_symbol() {
+    let tsg = r#"
+      (identifier) @id {
+         node result
+         attr (result) type = "definition"
+      }
+    "#;
+    let python = "a";
+    let result = load_stack_graph(python, tsg);
+    assert!(matches!(result, Err(LoadError::MissingSymbol(_))));
+}
+
+#[test]
+fn can_create_drop_node() {
+    let tsg = r#"
+      (identifier) @id {
+         node result
+         attr (result) type = "drop"
+      }
+    "#;
+    let python = "a";
+    check_stack_graph_node(python, tsg, &["[test.py(0) drop scopes]"]);
+}
+
+#[test]
+fn can_create_exported_node() {
+    let tsg = r#"
+      (identifier) @id {
+         node result
+         attr (result) type = "exported"
+      }
+    "#;
+    let python = "a";
+    check_stack_graph_node(python, tsg, &["[test.py(0) exported scope]"]);
+}
+
+#[test]
+fn can_create_endpoint_node() {
+    let tsg = r#"
+      (identifier) @id {
+         node result
+         attr (result) type = "endpoint"
+      }
+    "#;
+    let python = "a";
+    check_stack_graph_node(python, tsg, &["[test.py(0) exported scope]"]);
+}
+
+#[test]
+fn can_create_implicit_internal_node() {
+    let tsg = r#"
+      (identifier) @id {
+         node result
+      }
+    "#;
+    let python = "a";
+    check_stack_graph_node(python, tsg, &["[test.py(0) scope]"]);
+}
+
+#[test]
+fn can_create_explicit_internal_node() {
+    let tsg = r#"
+      (identifier) @id {
+         node result
+         attr (result) type = "internal"
+      }
+    "#;
+    let python = "a";
+    check_stack_graph_node(python, tsg, &["[test.py(0) scope]"]);
+}
+
+#[test]
+fn can_create_pop_symbol_node() {
+    let tsg = r#"
+      (identifier) @id {
+         node result
+         attr (result) type = "pop", symbol = (source-text @id)
+      }
+    "#;
+    let python = "a";
+    check_stack_graph_node(python, tsg, &["[test.py(0) pop a]"]);
+}
+
+#[test]
+fn cannot_create_pop_symbol_node_without_symbol() {
+    let tsg = r#"
+      (identifier) @id {
+         node result
+         attr (result) type = "pop"
+      }
+    "#;
+    let python = "a";
+    let result = load_stack_graph(python, tsg);
+    assert!(matches!(result, Err(LoadError::MissingSymbol(_))));
+}
+
+#[test]
+fn can_create_pop_scoped_symbol_node() {
+    let tsg = r#"
+      (identifier) @id {
+         node result
+         attr (result) type = "pop", symbol = (source-text @id), scoped = #true
+      }
+    "#;
+    let python = "a";
+    check_stack_graph_node(python, tsg, &["[test.py(0) pop scoped a]"]);
+}
+
+#[test]
+fn cannot_create_pop_scoped_symbol_node_without_symbol() {
+    let tsg = r#"
+      (identifier) @id {
+         node result
+         attr (result) type = "pop", scoped = #true
+      }
+    "#;
+    let python = "a";
+    let result = load_stack_graph(python, tsg);
+    assert!(matches!(result, Err(LoadError::MissingSymbol(_))));
+}
+
+#[test]
+fn can_create_push_node() {
+    let tsg = r#"
+      (identifier) @id {
+         node result
+         attr (result) type = "push", symbol = (source-text @id)
+      }
+    "#;
+    let python = "a";
+    check_stack_graph_node(python, tsg, &["[test.py(0) push a]"]);
+}
+
+#[test]
+fn cannot_create_push_symbol_node_without_symbol() {
+    let tsg = r#"
+      (identifier) @id {
+         node result
+         attr (result) type = "push"
+      }
+    "#;
+    let python = "a";
+    let result = load_stack_graph(python, tsg);
+    assert!(matches!(result, Err(LoadError::MissingSymbol(_))));
+}
+
+#[test]
+fn can_create_push_scoped_node() {
+    let tsg = r#"
+      (identifier) @id {
+         node scope
+         attr (scope) type = "exported"
+         node result
+         attr (result) type = "push", symbol = (source-text @id), scope = scope
+      }
+    "#;
+    let python = "a";
+    check_stack_graph_node(
+        python,
+        tsg,
+        &[
+            "[test.py(0) exported scope]", //
+            "[test.py(1) push scoped a test.py(0)]",
+        ],
+    );
+}
+
+#[test]
+fn cannot_create_push_scoped_symbol_node_without_symbol() {
+    let tsg = r#"
+      (identifier) @id {
+         node scope
+         attr (scope) type = "exported"
+         node result
+         attr (result) type = "push", scope = scope
+      }
+    "#;
+    let python = "a";
+    let result = load_stack_graph(python, tsg);
+    assert!(matches!(result, Err(LoadError::MissingSymbol(_))));
+}
+
+#[test]
+fn can_create_reference_node() {
+    let tsg = r#"
+      (identifier) @id {
+         node result
+         attr (result) type = "reference", symbol = (source-text @id)
+      }
+    "#;
+    let python = "a";
+    check_stack_graph_node(python, tsg, &["[test.py(0) reference a]"]);
+}
+
+#[test]
+fn cannot_create_reference_node_without_symbol() {
+    let tsg = r#"
+      (identifier) @id {
+         node result
+         attr (result) type = "reference"
+      }
+    "#;
+    let python = "a";
+    let result = load_stack_graph(python, tsg);
+    assert!(matches!(result, Err(LoadError::MissingSymbol(_))));
+}

--- a/tree-sitter-stack-graphs/tests/it/nodes.rs
+++ b/tree-sitter-stack-graphs/tests/it/nodes.rs
@@ -7,19 +7,25 @@
 
 use pretty_assertions::assert_eq;
 use stack_graphs::graph::StackGraph;
+use tree_sitter_graph::functions::Functions;
+use tree_sitter_graph::Variables;
 use tree_sitter_stack_graphs::LoadError;
 use tree_sitter_stack_graphs::StackGraphLanguage;
 
-fn load_stack_graph(python_source: &str, tsg_source: &str) -> Result<StackGraph, LoadError> {
-    let mut language = StackGraphLanguage::new(tree_sitter_python::language(), tsg_source).unwrap();
+fn build_stack_graph(python_source: &str, tsg_source: &str) -> Result<StackGraph, LoadError> {
+    let functions = Functions::stdlib();
+    let mut language =
+        StackGraphLanguage::from_str(tree_sitter_python::language(), tsg_source, functions)
+            .unwrap();
     let mut graph = StackGraph::new();
     let file = graph.get_or_create_file("test.py");
-    language.load_stack_graph(&mut graph, file, python_source)?;
+    let mut globals = Variables::new();
+    language.build_stack_graph_into(&mut graph, file, python_source, &mut globals)?;
     Ok(graph)
 }
 
 fn check_stack_graph_node(python_source: &str, tsg_source: &str, expected_nodes: &[&str]) {
-    let graph = load_stack_graph(python_source, tsg_source).expect("Could not load stack graph");
+    let graph = build_stack_graph(python_source, tsg_source).expect("Could not load stack graph");
     let actual_nodes = graph
         .iter_nodes()
         .skip(2) // skip root and jump-to-scope nodes
@@ -49,7 +55,7 @@ fn cannot_create_definition_node_without_symbol() {
       }
     "#;
     let python = "a";
-    let result = load_stack_graph(python, tsg);
+    let result = build_stack_graph(python, tsg);
     assert!(matches!(result, Err(LoadError::MissingSymbol(_))));
 }
 
@@ -133,7 +139,7 @@ fn cannot_create_pop_symbol_node_without_symbol() {
       }
     "#;
     let python = "a";
-    let result = load_stack_graph(python, tsg);
+    let result = build_stack_graph(python, tsg);
     assert!(matches!(result, Err(LoadError::MissingSymbol(_))));
 }
 
@@ -158,7 +164,7 @@ fn cannot_create_pop_scoped_symbol_node_without_symbol() {
       }
     "#;
     let python = "a";
-    let result = load_stack_graph(python, tsg);
+    let result = build_stack_graph(python, tsg);
     assert!(matches!(result, Err(LoadError::MissingSymbol(_))));
 }
 
@@ -183,7 +189,7 @@ fn cannot_create_push_symbol_node_without_symbol() {
       }
     "#;
     let python = "a";
-    let result = load_stack_graph(python, tsg);
+    let result = build_stack_graph(python, tsg);
     assert!(matches!(result, Err(LoadError::MissingSymbol(_))));
 }
 
@@ -219,7 +225,7 @@ fn cannot_create_push_scoped_symbol_node_without_symbol() {
       }
     "#;
     let python = "a";
-    let result = load_stack_graph(python, tsg);
+    let result = build_stack_graph(python, tsg);
     assert!(matches!(result, Err(LoadError::MissingSymbol(_))));
 }
 
@@ -244,7 +250,7 @@ fn cannot_create_reference_node_without_symbol() {
       }
     "#;
     let python = "a";
-    let result = load_stack_graph(python, tsg);
+    let result = build_stack_graph(python, tsg);
     assert!(matches!(result, Err(LoadError::MissingSymbol(_))));
 }
 
@@ -257,7 +263,7 @@ fn can_calculate_spans() {
       }
     "#;
     let python = "  a  ";
-    let graph = load_stack_graph(python, tsg).unwrap();
+    let graph = build_stack_graph(python, tsg).unwrap();
     let node_handle = graph.iter_nodes().nth(2).unwrap();
     let source_info = graph.source_info(node_handle).unwrap();
 

--- a/tree-sitter-stack-graphs/tests/it/nodes.rs
+++ b/tree-sitter-stack-graphs/tests/it/nodes.rs
@@ -39,7 +39,7 @@ fn can_create_definition_node() {
     let tsg = r#"
       (identifier) @id {
          node result
-         attr (result) type = "definition", symbol = (source-text @id)
+         attr (result) type = "pop_symbol", symbol = (source-text @id), is_definition
       }
     "#;
     let python = "a";
@@ -51,7 +51,7 @@ fn cannot_create_definition_node_without_symbol() {
     let tsg = r#"
       (identifier) @id {
          node result
-         attr (result) type = "definition"
+         attr (result) type = "pop_symbol", is_definition
       }
     "#;
     let python = "a";
@@ -64,7 +64,7 @@ fn can_create_drop_node() {
     let tsg = r#"
       (identifier) @id {
          node result
-         attr (result) type = "drop"
+         attr (result) type = "drop_scopes"
       }
     "#;
     let python = "a";
@@ -76,7 +76,7 @@ fn can_create_exported_node() {
     let tsg = r#"
       (identifier) @id {
          node result
-         attr (result) type = "exported"
+         attr (result) is_exported
       }
     "#;
     let python = "a";
@@ -88,7 +88,7 @@ fn can_create_endpoint_node() {
     let tsg = r#"
       (identifier) @id {
          node result
-         attr (result) type = "endpoint"
+         attr (result) is_endpoint
       }
     "#;
     let python = "a";
@@ -111,7 +111,7 @@ fn can_create_explicit_internal_node() {
     let tsg = r#"
       (identifier) @id {
          node result
-         attr (result) type = "internal"
+         attr (result) type = "scope"
       }
     "#;
     let python = "a";
@@ -123,7 +123,7 @@ fn can_create_pop_symbol_node() {
     let tsg = r#"
       (identifier) @id {
          node result
-         attr (result) type = "pop", symbol = (source-text @id)
+         attr (result) type = "pop_symbol", symbol = (source-text @id)
       }
     "#;
     let python = "a";
@@ -135,7 +135,7 @@ fn cannot_create_pop_symbol_node_without_symbol() {
     let tsg = r#"
       (identifier) @id {
          node result
-         attr (result) type = "pop"
+         attr (result) type = "pop_symbol"
       }
     "#;
     let python = "a";
@@ -148,7 +148,7 @@ fn can_create_pop_scoped_symbol_node() {
     let tsg = r#"
       (identifier) @id {
          node result
-         attr (result) type = "pop", symbol = (source-text @id), scoped = #true
+         attr (result) type = "pop_scoped_symbol", symbol = (source-text @id)
       }
     "#;
     let python = "a";
@@ -160,7 +160,7 @@ fn cannot_create_pop_scoped_symbol_node_without_symbol() {
     let tsg = r#"
       (identifier) @id {
          node result
-         attr (result) type = "pop", scoped = #true
+         attr (result) type = "pop_scoped_symbol"
       }
     "#;
     let python = "a";
@@ -173,7 +173,7 @@ fn can_create_push_node() {
     let tsg = r#"
       (identifier) @id {
          node result
-         attr (result) type = "push", symbol = (source-text @id)
+         attr (result) type = "push_symbol", symbol = (source-text @id)
       }
     "#;
     let python = "a";
@@ -185,7 +185,7 @@ fn cannot_create_push_symbol_node_without_symbol() {
     let tsg = r#"
       (identifier) @id {
          node result
-         attr (result) type = "push"
+         attr (result) type = "push_symbol"
       }
     "#;
     let python = "a";
@@ -198,9 +198,9 @@ fn can_create_push_scoped_node() {
     let tsg = r#"
       (identifier) @id {
          node scope
-         attr (scope) type = "exported"
+         attr (scope) is_exported
          node result
-         attr (result) type = "push", symbol = (source-text @id), scope = scope
+         attr (result) type = "push_scoped_symbol", symbol = (source-text @id), scope = scope
       }
     "#;
     let python = "a";
@@ -219,9 +219,9 @@ fn cannot_create_push_scoped_symbol_node_without_symbol() {
     let tsg = r#"
       (identifier) @id {
          node scope
-         attr (scope) type = "exported"
+         attr (scope) is_exported
          node result
-         attr (result) type = "push", scope = scope
+         attr (result) type = "push_scoped_symbol", scope = scope
       }
     "#;
     let python = "a";
@@ -234,7 +234,7 @@ fn can_create_reference_node() {
     let tsg = r#"
       (identifier) @id {
          node result
-         attr (result) type = "reference", symbol = (source-text @id)
+         attr (result) type = "push_symbol", symbol = (source-text @id), is_reference
       }
     "#;
     let python = "a";
@@ -246,7 +246,7 @@ fn cannot_create_reference_node_without_symbol() {
     let tsg = r#"
       (identifier) @id {
          node result
-         attr (result) type = "reference"
+         attr (result) type = "push_symbol", is_reference
       }
     "#;
     let python = "a";
@@ -259,7 +259,7 @@ fn can_calculate_spans() {
     let tsg = r#"
       (identifier) @id {
          node result
-         attr (result) type = "definition", symbol = "test", source_node = @id
+         attr (result) type = "pop_symbol", symbol = "test", source_node = @id, is_definition
       }
     "#;
     let python = "  a  ";


### PR DESCRIPTION
This is a draft of the "spackle" needed to construct stack graphs using tree-sitter's new [graph construction DSL](https://docs.rs/tree-sitter-graph/*/tree_sitter_graph/).