### PR TITLE
Unify internal and exported scopes

### DIFF
--- a/stack-graphs/include/stack-graphs.h
+++ b/stack-graphs/include/stack-graphs.h
@@ -31,12 +31,6 @@ enum sg_deque_direction {
 enum sg_node_kind {
     // Removes everything from the current scope stack.
     SG_NODE_KIND_DROP_SCOPES,
-    // A node that can be referred to on the scope stack, which allows "jump to" nodes in any
-    // other part of the graph can jump back here.
-    SG_NODE_KIND_EXPORTED_SCOPE,
-    // A node internal to a single file.  This node has no effect on the symbol or scope stacks;
-    // it's just used to add structure to the graph.
-    SG_NODE_KIND_INTERNAL_SCOPE,
     // The singleton "jump to" node, which allows a name binding path to jump back to another part
     // of the graph.
     SG_NODE_KIND_JUMP_TO,
@@ -53,6 +47,10 @@ enum sg_node_kind {
     SG_NODE_KIND_PUSH_SYMBOL,
     // The singleton root node, which allows a name binding path to cross between files.
     SG_NODE_KIND_ROOT,
+    // A node that adds structure to the graph. If the node is exported, it can be
+    // referred to on the scope stack, which allows "jump to" nodes in any other
+    // part of the graph can jump back here.
+    SG_NODE_KIND_SCOPE,
 };
 
 // Manages the state of a collection of partial paths to be used in the path-stitching algorithm.
@@ -176,10 +174,11 @@ struct sg_node {
     // attached to the symbol before it's pushed onto the symbol stack.  For all other node types,
     // this will be null.
     struct sg_node_id scope;
-    // Whether this node is "clickable".  For push nodes, this indicates that the node represents
+    // Whether this node is an endpoint.  For push nodes, this indicates that the node represents
     // a reference in the source.  For pop nodes, this indicates that the node represents a
-    // definition in the source.  For all other node types, this field will be unused.
-    bool is_clickable;
+    // definition in the source.  For scopes, this indicates that the scope is exported. For all
+    // other node types, this field will be unused.
+    bool is_endpoint;
 };
 
 // An array of all of the nodes in a stack graph.  Node handles are indices into this array.

--- a/stack-graphs/src/c.rs
+++ b/stack-graphs/src/c.rs
@@ -429,10 +429,11 @@ pub struct sg_node {
     /// attached to the symbol before it's pushed onto the symbol stack.  For all other node types,
     /// this will be null.
     pub scope: sg_node_id,
-    /// Whether this node is "clickable".  For push nodes, this indicates that the node represents
+    /// Whether this node is an endpoint.  For push nodes, this indicates that the node represents
     /// a reference in the source.  For pop nodes, this indicates that the node represents a
-    /// definition in the source.  For all other node types, this field will be unused.
-    pub is_clickable: bool,
+    /// definition in the source.  For scopes, this indicates that the scope is exported. For all
+    /// other node types, this field will be unused.
+    pub is_endpoint: bool,
 }
 
 impl Into<Node> for sg_node {
@@ -447,12 +448,6 @@ impl Into<Node> for sg_node {
 pub enum sg_node_kind {
     /// Removes everything from the current scope stack.
     SG_NODE_KIND_DROP_SCOPES,
-    /// A node that can be referred to on the scope stack, which allows "jump to" nodes in any
-    /// other part of the graph can jump back here.
-    SG_NODE_KIND_EXPORTED_SCOPE,
-    /// A node internal to a single file.  This node has no effect on the symbol or scope stacks;
-    /// it's just used to add structure to the graph.
-    SG_NODE_KIND_INTERNAL_SCOPE,
     /// The singleton "jump to" node, which allows a name binding path to jump back to another part
     /// of the graph.
     SG_NODE_KIND_JUMP_TO,
@@ -469,6 +464,10 @@ pub enum sg_node_kind {
     SG_NODE_KIND_PUSH_SYMBOL,
     /// The singleton root node, which allows a name binding path to cross between files.
     SG_NODE_KIND_ROOT,
+    /// A node that adds structure to the graph. If the node is exported, it can be
+    /// referred to on the scope stack, which allows "jump to" nodes in any other
+    /// part of the graph can jump back here.
+    SG_NODE_KIND_SCOPE,
 }
 
 /// A handle to a node in a stack graph.  A zero handle represents a missing node.

--- a/stack-graphs/src/graph.rs
+++ b/stack-graphs/src/graph.rs
@@ -24,8 +24,7 @@
 //!
 //!   - the singleton [_root node_][`RootNode`], which allows name binding paths to cross between
 //!     files
-//!   - [_exported_][`ExportedScopeNode`] and [_internal_][`InternalScopeNode`] _scopes_, which
-//!     define the name binding structure within a single file
+//!   - [_scope_][`ScopeNode`] nodes, which define the name binding structure within a single file
 //!   - [_push symbol_][`PushSymbolNode`] and [_push scoped symbol_][`PushScopedSymbolNode`] nodes,
 //!     which push onto the symbol stack new things for us to look for
 //!   - [_pop symbol_][`PopSymbolNode`] and [_pop scoped symbol_][`PopScopedSymbolNode`] nodes,
@@ -34,14 +33,13 @@
 //!     manipulate the scope stack
 //!
 //! [`DropScopesNode`]: struct.DropScopesNode.html
-//! [`ExportedScopeNode`]: struct.ExportedScopeNode.html
-//! [`InternalScopeNode`]: struct.InternalScopeNode.html
 //! [`JumpToNode`]: struct.JumpToNode.html
 //! [`PushScopedSymbolNode`]: struct.PushScopedSymbolNode.html
 //! [`PushSymbolNode`]: struct.PushSymbolNode.html
 //! [`PopScopedSymbolNode`]: struct.PopScopedSymbolNode.html
 //! [`PopSymbolNode`]: struct.PopSymbolNode.html
 //! [`RootNode`]: struct.RootNode.html
+//! [`ScopeNode`]: struct.ScopeNode.html
 //!
 //! All nodes except for the singleton _root node_ and _jump to scope_ node belong to
 //! [files][`File`].
@@ -535,17 +533,24 @@ impl NodeID {
 #[repr(C)]
 pub enum Node {
     DropScopes(DropScopesNode),
-    ExportedScope(ExportedScopeNode),
-    InternalScope(InternalScopeNode),
     JumpTo(JumpToNode),
     PopScopedSymbol(PopScopedSymbolNode),
     PopSymbol(PopSymbolNode),
     PushScopedSymbol(PushScopedSymbolNode),
     PushSymbol(PushSymbolNode),
     Root(RootNode),
+    Scope(ScopeNode),
 }
 
 impl Node {
+    #[inline(always)]
+    pub fn is_exported_scope(&self) -> bool {
+        match self {
+            Node::Scope(node) => node.is_exported,
+            _ => false,
+        }
+    }
+
     #[inline(always)]
     pub fn is_definition(&self) -> bool {
         match self {
@@ -599,14 +604,13 @@ impl Node {
     pub fn id(&self) -> NodeID {
         match self {
             Node::DropScopes(node) => node.id,
-            Node::ExportedScope(node) => node.id,
-            Node::InternalScope(node) => node.id,
             Node::JumpTo(node) => node.id,
             Node::PushScopedSymbol(node) => node.id,
             Node::PushSymbol(node) => node.id,
             Node::PopScopedSymbol(node) => node.id,
             Node::PopSymbol(node) => node.id,
             Node::Root(node) => node.id,
+            Node::Scope(node) => node.id,
         }
     }
 
@@ -700,14 +704,13 @@ impl<'a> Display for DisplayNode<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self.wrapped {
             Node::DropScopes(node) => node.display(self.graph).fmt(f),
-            Node::ExportedScope(node) => node.display(self.graph).fmt(f),
-            Node::InternalScope(node) => node.display(self.graph).fmt(f),
             Node::JumpTo(node) => node.fmt(f),
             Node::PushScopedSymbol(node) => node.display(self.graph).fmt(f),
             Node::PushSymbol(node) => node.display(self.graph).fmt(f),
             Node::PopScopedSymbol(node) => node.display(self.graph).fmt(f),
             Node::PopSymbol(node) => node.display(self.graph).fmt(f),
             Node::Root(node) => node.fmt(f),
+            Node::Scope(node) => node.display(self.graph).fmt(f),
         }
     }
 }
@@ -743,7 +746,7 @@ pub struct DropScopesNode {
     pub id: NodeID,
     _symbol: ControlledOption<Handle<Symbol>>,
     _scope: NodeID,
-    _is_clickable: bool,
+    _is_endpoint: bool,
 }
 
 impl From<DropScopesNode> for Node {
@@ -759,7 +762,7 @@ impl StackGraph {
             id,
             _symbol: ControlledOption::none(),
             _scope: NodeID::default(),
-            _is_clickable: false,
+            _is_endpoint: false,
         };
         self.add_node(id, node.into())
     }
@@ -790,124 +793,6 @@ impl<'a> Display for DisplayDropScopesNode<'a> {
     }
 }
 
-/// A node that can be referred to on the scope stack, which allows "jump to" nodes in any other
-/// part of the graph can jump back here.
-#[repr(C)]
-pub struct ExportedScopeNode {
-    /// The unique identifier for this node.
-    pub id: NodeID,
-    _symbol: ControlledOption<Handle<Symbol>>,
-    _scope: NodeID,
-    _is_clickable: bool,
-}
-
-impl From<ExportedScopeNode> for Node {
-    fn from(node: ExportedScopeNode) -> Node {
-        Node::ExportedScope(node)
-    }
-}
-
-impl StackGraph {
-    /// Adds a _exported scope_ node to the stack graph.
-    pub fn add_exported_scope_node(&mut self, id: NodeID) -> Option<Handle<Node>> {
-        let node = ExportedScopeNode {
-            id,
-            _symbol: ControlledOption::none(),
-            _scope: NodeID::default(),
-            _is_clickable: false,
-        };
-        self.add_node(id, node.into())
-    }
-}
-
-impl ExportedScopeNode {
-    pub fn display<'a>(&'a self, graph: &'a StackGraph) -> impl Display + 'a {
-        DisplayExportedScopeNode {
-            wrapped: self,
-            graph,
-        }
-    }
-}
-
-#[doc(hidden)]
-pub struct DisplayExportedScopeNode<'a> {
-    wrapped: &'a ExportedScopeNode,
-    graph: &'a StackGraph,
-}
-
-impl<'a> Display for DisplayExportedScopeNode<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        if f.alternate() {
-            write!(f, "[{}]", self.wrapped.id.display(self.graph))
-        } else {
-            write!(
-                f,
-                "[{} exported scope]",
-                self.wrapped.id.display(self.graph),
-            )
-        }
-    }
-}
-
-/// A node internal to a single file.  This node has no effect on the symbol or scope stacks;
-/// it's just used to add structure to the graph.
-#[repr(C)]
-pub struct InternalScopeNode {
-    /// The unique identifier for this node.
-    pub id: NodeID,
-    _symbol: ControlledOption<Handle<Symbol>>,
-    _scope: NodeID,
-    _is_clickable: bool,
-}
-
-impl From<InternalScopeNode> for Node {
-    fn from(node: InternalScopeNode) -> Node {
-        Node::InternalScope(node)
-    }
-}
-
-impl StackGraph {
-    /// Adds a _internal scope_ node to the stack graph.
-    pub fn add_internal_scope_node(&mut self, id: NodeID) -> Option<Handle<Node>> {
-        let node = InternalScopeNode {
-            id,
-            _symbol: ControlledOption::none(),
-            _scope: NodeID::default(),
-            _is_clickable: false,
-        };
-        self.add_node(id, node.into())
-    }
-}
-
-impl InternalScopeNode {
-    pub fn display<'a>(&'a self, graph: &'a StackGraph) -> impl Display + 'a {
-        DisplayInternalScopeNode {
-            wrapped: self,
-            graph,
-        }
-    }
-}
-
-#[doc(hidden)]
-pub struct DisplayInternalScopeNode<'a> {
-    wrapped: &'a InternalScopeNode,
-    graph: &'a StackGraph,
-}
-
-impl<'a> Display for DisplayInternalScopeNode<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        if f.alternate() {
-            write!(f, "[{}]", self.wrapped.id.display(self.graph))
-        } else {
-            write!(
-                f,
-                "[{} internal scope]",
-                self.wrapped.id.display(self.graph),
-            )
-        }
-    }
-}
-
 /// The singleton "jump to" node, which allows a name binding path to jump back to another part of
 /// the graph.
 #[repr(C)]
@@ -915,7 +800,7 @@ pub struct JumpToNode {
     id: NodeID,
     _symbol: ControlledOption<Handle<Symbol>>,
     _scope: NodeID,
-    _is_clickable: bool,
+    _is_endpoint: bool,
 }
 
 impl From<JumpToNode> for Node {
@@ -930,7 +815,7 @@ impl JumpToNode {
             id: NodeID::jump_to(),
             _symbol: ControlledOption::none(),
             _scope: NodeID::default(),
-            _is_clickable: false,
+            _is_endpoint: false,
         }
     }
 }
@@ -1240,7 +1125,7 @@ pub struct RootNode {
     id: NodeID,
     _symbol: ControlledOption<Handle<Symbol>>,
     _scope: NodeID,
-    _is_clickable: bool,
+    _is_endpoint: bool,
 }
 
 impl From<RootNode> for Node {
@@ -1255,7 +1140,7 @@ impl RootNode {
             id: NodeID::root(),
             _symbol: ControlledOption::none(),
             _scope: NodeID::default(),
-            _is_clickable: false,
+            _is_endpoint: false,
         }
     }
 }
@@ -1316,6 +1201,71 @@ impl NodeIDHandles {
             None => return Either::Left(std::iter::empty()),
         };
         Either::Right(file_entry.iter().filter_map(|entry| *entry))
+    }
+}
+
+/// A node that adds structure to the graph. If the node is exported, it can be
+/// referred to on the scope stack, which allows "jump to" nodes in any other
+/// part of the graph can jump back here.
+#[repr(C)]
+pub struct ScopeNode {
+    /// The unique identifier for this node.
+    pub id: NodeID,
+    _symbol: ControlledOption<Handle<Symbol>>,
+    _scope: NodeID,
+    pub is_exported: bool,
+}
+
+impl From<ScopeNode> for Node {
+    fn from(node: ScopeNode) -> Node {
+        Node::Scope(node)
+    }
+}
+
+impl StackGraph {
+    /// Adds a _scope_ node to the stack graph.
+    pub fn add_scope_node(&mut self, id: NodeID, is_exported: bool) -> Option<Handle<Node>> {
+        let node = ScopeNode {
+            id,
+            _symbol: ControlledOption::none(),
+            _scope: NodeID::default(),
+            is_exported,
+        };
+        self.add_node(id, node.into())
+    }
+}
+
+impl ScopeNode {
+    pub fn display<'a>(&'a self, graph: &'a StackGraph) -> impl Display + 'a {
+        DisplayScopeNode {
+            wrapped: self,
+            graph,
+        }
+    }
+}
+
+#[doc(hidden)]
+pub struct DisplayScopeNode<'a> {
+    wrapped: &'a ScopeNode,
+    graph: &'a StackGraph,
+}
+
+impl<'a> Display for DisplayScopeNode<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        if f.alternate() {
+            write!(f, "[{}]", self.wrapped.id.display(self.graph))
+        } else {
+            write!(
+                f,
+                "[{}{} scope]",
+                self.wrapped.id.display(self.graph),
+                if self.wrapped.is_exported {
+                    " exported"
+                } else {
+                    ""
+                },
+            )
+        }
     }
 }
 

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -2014,7 +2014,11 @@ impl PartialPath {
     pub fn is_complete_as_possible(&self, graph: &StackGraph) -> bool {
         match &graph[self.start_node] {
             Node::Root(_) => (),
-            Node::ExportedScope(_) => (),
+            node @ Node::Scope(_) => {
+                if !node.is_exported_scope() {
+                    return false;
+                }
+            }
             node @ Node::PushScopedSymbol(_) | node @ Node::PushSymbol(_) => {
                 if !node.is_reference() {
                     return false;
@@ -2395,10 +2399,10 @@ impl PartialPaths {
         queue.extend(
             graph
                 .nodes_for_file(file)
-                .filter(|node| match graph[*node] {
+                .filter(|node| match &graph[*node] {
                     Node::PushScopedSymbol(_) => true,
                     Node::PushSymbol(_) => true,
-                    Node::ExportedScope(_) => true,
+                    node @ Node::Scope(_) => node.is_exported_scope(),
                     _ => false,
                 })
                 .map(|node| PartialPath::from_node(graph, self, node).unwrap()),

--- a/stack-graphs/tests/it/c/nodes.rs
+++ b/stack-graphs/tests/it/c/nodes.rs
@@ -107,7 +107,7 @@ fn jump_to_node() -> sg_node {
             local_id: SG_JUMP_TO_NODE_ID,
         },
         symbol: SG_NULL_HANDLE,
-        is_clickable: false,
+        is_endpoint: false,
         scope: sg_node_id::default(),
     }
 }
@@ -120,7 +120,7 @@ fn root_node() -> sg_node {
             local_id: SG_ROOT_NODE_ID,
         },
         symbol: SG_NULL_HANDLE,
-        is_clickable: false,
+        is_endpoint: false,
         scope: sg_node_id::default(),
     }
 }
@@ -175,7 +175,7 @@ fn drop_scopes(file: sg_file_handle, local_id: u32) -> sg_node {
         kind: sg_node_kind::SG_NODE_KIND_DROP_SCOPES,
         id: sg_node_id { file, local_id },
         symbol: SG_NULL_HANDLE,
-        is_clickable: false,
+        is_endpoint: false,
         scope: sg_node_id::default(),
     }
 }
@@ -237,10 +237,10 @@ fn drop_scopes_cannot_have_scope() {
 
 fn exported_scope(file: sg_file_handle, local_id: u32) -> sg_node {
     sg_node {
-        kind: sg_node_kind::SG_NODE_KIND_EXPORTED_SCOPE,
+        kind: sg_node_kind::SG_NODE_KIND_SCOPE,
         id: sg_node_id { file, local_id },
         symbol: SG_NULL_HANDLE,
-        is_clickable: false,
+        is_endpoint: true,
         scope: sg_node_id::default(),
     }
 }
@@ -255,7 +255,8 @@ fn can_add_exported_scope_node() {
     sg_stack_graph_get_or_create_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     let node_arena = sg_stack_graph_nodes(graph);
     let node = get_node(&node_arena, handles[0]);
-    assert!(matches!(node, Node::ExportedScope(_)));
+    assert!(matches!(node, Node::Scope(_)));
+    assert!(node.is_exported_scope());
     assert!(node.id() == node_id(file, 42));
     // Make sure that we get the same handle if we add the node again.
     let mut new_handles: [sg_node_handle; 1] = [SG_NULL_HANDLE; 1];
@@ -302,10 +303,10 @@ fn exported_scope_cannot_have_scope() {
 
 fn internal_scope(file: sg_file_handle, local_id: u32) -> sg_node {
     sg_node {
-        kind: sg_node_kind::SG_NODE_KIND_INTERNAL_SCOPE,
+        kind: sg_node_kind::SG_NODE_KIND_SCOPE,
         id: sg_node_id { file, local_id },
         symbol: SG_NULL_HANDLE,
-        is_clickable: false,
+        is_endpoint: false,
         scope: sg_node_id::default(),
     }
 }
@@ -320,7 +321,8 @@ fn can_add_internal_scope_node() {
     sg_stack_graph_get_or_create_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     let node_arena = sg_stack_graph_nodes(graph);
     let node = get_node(&node_arena, handles[0]);
-    assert!(matches!(node, Node::InternalScope(_)));
+    assert!(matches!(node, Node::Scope(_)));
+    assert!(!node.is_exported_scope());
     assert!(node.id() == node_id(file, 42));
     // Make sure that we get the same handle if we add the node again.
     let mut new_handles: [sg_node_handle; 1] = [SG_NULL_HANDLE; 1];
@@ -370,7 +372,7 @@ fn pop_scoped_symbol(file: sg_file_handle, local_id: u32, symbol: sg_symbol_hand
         kind: sg_node_kind::SG_NODE_KIND_POP_SCOPED_SYMBOL,
         id: sg_node_id { file, local_id },
         symbol,
-        is_clickable: true,
+        is_endpoint: true,
         scope: sg_node_id::default(),
     }
 }
@@ -437,7 +439,7 @@ fn pop_symbol(file: sg_file_handle, local_id: u32, symbol: sg_symbol_handle) -> 
         kind: sg_node_kind::SG_NODE_KIND_POP_SYMBOL,
         id: sg_node_id { file, local_id },
         symbol,
-        is_clickable: true,
+        is_endpoint: true,
         scope: sg_node_id::default(),
     }
 }
@@ -514,7 +516,7 @@ fn push_scoped_symbol(
         kind: sg_node_kind::SG_NODE_KIND_PUSH_SCOPED_SYMBOL,
         id: sg_node_id { file, local_id },
         symbol,
-        is_clickable: true,
+        is_endpoint: true,
         scope,
     }
 }
@@ -590,7 +592,7 @@ fn push_symbol(file: sg_file_handle, local_id: u32, symbol: sg_symbol_handle) ->
         kind: sg_node_kind::SG_NODE_KIND_PUSH_SYMBOL,
         id: sg_node_id { file, local_id },
         symbol,
-        is_clickable: true,
+        is_endpoint: true,
         scope: sg_node_id::default(),
     }
 }

--- a/stack-graphs/tests/it/c/partial.rs
+++ b/stack-graphs/tests/it/c/partial.rs
@@ -77,10 +77,10 @@ fn add_exported_scope(
     local_id: u32,
 ) -> sg_node_handle {
     let node = sg_node {
-        kind: sg_node_kind::SG_NODE_KIND_EXPORTED_SCOPE,
+        kind: sg_node_kind::SG_NODE_KIND_SCOPE,
         id: sg_node_id { file, local_id },
         symbol: SG_NULL_HANDLE,
-        is_clickable: false,
+        is_endpoint: true,
         scope: sg_node_id::default(),
     };
     let nodes = [node];

--- a/stack-graphs/tests/it/c/paths.rs
+++ b/stack-graphs/tests/it/c/paths.rs
@@ -77,10 +77,10 @@ fn add_exported_scope(
     local_id: u32,
 ) -> sg_node_handle {
     let node = sg_node {
-        kind: sg_node_kind::SG_NODE_KIND_EXPORTED_SCOPE,
+        kind: sg_node_kind::SG_NODE_KIND_SCOPE,
         id: sg_node_id { file, local_id },
         symbol: SG_NULL_HANDLE,
-        is_clickable: false,
+        is_endpoint: true,
         scope: sg_node_id::default(),
     };
     let nodes = [node];

--- a/stack-graphs/tests/it/c/test_graph.rs
+++ b/stack-graphs/tests/it/c/test_graph.rs
@@ -72,7 +72,7 @@ impl CreateStackGraph for TestGraph {
             kind: sg_node_kind::SG_NODE_KIND_POP_SYMBOL,
             id: sg_node_id { file, local_id },
             symbol,
-            is_clickable: true,
+            is_endpoint: true,
             scope: sg_node_id::default(),
         })
     }
@@ -82,7 +82,7 @@ impl CreateStackGraph for TestGraph {
             kind: sg_node_kind::SG_NODE_KIND_DROP_SCOPES,
             id: sg_node_id { file, local_id },
             symbol: SG_NULL_HANDLE,
-            is_clickable: false,
+            is_endpoint: false,
             scope: sg_node_id::default(),
         })
     }
@@ -99,10 +99,10 @@ impl CreateStackGraph for TestGraph {
 
     fn exported_scope(&mut self, file: sg_file_handle, local_id: u32) -> sg_node_handle {
         self.add_node(sg_node {
-            kind: sg_node_kind::SG_NODE_KIND_EXPORTED_SCOPE,
+            kind: sg_node_kind::SG_NODE_KIND_SCOPE,
             id: sg_node_id { file, local_id },
             symbol: SG_NULL_HANDLE,
-            is_clickable: false,
+            is_endpoint: true,
             scope: sg_node_id::default(),
         })
     }
@@ -122,10 +122,10 @@ impl CreateStackGraph for TestGraph {
 
     fn internal_scope(&mut self, file: sg_file_handle, local_id: u32) -> sg_node_handle {
         self.add_node(sg_node {
-            kind: sg_node_kind::SG_NODE_KIND_INTERNAL_SCOPE,
+            kind: sg_node_kind::SG_NODE_KIND_SCOPE,
             id: sg_node_id { file, local_id },
             symbol: SG_NULL_HANDLE,
-            is_clickable: false,
+            is_endpoint: false,
             scope: sg_node_id::default(),
         })
     }
@@ -144,7 +144,7 @@ impl CreateStackGraph for TestGraph {
             kind: sg_node_kind::SG_NODE_KIND_POP_SCOPED_SYMBOL,
             id: sg_node_id { file, local_id },
             symbol,
-            is_clickable: false,
+            is_endpoint: false,
             scope: sg_node_id::default(),
         })
     }
@@ -159,7 +159,7 @@ impl CreateStackGraph for TestGraph {
             kind: sg_node_kind::SG_NODE_KIND_POP_SYMBOL,
             id: sg_node_id { file, local_id },
             symbol,
-            is_clickable: false,
+            is_endpoint: false,
             scope: sg_node_id::default(),
         })
     }
@@ -180,7 +180,7 @@ impl CreateStackGraph for TestGraph {
             kind: sg_node_kind::SG_NODE_KIND_PUSH_SCOPED_SYMBOL,
             id: sg_node_id { file, local_id },
             symbol,
-            is_clickable: false,
+            is_endpoint: false,
             scope,
         })
     }
@@ -195,7 +195,7 @@ impl CreateStackGraph for TestGraph {
             kind: sg_node_kind::SG_NODE_KIND_PUSH_SYMBOL,
             id: sg_node_id { file, local_id },
             symbol,
-            is_clickable: false,
+            is_endpoint: false,
             scope: sg_node_id::default(),
         })
     }
@@ -210,7 +210,7 @@ impl CreateStackGraph for TestGraph {
             kind: sg_node_kind::SG_NODE_KIND_PUSH_SYMBOL,
             id: sg_node_id { file, local_id },
             symbol,
-            is_clickable: true,
+            is_endpoint: true,
             scope: sg_node_id::default(),
         })
     }

--- a/stack-graphs/tests/it/partial.rs
+++ b/stack-graphs/tests/it/partial.rs
@@ -337,7 +337,7 @@ fn create_scope_stack(
         let node_id = NodeID::new_in_file(file, *scope);
         let node = match graph.node_for_id(node_id) {
             Some(node) => node,
-            None => graph.add_exported_scope_node(node_id).unwrap(),
+            None => graph.add_scope_node(node_id, true).unwrap(),
         };
         stack.push_back(partials, node);
     }

--- a/stack-graphs/tests/it/test_graphs/mod.rs
+++ b/stack-graphs/tests/it/test_graphs/mod.rs
@@ -87,7 +87,7 @@ impl CreateStackGraph for StackGraph {
     }
 
     fn exported_scope(&mut self, file: Handle<File>, local_id: u32) -> Handle<Node> {
-        self.add_exported_scope_node(NodeID::new_in_file(file, local_id))
+        self.add_scope_node(NodeID::new_in_file(file, local_id), true)
             .expect("Duplicate node ID")
     }
 
@@ -96,7 +96,7 @@ impl CreateStackGraph for StackGraph {
     }
 
     fn internal_scope(&mut self, file: Handle<File>, local_id: u32) -> Handle<Node> {
-        self.add_internal_scope_node(NodeID::new_in_file(file, local_id))
+        self.add_scope_node(NodeID::new_in_file(file, local_id), false)
             .expect("Duplicate node ID")
     }
 


### PR DESCRIPTION
Since internal and external scopes do not really differ in behavior and the difference is only used for selection, I propose to unify them and use a flag to indicate exported scopes, in the same way as we do for references and definitions.

## Changes

 * Replaces `InternalScope` and `ExternalScope` with a single `Scope`, and use an `is_exported` flag to indicate if the scope is exported.
 * The `is_clickable` field in the C API is renamed to `is_endpoint`, which represents `is_exported`, `is_reference`, and `is_definition`.