### PR TITLE
Add support for grapheme positions

### DIFF
--- a/lsp-positions/Cargo.toml
+++ b/lsp-positions/Cargo.toml
@@ -22,3 +22,4 @@ default = ["tree-sitter"]
 [dependencies]
 memchr = "2.4"
 tree-sitter = { version=">= 0.19", optional=true }
+unicode-segmentation = { version="1.8" }

--- a/lsp-positions/tests/it/main.rs
+++ b/lsp-positions/tests/it/main.rs
@@ -5,29 +5,45 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+use unicode_segmentation::UnicodeSegmentation as _;
+
 use lsp_positions::Offset;
 
-fn check_utf16_offsets(line: &str) {
+fn check_offsets(line: &str) {
     let offsets = Offset::all_chars(line).collect::<Vec<_>>();
     assert!(!offsets.is_empty());
+
     assert_eq!(offsets.first().unwrap().utf8_offset, 0);
-    assert_eq!(offsets.first().unwrap().utf16_offset, 0);
     assert_eq!(offsets.last().unwrap().utf8_offset, line.len());
+
+    assert_eq!(offsets.first().unwrap().utf16_offset, 0);
     assert_eq!(
         offsets.last().unwrap().utf16_offset,
         line.encode_utf16().count()
     );
+
+    assert_eq!(offsets.first().unwrap().grapheme_offset, 0);
+    assert_eq!(
+        offsets.last().unwrap().grapheme_offset,
+        line.graphemes(true).count()
+    );
+
     for (index, (utf8_offset, _)) in line.char_indices().enumerate() {
+        assert_eq!(offsets[index].utf8_offset, utf8_offset);
+
         let prefix = &line[0..utf8_offset];
         let utf16_offset = prefix.encode_utf16().count();
-        assert_eq!(offsets[index].utf8_offset, utf8_offset);
         assert_eq!(offsets[index].utf16_offset, utf16_offset);
+
+        let prefix = &line[0..utf8_offset];
+        let grapheme_offset = prefix.graphemes(true).count();
+        assert_eq!(offsets[index].grapheme_offset, grapheme_offset);
     }
 }
 
 #[test]
 fn can_calculate_column_offsets() {
-    check_utf16_offsets("from a import *");
-    check_utf16_offsets("print '❤️', b, '👨‍👨‍👧', c");
-    check_utf16_offsets("print '✨✨✨', d");
+    check_offsets("from a import *");
+    check_offsets("print '❤️', b, '👨‍👨‍👧', c");
+    check_offsets("print '✨✨✨', d");
 }

--- a/stack-graphs/include/stack-graphs.h
+++ b/stack-graphs/include/stack-graphs.h
@@ -214,6 +214,8 @@ struct sg_offset {
     size_t utf8_offset;
     // The number of UTF-16 code units appearing before this character in the string
     size_t utf16_offset;
+    // The number of graphemes appearing before this character in the string
+    size_t grapheme_offset;
 };
 
 // A half-open range identifying a range of characters in a string.

--- a/stack-graphs/src/c.rs
+++ b/stack-graphs/src/c.rs
@@ -668,6 +668,8 @@ pub struct sg_offset {
     pub utf8_offset: usize,
     /// The number of UTF-16 code units appearing before this character in the string
     pub utf16_offset: usize,
+    /// The number of graphemes appearing before this character in the string
+    pub grapheme_offset: usize,
 }
 
 /// A half-open range identifying a range of characters in a string.


### PR DESCRIPTION
This PR adds support for computing grapheme positions, next to the UTF-8 and UTF-16 positions already tracked. Graphemes are useful for reasoning about corresponding positions between lines, and for use as column positions reported to users.

Because not all users may need both UTF-16 and graphemes, both features are now behind a feature (`utf16` and `graphemes` repsectively), allowing lean use.

**Limitations**

Graphemes work for visual alignment purposes as long as all characters a the same width. Even with fixed-width fonts this is not always the case, e.g. for East Asian characters or Emojis.