### PR TITLE
Implement CLI to use stack graphs with tree-sitter

### DIFF
--- a/stack-graphs/src/assert.rs
+++ b/stack-graphs/src/assert.rs
@@ -14,7 +14,6 @@ use crate::arena::Handle;
 use crate::graph::File;
 use crate::graph::Node;
 use crate::graph::StackGraph;
-use crate::graph::Symbol;
 use crate::paths::Path;
 use crate::paths::Paths;
 
@@ -75,7 +74,7 @@ pub enum AssertionError {
     },
     IncorrectDefinitions {
         source: AssertionSource,
-        symbols: Vec<Handle<Symbol>>,
+        references: Vec<Handle<Node>>,
         missing_targets: Vec<AssertionTarget>,
         unexpected_paths: Vec<Path>,
     },
@@ -131,14 +130,9 @@ impl Assertion {
             .cloned()
             .collect::<Vec<_>>();
         if !missing_targets.is_empty() || !unexpected_paths.is_empty() {
-            let symbols = references
-                .iter()
-                .map(|r| graph[*r].symbol().unwrap())
-                .unique()
-                .collect::<Vec<_>>();
             return Err(AssertionError::IncorrectDefinitions {
                 source: source.clone(),
-                symbols,
+                references,
                 missing_targets,
                 unexpected_paths,
             });

--- a/stack-graphs/src/assert.rs
+++ b/stack-graphs/src/assert.rs
@@ -110,6 +110,7 @@ impl Assertion {
                 actual_paths.push(p);
             }
         });
+        paths.remove_shadowed_paths(&mut actual_paths);
         let missing_targets = expected_targets
             .iter()
             .filter(|t| {

--- a/tree-sitter-stack-graphs/CHANGELOG.md
+++ b/tree-sitter-stack-graphs/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Added
+### Library
+
+#### Added
 
 - `StackGraphLanguage` data type that handles parsing sources, executing the tree-sitter-graph rules, and constructing the resulting stack graph.
+- `test` module that defines data types for parsing and running stack graph tests.
+- `loader` module that defines data types for loading stack graph languages for source files.
+
+### CLI
+
+#### Added
+
+- `test` command that allows running stack graph tests.

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -22,7 +22,7 @@ name = "tree-sitter-stack-graphs"
 required-features = ["cli"]
 
 [features]
-cli = ["clap", "env_logger", "tree-sitter-config"]
+cli = ["clap", "env_logger", "tree-sitter-config", "walkdir"]
 
 [dependencies]
 anyhow = "1.0"
@@ -40,6 +40,7 @@ tree-sitter = ">= 0.19"
 tree-sitter-config = { version = "0.19", optional = true }
 tree-sitter-graph = "0.4"
 tree-sitter-loader = "0.20"
+walkdir = { version = "2.3", optional = true }
 
 [dev-dependencies]
 pretty_assertions = "0.7"

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -22,11 +22,12 @@ name = "tree-sitter-stack-graphs"
 required-features = ["cli"]
 
 [features]
-cli = ["clap", "env_logger", "tree-sitter-config", "walkdir"]
+cli = ["clap", "colored", "env_logger", "stack-graphs/json", "tree-sitter-config", "walkdir"]
 
 [dependencies]
 anyhow = "1.0"
 clap = { version = "3", optional = true, features=["derive"] }
+colored = { version = "2.0", optional = true }
 controlled-option = ">=0.4"
 env_logger = { version = "0.9", optional = true }
 itertools = "0.10"

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -8,7 +8,8 @@ readme = "README.md"
 license = "MIT OR Apache-2.0"
 authors = [
   "GitHub <opensource+stack-graphs@github.com>",
-  "Douglas Creager <dcreager@dcreager.net>"
+  "Douglas Creager <dcreager@dcreager.net>",
+  "Hendrik van Antwerpen <hendrikvanantwerpen@github.com>",
 ]
 edition = "2018"
 
@@ -16,17 +17,27 @@ edition = "2018"
 # All of our tests are in the tests/it "integration" test executable.
 test = false
 
+[[bin]]
+name = "tree-sitter-stack-graphs"
+required-features = ["cli"]
+
+[features]
+cli = ["clap", "env_logger", "tree-sitter-config"]
+
 [dependencies]
 anyhow = "1.0"
+clap = { version = "3", optional = true, features=["derive"] }
 controlled-option = ">=0.4"
+env_logger = { version = "0.9", optional = true }
 itertools = "0.10"
 lazy_static = "1.4"
+log = "0.4"
 lsp-positions = { version="0.2", path="../lsp-positions" }
 regex = "1"
 stack-graphs = { version="0.6", path="../stack-graphs" }
 thiserror = "1.0"
 tree-sitter = ">= 0.19"
-tree-sitter-config = "0.19"
+tree-sitter-config = { version = "0.19", optional = true }
 tree-sitter-graph = "0.4"
 tree-sitter-loader = "0.20"
 

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -17,6 +17,7 @@ edition = "2018"
 test = false
 
 [dependencies]
+anyhow = "1.0"
 controlled-option = ">=0.4"
 itertools = "0.10"
 lazy_static = "1.4"
@@ -25,7 +26,9 @@ regex = "1"
 stack-graphs = { version="0.6", path="../stack-graphs" }
 thiserror = "1.0"
 tree-sitter = ">= 0.19"
+tree-sitter-config = "0.19"
 tree-sitter-graph = "0.4"
+tree-sitter-loader = "0.20"
 
 [dev-dependencies]
 pretty_assertions = "0.7"

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -18,7 +18,10 @@ test = false
 
 [dependencies]
 controlled-option = ">=0.4"
+itertools = "0.10"
+lazy_static = "1.4"
 lsp-positions = { version="0.2", path="../lsp-positions" }
+regex = "1"
 stack-graphs = { version="0.6", path="../stack-graphs" }
 thiserror = "1.0"
 tree-sitter = ">= 0.19"

--- a/tree-sitter-stack-graphs/README.md
+++ b/tree-sitter-stack-graphs/README.md
@@ -20,6 +20,29 @@ tree-sitter-stack-graphs = "0.0"
 Check out our [documentation](https://docs.rs/tree-sitter-stack-graphs/*/) for
 more details on how to use this library.
 
+## Command-line Program
+
+The command-line program for `tree-sitter-stack-graphs` lets you do stack
+graph based analysis and lookup from the command line.
+
+To run from source, run the following command:
+
+``` sh
+cargo run --bin tree-sitter-stack-graphs --features cli -- ARGS
+```
+
+To install, run the following command:
+
+``` sh
+cargo install --path TARGETDIR --bin tree-sitter-stack-graphs --features cli
+```
+
+Run the program as follows to show the supported commands:
+
+```sh
+tree-sitter-stack-graphs --help
+```
+
 ## License
 
 Licensed under either of

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/loader.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/loader.rs
@@ -5,34 +5,62 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+use anyhow::Context;
 use anyhow::Result;
 use clap::Args;
+use std::path::Path;
 use std::path::PathBuf;
-use tree_sitter_config::Config;
-use tree_sitter_loader::Loader as TSLoader;
+use tree_sitter::Language;
+use tree_sitter_config::Config as TsConfig;
+use tree_sitter_graph::ast::File as TsgFile;
 use tree_sitter_stack_graphs::loader::Loader;
 
 #[derive(Args)]
 pub struct LoaderArgs {
     /// The TSG file to use for stack graph construction
     #[clap(long)]
-    #[clap(name = "PATH")]
+    #[clap(name = "TSG_PATH")]
     tsg: Option<PathBuf>,
 
-    /// The scope of the tree-sitter grammar to use.
+    /// The path to look for tree-sitter grammars.
+    #[clap(long)]
+    #[clap(name = "GRAMMAR_PATH")]
+    grammar: Option<PathBuf>,
+
+    /// The scope of the tree-sitter grammar.
     /// See https://tree-sitter.github.io/tree-sitter/syntax-highlighting#basics for details.
     #[clap(long)]
+    #[clap(name = "SCOPE")]
     scope: Option<String>,
 }
 
 impl LoaderArgs {
     pub fn new_loader(&self) -> Result<Loader> {
-        let config = Config::load()?;
+        let tsg_path = self.tsg.clone();
+        let tsg = move |language| {
+            if let Some(tsg_path) = &tsg_path {
+                Self::load_tsg_from_path(language, &tsg_path).map(Some)
+            } else {
+                Ok(None)
+            }
+        };
 
-        let loader_config = config.get()?;
-        let mut loader = TSLoader::new()?;
-        loader.find_all_languages(&loader_config)?;
+        let loader_config = TsConfig::load()?.get()?;
+        let loader = Loader::from_config(
+            &loader_config,
+            self.grammar.clone(),
+            self.scope.clone(),
+            tsg,
+        )?;
+        Ok(loader)
+    }
 
-        Ok(Loader::new(self.tsg.clone(), self.scope.clone(), loader))
+    fn load_tsg_from_path(language: Language, tsg_path: &Path) -> Result<TsgFile> {
+        let tsg_source = std::fs::read(tsg_path)
+            .with_context(|| format!("Failed to read {}", tsg_path.display()))?;
+        let tsg_source = String::from_utf8(tsg_source)?;
+        let tsg = TsgFile::from_str(language, &tsg_source)
+            .with_context(|| format!("Failed to parse {}", tsg_path.display()))?;
+        return Ok(tsg);
     }
 }

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/loader.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/loader.rs
@@ -23,9 +23,10 @@ pub struct LoaderArgs {
     tsg: Option<PathBuf>,
 
     /// The path to look for tree-sitter grammars.
+    /// Can be specified multiple times.
     #[clap(long)]
     #[clap(name = "GRAMMAR_PATH")]
-    grammar: Option<PathBuf>,
+    grammar: Vec<PathBuf>,
 
     /// The scope of the tree-sitter grammar.
     /// See https://tree-sitter.github.io/tree-sitter/syntax-highlighting#basics for details.
@@ -45,13 +46,12 @@ impl LoaderArgs {
             }
         };
 
-        let loader = match &self.grammar {
-            Some(path) => Loader::from_paths(vec![path.clone()], self.scope.clone(), tsg),
-            None => {
-                let loader_config = TsConfig::load()?.get()?;
-                Loader::from_config(&loader_config, self.scope.clone(), tsg)
-            }
-        }?;
+        let loader = if !self.grammar.is_empty() {
+            Loader::from_paths(self.grammar.clone(), self.scope.clone(), tsg)?
+        } else {
+            let loader_config = TsConfig::load()?.get()?;
+            Loader::from_config(&loader_config, self.scope.clone(), tsg)?
+        };
         Ok(loader)
     }
 

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/loader.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/loader.rs
@@ -45,13 +45,13 @@ impl LoaderArgs {
             }
         };
 
-        let loader_config = TsConfig::load()?.get()?;
-        let loader = Loader::from_config(
-            &loader_config,
-            self.grammar.clone(),
-            self.scope.clone(),
-            tsg,
-        )?;
+        let loader = match &self.grammar {
+            Some(path) => Loader::from_paths(vec![path.clone()], self.scope.clone(), tsg),
+            None => {
+                let loader_config = TsConfig::load()?.get()?;
+                Loader::from_config(&loader_config, self.scope.clone(), tsg)
+            }
+        }?;
         Ok(loader)
     }
 

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/loader.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/loader.rs
@@ -1,0 +1,38 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use anyhow::Result;
+use clap::Args;
+use std::path::PathBuf;
+use tree_sitter_config::Config;
+use tree_sitter_loader::Loader as TSLoader;
+use tree_sitter_stack_graphs::loader::Loader;
+
+#[derive(Args)]
+pub struct LoaderArgs {
+    /// The TSG file to use for stack graph construction
+    #[clap(long)]
+    #[clap(name = "PATH")]
+    tsg: Option<PathBuf>,
+
+    /// The scope of the tree-sitter grammar to use.
+    /// See https://tree-sitter.github.io/tree-sitter/syntax-highlighting#basics for details.
+    #[clap(long)]
+    scope: Option<String>,
+}
+
+impl LoaderArgs {
+    pub fn new_loader(&self) -> Result<Loader> {
+        let config = Config::load()?;
+
+        let loader_config = config.get()?;
+        let mut loader = TSLoader::new()?;
+        loader.find_all_languages(&loader_config)?;
+
+        Ok(Loader::new(self.tsg.clone(), self.scope.clone(), loader))
+    }
+}

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/main.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/main.rs
@@ -5,7 +5,6 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-use anyhow::anyhow;
 use anyhow::Result;
 use clap::Parser;
 use clap::Subcommand;
@@ -18,14 +17,16 @@ struct Cli {
     command: Commands,
 }
 
-#[derive(Subcommand)]
-enum Commands {}
+mod test;
 
-#[allow(unused_variables)]
-#[allow(unreachable_code)]
+#[derive(Subcommand)]
+enum Commands {
+    Test(test::Command),
+}
+
 fn main() -> Result<()> {
     let cli = Cli::parse();
     match &cli.command {
-        _ => Err(anyhow!("no commands defined")),
+        Commands::Test(cmd) => cmd.run(),
     }
 }

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/main.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/main.rs
@@ -9,6 +9,8 @@ use anyhow::Result;
 use clap::Parser;
 use clap::Subcommand;
 
+pub(crate) const MAX_PARSE_ERRORS: usize = 5;
+
 #[derive(Parser)]
 #[clap(about)]
 #[clap(version)]

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/main.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/main.rs
@@ -17,6 +17,7 @@ struct Cli {
     command: Commands,
 }
 
+mod loader;
 mod test;
 
 #[derive(Subcommand)]

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/main.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/main.rs
@@ -1,0 +1,31 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use anyhow::anyhow;
+use anyhow::Result;
+use clap::Parser;
+use clap::Subcommand;
+
+#[derive(Parser)]
+#[clap(about)]
+#[clap(version)]
+struct Cli {
+    #[clap(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {}
+
+#[allow(unused_variables)]
+#[allow(unreachable_code)]
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    match &cli.command {
+        _ => Err(anyhow!("no commands defined")),
+    }
+}

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
@@ -45,6 +45,18 @@ pub struct Command {
 
 impl Command {
     pub fn run(&self) -> anyhow::Result<()> {
+        if self.sources.is_empty() {
+            return Err(anyhow!("No source path provided"));
+        }
+        for source_path in &self.sources {
+            if !source_path.exists() {
+                return Err(anyhow!(
+                    "Source path {} does not exist",
+                    source_path.display()
+                ));
+            }
+        }
+
         let mut loader = self.loader.new_loader()?;
         let mut total_failure_count = 0;
         for source_path in &self.sources {

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
@@ -141,7 +141,7 @@ impl Command {
         };
         let mut test = Test::from_source(&source_path, &source)?;
         for test_fragment in &test.fragments {
-            let test_path = Path::new(test.graph[test_fragment.file].name());
+            let test_path = Path::new(test.graph[test_fragment.file].name()).to_path_buf();
             if source_path.extension() != test_path.extension() {
                 return Err(anyhow!(
                     "Test fragment {} has different file extension than test file {}",
@@ -149,7 +149,7 @@ impl Command {
                     source_path.display()
                 ));
             }
-            self.build_fragment_stack_graph_into(source_path, sgl, test_fragment, &mut test.graph)?;
+            self.build_fragment_stack_graph_into(&test_path, sgl, test_fragment, &mut test.graph)?;
         }
         let result = test.run();
         let success = self.handle_result(source_path, &result)?;

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
@@ -1,0 +1,35 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use anyhow::anyhow;
+use anyhow::Result;
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Run tests
+#[derive(Parser)]
+pub struct Command {
+    /// The TSG file to use for stack graph construction.
+    #[clap(long)]
+    #[clap(name = "PATH")]
+    tsg: Option<PathBuf>,
+
+    /// The scope of the tree-sitter grammar to use.
+    /// See https://tree-sitter.github.io/tree-sitter/syntax-highlighting#basics for details.
+    #[clap(long)]
+    scope: Option<String>,
+
+    /// Source paths to analyze.
+    #[clap(name = "PATHS")]
+    sources: Vec<PathBuf>,
+}
+
+impl Command {
+    pub fn run(&self) -> Result<()> {
+        Err(anyhow!("not implemented"))
+    }
+}

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
@@ -77,13 +77,10 @@ impl Command {
         source_path: &Path,
         loader: &mut Loader,
     ) -> std::result::Result<(), TestError> {
-        let source = std::fs::read(source_path)
-            .with_context(|| format!("Error reading source file {}", source_path.display()))?;
-        let source = String::from_utf8(source)
-            .with_context(|| format!("Error reading source file {}", source_path.display()))?;
+        let source = std::fs::read(source_path).map_err(TestError::other)?;
+        let source = String::from_utf8(source).map_err(TestError::other)?;
         let source_path_str = source_path.to_string_lossy();
-        let mut test = Test::from_source(&source_path_str, &source)
-            .with_context(|| format!("Error parsing test file {}", source_path.display()))?;
+        let mut test = Test::from_source(&source_path_str, &source).map_err(TestError::other)?;
 
         // construct stack graph
         for test_file in &test.files {
@@ -93,7 +90,7 @@ impl Command {
                 Err(e) => {
                     println!("{} {}", "⦵".dimmed(), source_path_str);
                     if !self.hide_failure_errors {
-                        eprintln!("  {}", e);
+                        Self::print_err(e);
                     }
                     continue;
                 }
@@ -108,12 +105,7 @@ impl Command {
                 &test_file.source,
                 &mut globals,
             )
-            .with_context(|| {
-                anyhow!(
-                    "Could not execute stack graph rules on {}",
-                    source_path.display()
-                )
-            })?;
+            .map_err(TestError::other)?;
         }
 
         // run tests
@@ -143,7 +135,11 @@ impl Command {
             let graph_path = source_path.with_extension("graph.json");
             let paths_path = source_path.with_extension("paths.json");
             if self.save_graph_on_failure {
-                let json = test.graph.to_json().to_string_pretty()?;
+                let json = test
+                    .graph
+                    .to_json()
+                    .to_string_pretty()
+                    .map_err(TestError::other)?;
                 std::fs::write(&graph_path, json).expect("Unable to write graph");
                 println!("  Graph: {}", graph_path.display());
             }
@@ -151,11 +147,28 @@ impl Command {
                 let json = test
                     .paths
                     .to_json(&test.graph, |_, _, _| true)
-                    .to_string_pretty()?;
+                    .to_string_pretty()
+                    .map_err(TestError::other)?;
                 std::fs::write(&paths_path, json).expect("Unable to write paths");
                 println!("  Paths: {}", paths_path.display());
             }
             Err(TestError::AssertionsFailed(result.failure_count()))
+        }
+    }
+
+    fn print_err<E>(err: E)
+    where
+        E: Into<anyhow::Error>,
+    {
+        let err = err.into();
+        println!("  {}", err);
+        let mut first = true;
+        for err in err.chain().skip(1) {
+            if first {
+                println!("  Caused by:");
+                first = false;
+            }
+            println!("      {}", err);
         }
     }
 }
@@ -165,7 +178,14 @@ pub enum TestError {
     #[error("{0} assertions failed")]
     AssertionsFailed(usize),
     #[error(transparent)]
-    Json(#[from] stack_graphs::json::JsonError),
-    #[error(transparent)]
     Other(#[from] anyhow::Error),
+}
+
+impl TestError {
+    fn other<E>(error: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        Self::Other(error.into())
+    }
 }

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
@@ -6,22 +6,23 @@
 // ------------------------------------------------------------------------------------------------
 
 use anyhow::anyhow;
+use anyhow::Context as _;
 use anyhow::Result;
-use clap::Parser;
+use stack_graphs::graph::StackGraph;
+use std::path::Path;
 use std::path::PathBuf;
+use tree_sitter_graph::ExecutionError;
+use tree_sitter_graph::Variables;
+use tree_sitter_stack_graphs::StackGraphLanguage;
+use walkdir::WalkDir;
+
+use crate::loader::LoaderArgs;
 
 /// Run tests
-#[derive(Parser)]
+#[derive(clap::Parser)]
 pub struct Command {
-    /// The TSG file to use for stack graph construction.
-    #[clap(long)]
-    #[clap(name = "PATH")]
-    tsg: Option<PathBuf>,
-
-    /// The scope of the tree-sitter grammar to use.
-    /// See https://tree-sitter.github.io/tree-sitter/syntax-highlighting#basics for details.
-    #[clap(long)]
-    scope: Option<String>,
+    #[clap(flatten)]
+    loader: LoaderArgs,
 
     /// Source paths to analyze.
     #[clap(name = "PATHS")]
@@ -30,6 +31,58 @@ pub struct Command {
 
 impl Command {
     pub fn run(&self) -> Result<()> {
-        Err(anyhow!("not implemented"))
+        let mut loader = self.loader.new_loader()?;
+        for source_path in &self.sources {
+            for source_entry in WalkDir::new(source_path)
+                .follow_links(true)
+                .into_iter()
+                .filter_map(|e| e.ok())
+                .filter(|e| e.file_type().is_file())
+            {
+                let source_path = source_entry.path();
+
+                match loader.load_for_source_path(source_path) {
+                    Ok(sgl) => {
+                        eprintln!("Process {}", source_path.display());
+                        if let Err(e) = self.process(sgl, source_path) {
+                            eprintln!("{:?}", e);
+                            eprintln!("Failed {}", source_path.display());
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("{:?}", e);
+                        eprintln!("Ignored {}", source_path.display());
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn process(&self, sgl: &mut StackGraphLanguage, source_path: &Path) -> Result<()> {
+        let source = std::fs::read(source_path)
+            .with_context(|| format!("Error reading source file {}", source_path.display()))?;
+        let source = String::from_utf8(source)?;
+
+        let mut globals = Variables::new();
+        globals
+            .add(
+                "FILE_PATH".into(),
+                source_path.as_os_str().to_str().unwrap().into(),
+            )
+            .map_err(|_| ExecutionError::DuplicateVariable("FILE_PATH".into()))?;
+
+        let mut stack_graph = StackGraph::new();
+        let file = stack_graph.get_or_create_file(source_path.to_str().unwrap());
+
+        sgl.build_stack_graph_into(&mut stack_graph, file, &source, &mut globals)
+            .with_context(|| {
+                anyhow!(
+                    "Could not execute stack graph rules on {}",
+                    source_path.display()
+                )
+            })?;
+
+        Ok(())
     }
 }

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -249,6 +249,7 @@ use tree_sitter_graph::graph::Value;
 use tree_sitter_graph::ExecutionConfig;
 use tree_sitter_graph::Variables;
 
+pub mod loader;
 pub mod test;
 
 // Node type values

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -249,6 +249,8 @@ use tree_sitter_graph::graph::Value;
 use tree_sitter_graph::ExecutionConfig;
 use tree_sitter_graph::Variables;
 
+pub mod test;
+
 // Node type values
 static DROP_SCOPES_TYPE: &'static str = "drop_scopes";
 static POP_SCOPED_SYMBOL_TYPE: &'static str = "pop_scoped_symbol";

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -246,6 +246,8 @@ use tree_sitter_graph::graph::Graph;
 use tree_sitter_graph::graph::GraphNode;
 use tree_sitter_graph::graph::GraphNodeRef;
 use tree_sitter_graph::graph::Value;
+use tree_sitter_graph::parse_error::ParseError;
+use tree_sitter_graph::parse_error::TreeWithParseErrorVec;
 use tree_sitter_graph::ExecutionConfig;
 use tree_sitter_graph::Variables;
 
@@ -346,6 +348,12 @@ impl StackGraphLanguage {
             .parse(source, None)
             .ok_or(LoadError::ParseError)?;
 
+        let parse_errors = ParseError::into_all(tree);
+        if parse_errors.errors().len() > 0 {
+            return Err(LoadError::ParseErrors(parse_errors));
+        }
+        let tree = parse_errors.into_tree();
+
         let mut graph = Graph::new();
         globals
             .add(ROOT_NODE_VAR.into(), graph.add_graph_node().into())
@@ -381,6 +389,8 @@ pub enum LoadError {
     ExecutionError(#[from] tree_sitter_graph::ExecutionError),
     #[error("Error parsing source")]
     ParseError,
+    #[error("Error parsing source")]
+    ParseErrors(TreeWithParseErrorVec),
     #[error("Error converting shorthand ‘{0}’ on {1} with value {2}")]
     ConversionError(String, String, String),
 }

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -20,6 +20,7 @@
 //! Previously loaded languages are cached in the loader, so subsequent loads are fast.
 
 use anyhow::Context;
+use itertools::Itertools;
 use regex::Regex;
 use std::collections::HashMap;
 use std::ffi::OsStr;
@@ -151,7 +152,8 @@ impl Loader {
         }
         if !found_languages {
             return Err(LoadError::NoLanguagesFound(format!(
-                "in current directory or system{}",
+                "in {}{}",
+                self.paths.iter().map(|p| p.display()).format(":"),
                 self.scope
                     .as_ref()
                     .map_or(String::default(), |s| format!(" for scope {}", s)),

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -5,144 +5,207 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-use anyhow::Context as _;
+use anyhow::Context;
+use regex::Regex;
+use std::collections::HashMap;
+use std::ffi::OsStr;
 use std::path::Path;
 use std::path::PathBuf;
 use thiserror::Error;
 use tree_sitter::Language;
-use tree_sitter_graph::ast::File;
+use tree_sitter_graph::ast::File as TsgFile;
 use tree_sitter_graph::functions::Functions;
+use tree_sitter_loader::Config as TsConfig;
 use tree_sitter_loader::LanguageConfiguration;
-use tree_sitter_loader::Loader as TSLoader;
+use tree_sitter_loader::Loader as TsLoader;
 
 use crate::StackGraphLanguage;
 
 pub struct Loader {
-    tsg: Option<PathBuf>,
+    loader: SupplementedTsLoader,
+    path: Option<PathBuf>,
     scope: Option<String>,
-    loader: TSLoader,
+    tsg: Box<dyn Fn(Language) -> anyhow::Result<Option<TsgFile>>>,
     cache: Vec<(Language, StackGraphLanguage)>,
 }
 
 impl Loader {
-    pub fn new(tsg: Option<PathBuf>, scope: Option<String>, loader: TSLoader) -> Self {
-        Loader {
-            tsg,
+    pub fn from_config(
+        config: &TsConfig,
+        path: Option<PathBuf>,
+        scope: Option<String>,
+        tsg: impl Fn(Language) -> anyhow::Result<Option<TsgFile>> + 'static,
+    ) -> anyhow::Result<Self> {
+        Ok(Self {
+            loader: SupplementedTsLoader::from_config(config)?,
+            path,
             scope,
-            loader,
+            tsg: Box::new(tsg),
             cache: Vec::new(),
-        }
+        })
     }
 
-    pub fn load_for_source_path(
+    pub fn load_for_file(
         &mut self,
-        source_path: &Path,
-    ) -> Result<&mut StackGraphLanguage, LoadError> {
-        let current_dir = std::env::current_dir().map_err(LoadError::other)?;
-        let scope = self.scope.clone();
-        let (language, path) = self.select_language(source_path, &current_dir, scope.as_deref())?;
+        path: &Path,
+        content: Option<&str>,
+    ) -> Result<Option<&mut StackGraphLanguage>, LoadError> {
+        let selected_language = self.select_language_for_file(path, content)?;
+        let language = match selected_language {
+            Some(selected_language) => selected_language.clone(),
+            None => return Ok(None),
+        };
         // the borrow checker is a hard master...
-        let index = self.cache.iter().position(|e| &e.0 == &language);
+        let index = self.cache.iter().position(|e| &e.0 == &language.language);
         let index = match index {
             Some(index) => index,
             None => {
                 let functions = Functions::stdlib();
-                let tsg = self.load_tsg_for_language(language, &path)?;
-                let sgl =
-                    StackGraphLanguage::new(language, tsg, functions).map_err(LoadError::other)?;
-                self.cache.push((language, sgl));
+                let tsg = self.load_tsg_for_language(&language)?;
+                let sgl = StackGraphLanguage::new(language.language, tsg, functions)
+                    .map_err(LoadError::other)?;
+                self.cache.push((language.language, sgl));
+
                 self.cache.len() - 1
             }
         };
         let sgl = &mut self.cache[index].1;
-        Ok(sgl)
+        Ok(Some(sgl))
     }
 
-    // This is a modified version of tree_sitter_loader::Loader::select_language that also returns the language path.
-    // TODO: Some version of this should be upstreamed to tree-sitter-loader
-    fn select_language(
+    // Select language for the given file, considering path and scope fields
+    fn select_language_for_file(
         &mut self,
-        path: &Path,
-        current_dir: &Path,
-        scope: Option<&str>,
-    ) -> Result<(Language, PathBuf), LoadError> {
-        if let Some(scope) = scope {
-            if let Some((lang, config)) = self
-                .loader
-                .language_configuration_for_scope(scope)
-                .with_context(|| format!("Failed to load language for scope '{}'", scope))?
-            {
-                // FIXME Because we try all files in a directory, we should not return a language here
-                //       if it does not match the given path.
-                Ok((lang, config.root_path.clone()))
-            } else {
-                return Err(LoadError::UnknownLanguageScope(scope.to_string()));
-            }
-        } else if let Some((lang, config)) = self
-            .loader
-            .language_configuration_for_file_name(path)
-            .with_context(|| format!("Failed to load language for file name {}", &path.display()))?
-        {
-            Ok((lang, config.root_path.clone()))
-        } else if let Some((lang, config)) = self
-            .language_configurations_at_path(&current_dir)
-            .with_context(|| "Failed to load language in current directory")?
-            .first()
-            .cloned()
-        {
-            Ok((lang, config.root_path.clone()))
+        file_path: &Path,
+        file_content: Option<&str>,
+    ) -> Result<Option<&SupplementedLanguage>, LoadError> {
+        if let Some(path) = self.path.to_owned() {
+            self.select_language_for_file_from_path(&path, file_path, file_content)
         } else {
-            Err(LoadError::NoLanguageFound)
+            self.select_language_for_file_auto(file_path, file_content)
         }
     }
 
-    // This is a stand in for a missing tree_sitter_loader::Loader::languages_at_path method
-    // TODO: Some version of this should be upstreamed to tree-sitter-loader
-    fn language_configurations_at_path(
+    // Select language from the current directory or the system for the given file, considering scope field
+    fn select_language_for_file_auto(
         &mut self,
-        path: &Path,
-    ) -> Result<Vec<(Language, &LanguageConfiguration<'_>)>, LoadError> {
-        let languages = self.loader.languages_at_path(path)?;
-        let configurations = self.loader.find_language_configurations_at_path(path)?;
-        let result = languages
-            .iter()
-            .cloned()
-            .zip(configurations.iter())
-            .into_iter()
-            .collect();
-        Ok(result)
+        file_path: &Path,
+        file_content: Option<&str>,
+    ) -> Result<Option<&SupplementedLanguage>, LoadError> {
+        // The borrow checker is not smart enough to realize that the early returns
+        // ensure any references from the self.select_* calls (which require a mutable
+        // borrow) do not outlive the match. Therefor, we use a raw self_ptr and unsafe
+        // dereferencing to make those calls.
+        let self_ptr = self as *mut Self;
+        let found_any_in_cwd = match unsafe { &mut *self_ptr }.select_language_for_file_from_path(
+            &std::env::current_dir()?,
+            file_path,
+            file_content,
+        ) {
+            Ok(Some(language)) => return Ok(Some(language)),
+            Ok(None) => true,
+            Err(LoadError::NoLanguagesFound(_)) => false,
+            Err(err) => return Err(err),
+        };
+        let found_any_in_system = match unsafe { &mut *self_ptr }
+            .select_language_for_file_from_system(file_path, file_content)
+        {
+            Ok(Some(language)) => return Ok(Some(language)),
+            Ok(None) => true,
+            Err(LoadError::NoLanguagesFound(_)) => false,
+            err => return err,
+        };
+        if !(found_any_in_cwd || found_any_in_system) {
+            return Err(LoadError::NoLanguagesFound(format!(
+                "in current directory or system{}",
+                self.scope
+                    .as_ref()
+                    .map_or(String::default(), |s| format!(" for scope {}", s)),
+            )));
+        }
+        Ok(None)
     }
 
-    fn load_tsg_for_language(&self, language: Language, path: &Path) -> Result<File, LoadError> {
-        let lang_tsg_path = path.join("queries/stack-graphs.tsg");
-        let tsg_path = if let Some(path) = &self.tsg {
-            path
-        } else if lang_tsg_path.exists() {
-            &lang_tsg_path
-        } else {
-            return Err(LoadError::NoTsgFound);
+    // Select language from the system for the given file, considering scope field
+    fn select_language_for_file_from_system(
+        &mut self,
+        file_path: &Path,
+        file_content: Option<&str>,
+    ) -> Result<Option<&SupplementedLanguage>, LoadError> {
+        let scope = self.scope.as_deref();
+        let languages = self.loader.all_languages(scope)?;
+        if languages.is_empty() {
+            return Err(LoadError::NoLanguagesFound(format!(
+                "on system{}",
+                scope.map_or(String::default(), |s| format!(" for scope {}", s)),
+            )));
+        }
+        if let Some(language) =
+            SupplementedLanguage::best_for_file(languages, file_path, file_content)
+        {
+            return Ok(Some(language));
         };
+        Ok(None)
+    }
 
-        let tsg_source = std::fs::read(tsg_path)
-            .with_context(|| format!("Failed to read {}", tsg_path.display()))?;
-        let tsg_source = String::from_utf8(tsg_source).map_err(LoadError::other)?;
-        let tsg = File::from_str(language, &tsg_source)
-            .with_context(|| format!("Failed to parse {}", tsg_path.display()))?;
+    // Select language from the given path for the given file, considering scope field
+    fn select_language_for_file_from_path(
+        &mut self,
+        language_path: &Path,
+        file_path: &Path,
+        file_content: Option<&str>,
+    ) -> Result<Option<&SupplementedLanguage>, LoadError> {
+        let scope = self.scope.as_deref();
+        let languages = self.loader.languages_at_path(language_path, scope)?;
+        if languages.is_empty() {
+            return Err(LoadError::NoLanguagesFound(format!(
+                "at {}{}",
+                language_path.display(),
+                scope.map_or(String::default(), |s| format!(" for scope {}", s)),
+            )));
+        }
+        if let Some(language) =
+            SupplementedLanguage::best_for_file(languages, file_path, file_content)
+        {
+            return Ok(Some(language));
+        };
+        Ok(None)
+    }
 
-        Ok(tsg)
+    // Load the TSG file for the given language and path
+    fn load_tsg_for_language(&self, language: &SupplementedLanguage) -> Result<TsgFile, LoadError> {
+        if let Some(tsg) = (self.tsg)(language.language)? {
+            return Ok(tsg);
+        }
+
+        let tsg_path = language.root_path.join("queries/stack-graphs.tsg");
+        if tsg_path.exists() {
+            let tsg_source = std::fs::read(tsg_path.clone())
+                .with_context(|| format!("Failed to read {}", tsg_path.display()))?;
+            let tsg_source = String::from_utf8(tsg_source).map_err(LoadError::other)?;
+            let tsg = TsgFile::from_str(language.language, &tsg_source)
+                .with_context(|| format!("Failed to parse {}", tsg_path.display()))?;
+            return Ok(tsg);
+        }
+
+        return Err(LoadError::NoTsgFound);
     }
 }
 
 #[derive(Debug, Error)]
 pub enum LoadError {
-    #[error("No language found")]
-    NoLanguageFound,
+    #[error("No languages found {0}")]
+    NoLanguagesFound(String),
     #[error("No TSG file found")]
     NoTsgFound,
-    #[error("Unknown language scope {0}")]
-    UnknownLanguageScope(String),
     #[error(transparent)]
     Other(#[from] anyhow::Error),
+}
+
+impl From<std::io::Error> for LoadError {
+    fn from(err: std::io::Error) -> Self {
+        Self::Other(err.into())
+    }
 }
 
 impl LoadError {
@@ -151,5 +214,174 @@ impl LoadError {
         E: std::error::Error + Send + Sync + 'static,
     {
         Self::Other(error.into())
+    }
+}
+// ------------------------------------------------------------------------------------------------
+// tree_sitter_loader supplements
+
+// Wraps a tree_sitter_loader::Loader
+struct SupplementedTsLoader(
+    TsLoader,
+    HashMap<PathBuf, Vec<SupplementedLanguage>>,
+    Vec<SupplementedLanguage>,
+);
+
+impl SupplementedTsLoader {
+    pub fn from_config(config: &TsConfig) -> anyhow::Result<Self> {
+        let loader = TsLoader::new()?;
+        let mut result = Self(loader, HashMap::new(), Vec::new());
+        result.load_system_languages(&config.parser_directories)?;
+        Ok(result)
+    }
+
+    // Adopted from tree_sitter_loader::Loader::load
+    fn load_system_languages(&mut self, parser_directories: &Vec<PathBuf>) -> anyhow::Result<()> {
+        if parser_directories.is_empty() {
+            eprintln!("Warning: You have not configured any parser directories!");
+            eprintln!("Please run `tree-sitter init-config` and edit the resulting");
+            eprintln!("configuration file to indicate where we should look for");
+            eprintln!("language grammars.");
+            eprintln!("");
+        }
+        let mut paths = Vec::new();
+        for parser_container_dir in parser_directories {
+            if let Ok(entries) = std::fs::read_dir(parser_container_dir) {
+                for entry in entries {
+                    let entry = entry?;
+                    if let Some(parser_dir_name) = entry.file_name().to_str() {
+                        if parser_dir_name.starts_with("tree-sitter-") {
+                            paths.push(parser_container_dir.join(parser_dir_name));
+                        }
+                    }
+                }
+            }
+        }
+        let languages = self
+            .languages_at_paths(&paths, None)?
+            .into_iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        self.2.extend(languages.into_iter());
+        Ok(())
+    }
+
+    pub fn languages_at_path(
+        &mut self,
+        path: &Path,
+        scope: Option<&str>,
+    ) -> anyhow::Result<Vec<&SupplementedLanguage>> {
+        self.languages_at_paths(&vec![path.to_path_buf()], scope)
+    }
+
+    pub fn all_languages(
+        &mut self,
+        scope: Option<&str>,
+    ) -> anyhow::Result<Vec<&SupplementedLanguage>> {
+        Ok(self
+            .2
+            .iter()
+            .filter(|language| scope.map_or(true, |scope| language.matches_scope(scope)))
+            .collect())
+    }
+
+    fn languages_at_paths(
+        &mut self,
+        paths: &Vec<PathBuf>,
+        scope: Option<&str>,
+    ) -> anyhow::Result<Vec<&SupplementedLanguage>> {
+        for path in paths {
+            if !self.1.contains_key(path) {
+                let languages = self.0.languages_at_path(&path)?;
+                let configurations = self.0.find_language_configurations_at_path(&path)?;
+                let languages = languages
+                    .into_iter()
+                    .zip(configurations.into_iter())
+                    .map(SupplementedLanguage::from)
+                    .collect::<Vec<_>>();
+                self.1.insert(path.clone(), languages);
+            }
+        }
+        let mut result = Vec::new();
+        for path in paths {
+            let languages = &self.1[path];
+            result.extend(
+                languages
+                    .iter()
+                    .filter(|language| scope.map_or(true, |scope| language.matches_scope(scope))),
+            );
+        }
+        Ok(result)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct SupplementedLanguage {
+    pub language: Language,
+    pub scope: Option<String>,
+    pub content_regex: Option<Regex>,
+    pub file_types: Vec<String>,
+    pub root_path: PathBuf,
+}
+
+impl SupplementedLanguage {
+    pub fn matches_scope(&self, scope: &str) -> bool {
+        self.scope.as_ref().map_or(false, |s| s == scope)
+    }
+
+    // Extracted from tree_sitter_loader::Loader::language_configuration_for_file_name
+    pub fn matches_file(&self, path: &Path, content: Option<&str>) -> Option<isize> {
+        // Check path extension
+        if !path
+            .extension()
+            .and_then(OsStr::to_str)
+            .map_or(false, |ext| self.file_types.iter().any(|ft| ft == ext))
+        {
+            return None;
+        }
+
+        // Apply content regex
+        if let (Some(file_content), Some(content_regex)) = (content, &self.content_regex) {
+            // If the language configuration has a content regex, assign
+            // a score based on the length of the first match.
+            if let Some(mat) = content_regex.find(&file_content) {
+                let score = (mat.end() - mat.start()) as isize;
+                return Some(score);
+            } else {
+                return None;
+            }
+        }
+
+        Some(0isize)
+    }
+
+    // Extracted from tree_sitter_loader::Loader::language_configuration_for_file_name
+    pub fn best_for_file<'a>(
+        languages: Vec<&'a SupplementedLanguage>,
+        path: &Path,
+        content: Option<&str>,
+    ) -> Option<&'a SupplementedLanguage> {
+        let mut best_score = -1isize;
+        let mut best = None;
+        for language in languages {
+            if let Some(score) = language.matches_file(path, content) {
+                if score > best_score {
+                    best_score = score;
+                    best = Some(language);
+                }
+            }
+        }
+        best
+    }
+}
+
+impl From<(Language, &LanguageConfiguration<'_>)> for SupplementedLanguage {
+    fn from((language, config): (Language, &LanguageConfiguration)) -> Self {
+        Self {
+            scope: config.scope.clone(),
+            content_regex: config.content_regex.clone(),
+            file_types: config.file_types.clone(),
+            root_path: config.root_path.clone(),
+            language,
+        }
     }
 }

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -1,0 +1,153 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use anyhow::Context as _;
+use std::path::Path;
+use std::path::PathBuf;
+use thiserror::Error;
+use tree_sitter::Language;
+use tree_sitter_graph::ast::File;
+use tree_sitter_graph::functions::Functions;
+use tree_sitter_loader::LanguageConfiguration;
+use tree_sitter_loader::Loader as TSLoader;
+
+use crate::StackGraphLanguage;
+
+pub struct Loader {
+    tsg: Option<PathBuf>,
+    scope: Option<String>,
+    loader: TSLoader,
+    cache: Vec<(Language, StackGraphLanguage)>,
+}
+
+impl Loader {
+    pub fn new(tsg: Option<PathBuf>, scope: Option<String>, loader: TSLoader) -> Self {
+        Loader {
+            tsg,
+            scope,
+            loader,
+            cache: Vec::new(),
+        }
+    }
+
+    pub fn load_for_source_path(
+        &mut self,
+        source_path: &Path,
+    ) -> Result<&mut StackGraphLanguage, LoadError> {
+        let current_dir = std::env::current_dir().map_err(LoadError::other)?;
+        let scope = self.scope.clone();
+        let (language, path) = self.select_language(source_path, &current_dir, scope.as_deref())?;
+        // the borrow checker is a hard master...
+        let index = self.cache.iter().position(|e| &e.0 == &language);
+        let index = match index {
+            Some(index) => index,
+            None => {
+                let functions = Functions::stdlib();
+                let tsg = self.load_tsg_for_language(language, &path)?;
+                let sgl =
+                    StackGraphLanguage::new(language, tsg, functions).map_err(LoadError::other)?;
+                self.cache.push((language, sgl));
+                self.cache.len() - 1
+            }
+        };
+        let sgl = &mut self.cache[index].1;
+        Ok(sgl)
+    }
+
+    // This is a modified version of tree_sitter_loader::Loader::select_language that also returns the language path.
+    // TODO: Some version of this should be upstreamed to tree-sitter-loader
+    fn select_language(
+        &mut self,
+        path: &Path,
+        current_dir: &Path,
+        scope: Option<&str>,
+    ) -> Result<(Language, PathBuf), LoadError> {
+        if let Some(scope) = scope {
+            if let Some((lang, config)) = self
+                .loader
+                .language_configuration_for_scope(scope)
+                .with_context(|| format!("Failed to load language for scope '{}'", scope))?
+            {
+                Ok((lang, config.root_path.clone()))
+            } else {
+                return Err(LoadError::UnknownLanguageScope(scope.to_string()));
+            }
+        } else if let Some((lang, config)) = self
+            .loader
+            .language_configuration_for_file_name(path)
+            .with_context(|| format!("Failed to load language for file name {}", &path.display()))?
+        {
+            Ok((lang, config.root_path.clone()))
+        } else if let Some((lang, config)) = self
+            .language_configurations_at_path(&current_dir)
+            .with_context(|| "Failed to load language in current directory")?
+            .first()
+            .cloned()
+        {
+            Ok((lang, config.root_path.clone()))
+        } else {
+            Err(LoadError::NoLanguageFound)
+        }
+    }
+
+    // This is a stand in for a missing tree_sitter_loader::Loader::languages_at_path method
+    // TODO: Some version of this should be upstreamed to tree-sitter-loader
+    fn language_configurations_at_path(
+        &mut self,
+        path: &Path,
+    ) -> Result<Vec<(Language, &LanguageConfiguration<'_>)>, LoadError> {
+        let languages = self.loader.languages_at_path(path)?;
+        let configurations = self.loader.find_language_configurations_at_path(path)?;
+        let result = languages
+            .iter()
+            .cloned()
+            .zip(configurations.iter())
+            .into_iter()
+            .collect();
+        Ok(result)
+    }
+
+    fn load_tsg_for_language(&self, language: Language, path: &Path) -> Result<File, LoadError> {
+        let lang_tsg_path = path.join("queries/stack-graphs.tsg");
+        let tsg_path = if let Some(path) = &self.tsg {
+            path
+        } else if lang_tsg_path.exists() {
+            &lang_tsg_path
+        } else {
+            return Err(LoadError::NoTsgFound);
+        };
+
+        let tsg_source = std::fs::read(tsg_path)
+            .with_context(|| format!("Failed to read {}", tsg_path.display()))?;
+        let tsg_source = String::from_utf8(tsg_source).map_err(LoadError::other)?;
+        let tsg = File::from_str(language, &tsg_source)
+            .with_context(|| format!("Failed to parse {}", tsg_path.display()))?;
+
+        Ok(tsg)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum LoadError {
+    #[error("No language found")]
+    NoLanguageFound,
+    #[error("No TSG file found")]
+    NoTsgFound,
+    #[error("Unknown language scope {0}")]
+    UnknownLanguageScope(String),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+impl LoadError {
+    fn other<E>(error: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        Self::Other(error.into())
+    }
+}

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -72,6 +72,8 @@ impl Loader {
                 .language_configuration_for_scope(scope)
                 .with_context(|| format!("Failed to load language for scope '{}'", scope))?
             {
+                // FIXME Because we try all files in a directory, we should not return a language here
+                //       if it does not match the given path.
                 Ok((lang, config.root_path.clone()))
             } else {
                 return Err(LoadError::UnknownLanguageScope(scope.to_string()));

--- a/tree-sitter-stack-graphs/src/test.rs
+++ b/tree-sitter-stack-graphs/src/test.rs
@@ -5,7 +5,47 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-//! Defines
+//! Defines a test file format for stack graph resolution.
+//!
+//! ## Assertions
+//!
+//! Test files are source files in the language under test with assertions added in comments.
+//! Assertions indicate a the position of a reference in the source with a carrot `^`, and
+//! specify the line numbers, separated by commas, of the definitions where the reference is
+//! expected to resolve.
+//!
+//! An example test for Python might be defined in `test.py` and look as follows:
+//!
+//! ``` skip
+//! x = 42
+//! y = -1
+//! print(x, y)
+//! #     ^ defined: 1
+//! #        ^ defined: 2
+//! ```
+//!
+//! Consecutive lines with assertions all apply to the last source line without an assertion.
+//! In the example, both assertions refer to positions on line 3.
+//!
+//! ## Fragments for multi-file testing
+//!
+//! Test files may also consist of multiple fragments, which are treated as separate files in the
+//! stack graph. An example test that simulates two different Python files:
+//!
+//! ``` skip
+//! # --- path: one.py ---
+//! x = 42
+//! y = -1
+//! # --- path: one.py ---
+//! print(x, y)
+//! #     ^ defined: 2
+//! #        ^ defined: 3
+//! ```
+//!
+//! Note that the line numbers still refer to lines in the complete test file, and are not relative
+//! to a fragment.
+//!
+//! Any content before the first fragment header of the file is ignored, and will not be part of the test.
 
 use itertools::Itertools;
 use lazy_static::lazy_static;

--- a/tree-sitter-stack-graphs/src/test.rs
+++ b/tree-sitter-stack-graphs/src/test.rs
@@ -1,0 +1,390 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2022, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! Defines
+
+use itertools::Itertools;
+use lazy_static::lazy_static;
+use lsp_positions::Position;
+use lsp_positions::PositionedSubstring;
+use lsp_positions::SpanCalculator;
+use regex::Regex;
+use stack_graphs::arena::Handle;
+use stack_graphs::assert::Assertion;
+use stack_graphs::assert::AssertionError;
+use stack_graphs::assert::AssertionSource;
+use stack_graphs::assert::AssertionTarget;
+use stack_graphs::graph::File;
+use stack_graphs::graph::StackGraph;
+use stack_graphs::paths::Paths;
+use thiserror::Error;
+
+lazy_static! {
+    static ref PATH_REGEX: Regex = Regex::new(r#"---\s*path:\s*([^\s]+)\s*---"#).unwrap();
+    static ref ASSERTION_REGEX: Regex =
+        Regex::new(r#"(\^)\s*defined:\s*(\d+(?:\s*,\s*\d+)*)?"#).unwrap();
+    static ref LINE_NUMBER_REGEX: Regex = Regex::new(r#"\d+"#).unwrap();
+}
+
+/// An error that can occur while parsing tests
+#[derive(Debug, Error)]
+pub enum TestError {
+    AssertionOnFirstLine,
+    DuplicatePath(String),
+    InvalidColumn(usize, usize, usize),
+}
+
+impl std::fmt::Display for TestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AssertionOnFirstLine => write!(f, "Assertion cannot appear on first line"),
+            Self::DuplicatePath(path) => write!(f, "Duplicate path {}", path),
+            Self::InvalidColumn(assertion_line, column, regular_line) => write!(
+                f,
+                "Assertion on line {} refers to missing column {} on line {}",
+                assertion_line + 1,
+                column + 1,
+                regular_line + 1
+            ),
+        }
+    }
+}
+
+/// A stack graph test
+pub struct Test {
+    pub path: String,
+    pub files: Vec<TestFile>,
+    pub graph: StackGraph,
+    pub paths: Paths,
+}
+
+/// A file from a stack graph test
+#[derive(Debug, Clone)]
+pub struct TestFile {
+    pub file: Handle<File>,
+    pub source: String,
+    pub assertions: Vec<Assertion>,
+}
+
+impl Test {
+    /// Creates a test from source.
+    pub fn from_source(path: &str, source: &str) -> Result<Self, TestError> {
+        let mut graph = StackGraph::new();
+        let mut test_files = Vec::new();
+        let mut current_file = graph.add_file(path).unwrap();
+        let mut current_source = String::new();
+        let mut prev_source = String::new();
+        let mut line_files = Vec::new();
+        for (current_line_number, current_line) in
+            PositionedSubstring::lines_iter(source).enumerate()
+        {
+            if let Some(m) = PATH_REGEX.captures_iter(current_line.content).next() {
+                // if the test starts with a file header, we do not create an empty entry for the
+                // test file itself
+                if current_line_number != 0 {
+                    test_files.push(TestFile {
+                        file: current_file,
+                        source: current_source,
+                        assertions: Vec::new(),
+                    });
+                }
+                let path = m.get(1).unwrap().as_str();
+                current_file = graph
+                    .add_file(path)
+                    .map_err(|_| TestError::DuplicatePath(path.to_string()))?;
+                current_source = prev_source.clone();
+            }
+
+            current_source.push_str(current_line.content);
+            current_source.push_str("\n");
+
+            line_files.push(current_file);
+
+            Self::push_whitespace_for(&current_line, &mut prev_source);
+            prev_source.push_str("\n");
+        }
+        test_files.push(TestFile {
+            file: current_file,
+            source: current_source,
+            assertions: Vec::new(),
+        });
+
+        for test_file in &mut test_files {
+            test_file.parse_assertions(|l| line_files[l])?;
+        }
+
+        Ok(Self {
+            path: path.to_string(),
+            files: test_files,
+            graph,
+            paths: Paths::new(),
+        })
+    }
+
+    /// Pushes whitespace equivalent to the given line into the string.
+    /// This is used to "erase" preceding content in multi-file test.
+    /// It is implemented as pushing as many SPACE-s as there are code
+    /// units in the original line.
+    /// * This preserves global UTF-8 positions, i.e., a UTF-8 position in a
+    ///   test file source points to the same thing in the original source
+    ///   and vice versa. However, global UTF-16 and grapheme positions are
+    ///   not preserved.
+    /// * Line numbers are preserved, i.e., a line in the test file source
+    ///   has the same line number as in the overall source, and vice versa.
+    /// * Positions within "erased" lines are not preserved, regardless of
+    ///   whether they are UTF-8, UTF-16, or grapheme positions. Positions
+    ///   in the actual content are preserved between the test file source and
+    ///   the test source.
+    fn push_whitespace_for(line: &PositionedSubstring, into: &mut String) {
+        (0..line.utf8_bounds.end).for_each(|_| into.push_str(" "));
+    }
+}
+
+impl TestFile {
+    /// Parse assertions in the source.
+    fn parse_assertions<F>(&mut self, line_file: F) -> Result<(), TestError>
+    where
+        F: Fn(usize) -> Handle<File>,
+    {
+        self.assertions.clear();
+
+        let mut current_line_span_calculator = SpanCalculator::new(&self.source);
+        let mut last_regular_line: Option<PositionedSubstring> = None;
+        let mut last_regular_line_number = None;
+        let mut last_regular_line_span_calculator = SpanCalculator::new(&self.source);
+        for (current_line_number, current_line) in
+            PositionedSubstring::lines_iter(&self.source).enumerate()
+        {
+            if let Some(m) = ASSERTION_REGEX.captures_iter(current_line.content).next() {
+                // assertion line
+                let last_regular_line = last_regular_line
+                    .as_ref()
+                    .ok_or_else(|| TestError::AssertionOnFirstLine)?;
+                let last_regular_line_number = last_regular_line_number.unwrap();
+
+                let carret_match = m.get(1).unwrap();
+                let line_numbers_match = m.get(2);
+
+                let column_utf8_offset = carret_match.start();
+                let column_grapheme_offset = current_line_span_calculator
+                    .for_line_and_column(
+                        current_line_number,
+                        current_line.utf8_bounds.start,
+                        column_utf8_offset,
+                    )
+                    .column
+                    .grapheme_offset;
+                if column_grapheme_offset >= last_regular_line.grapheme_length {
+                    return Err(TestError::InvalidColumn(
+                        current_line_number,
+                        column_grapheme_offset,
+                        last_regular_line_number,
+                    ));
+                }
+                let position = last_regular_line_span_calculator.for_line_and_grapheme(
+                    last_regular_line_number,
+                    last_regular_line.utf8_bounds.start,
+                    column_grapheme_offset,
+                );
+                let source = AssertionSource {
+                    file: self.file,
+                    position,
+                };
+
+                let targets = LINE_NUMBER_REGEX
+                    .find_iter(line_numbers_match.map(|m| m.as_str()).unwrap_or(""))
+                    .map(|l| l.as_str().parse::<usize>().unwrap() - 1)
+                    .map(|l| AssertionTarget {
+                        file: line_file(l),
+                        line: l,
+                    })
+                    .collect::<Vec<_>>();
+
+                self.assertions.push(Assertion::Defined { source, targets });
+            } else {
+                // regular source line
+                last_regular_line = Some(current_line);
+                last_regular_line_number = Some(current_line_number);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Result of running a stack graph test.
+#[derive(Debug, Clone)]
+pub struct TestResult {
+    success_count: usize,
+    failures: Vec<TestFailure>,
+}
+
+impl TestResult {
+    fn new() -> Self {
+        Self {
+            failures: Vec::new(),
+            success_count: 0,
+        }
+    }
+
+    fn add_success(&mut self) {
+        self.success_count += 1;
+    }
+
+    fn add_failure(&mut self, reason: TestFailure) {
+        self.failures.push(reason);
+    }
+
+    /// Number of successfull assertions.
+    pub fn success_count(&self) -> usize {
+        self.success_count
+    }
+
+    /// Number of failed assertions.
+    pub fn failure_count(&self) -> usize {
+        self.failures.len()
+    }
+
+    pub fn failures_iter(&self) -> std::slice::Iter<'_, TestFailure> {
+        self.failures.iter()
+    }
+
+    pub fn into_failures_iter(self) -> std::vec::IntoIter<TestFailure> {
+        self.failures.into_iter()
+    }
+
+    /// Total number of assertions that were run.
+    pub fn count(&self) -> usize {
+        self.success_count() + self.failure_count()
+    }
+}
+
+/// Description of test failures.
+// This mirrors AssertionError, but provides cleaner error messages. The underlying
+// assertions report errors in terms of the virtual files in the test. This type
+// ensures errors are reported in terms of locations in the original test file.
+// This makes errors clickable in e.g. the VS Code console, improving the developer
+// experience.
+#[derive(Debug, Clone)]
+pub enum TestFailure {
+    NoReferences {
+        path: String,
+        position: Position,
+    },
+    IncorrectDefinitions {
+        path: String,
+        position: Position,
+        symbols: Vec<String>,
+        missing_lines: Vec<usize>,
+        unexpected_lines: Vec<usize>,
+    },
+}
+
+impl std::fmt::Display for TestFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoReferences { path, position } => {
+                write!(
+                    f,
+                    "{}:{}:{}: no references found",
+                    path,
+                    position.line + 1,
+                    position.column.grapheme_offset + 1
+                )
+            }
+            Self::IncorrectDefinitions {
+                path,
+                position,
+                symbols,
+                missing_lines,
+                unexpected_lines,
+            } => {
+                write!(
+                    f,
+                    "{}:{}:{}: ",
+                    path,
+                    position.line + 1,
+                    position.column.grapheme_offset + 1
+                )?;
+                write!(f, "definition(s) for reference(s)")?;
+                for symbol in symbols {
+                    write!(f, " ‘{}’", symbol)?;
+                }
+                if !missing_lines.is_empty() {
+                    write!(
+                        f,
+                        " missing expected on line(s) {}",
+                        missing_lines.iter().map(|l| l + 1).format(", ")
+                    )?;
+                }
+                if !unexpected_lines.is_empty() {
+                    write!(
+                        f,
+                        " found unexpected on line(s) {}",
+                        unexpected_lines.iter().map(|l| l + 1).format(", ")
+                    )?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl Test {
+    /// Run the test. It is the responsibility of the caller to ensure that
+    /// the stack graph has been constructed for the test files before running
+    /// the test.
+    pub fn run(&mut self) -> TestResult {
+        let mut result = TestResult::new();
+        for file in &self.files {
+            for assertion in &file.assertions {
+                match assertion.run(&self.graph, &mut self.paths) {
+                    Ok(_) => result.add_success(),
+                    Err(e) => result.add_failure(self.from_error(e)),
+                }
+            }
+        }
+        result
+    }
+
+    /// Construct a TestFailure from an AssertionError.
+    fn from_error(&self, err: AssertionError) -> TestFailure {
+        match err {
+            AssertionError::NoReferences { source } => TestFailure::NoReferences {
+                path: self.path.clone(),
+                position: source.position,
+            },
+            AssertionError::IncorrectDefinitions {
+                source,
+                symbols,
+                missing_targets,
+                unexpected_paths,
+            } => TestFailure::IncorrectDefinitions {
+                path: self.path.clone(),
+                position: source.position,
+                symbols: symbols
+                    .iter()
+                    .map(|s| self.graph[*s].to_string())
+                    .sorted()
+                    .dedup()
+                    .collect(),
+                missing_lines: missing_targets
+                    .iter()
+                    .map(|t| t.line)
+                    .sorted()
+                    .dedup()
+                    .collect(),
+                unexpected_lines: unexpected_paths
+                    .iter()
+                    .map(|p| self.graph.source_info(p.end_node).unwrap().span.start.line)
+                    .sorted()
+                    .dedup()
+                    .collect(),
+            },
+        }
+    }
+}

--- a/tree-sitter-stack-graphs/tests/it/main.rs
+++ b/tree-sitter-stack-graphs/tests/it/main.rs
@@ -7,3 +7,4 @@
 
 mod edges;
 mod nodes;
+mod test;

--- a/tree-sitter-stack-graphs/tests/it/test.rs
+++ b/tree-sitter-stack-graphs/tests/it/test.rs
@@ -1,0 +1,144 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use lazy_static::lazy_static;
+use pretty_assertions::assert_eq;
+use stack_graphs::arena::Handle;
+use stack_graphs::graph::File;
+use stack_graphs::graph::StackGraph;
+use tree_sitter_graph::functions::Functions;
+use tree_sitter_graph::Variables;
+use tree_sitter_stack_graphs::test::Test;
+use tree_sitter_stack_graphs::LoadError;
+use tree_sitter_stack_graphs::StackGraphLanguage;
+
+lazy_static! {
+    static ref TSG: &'static str = r#"
+      (module) @mod {
+          node @mod.lexical_in
+          node @mod.lexical_out
+          edge @mod.lexical_in -> ROOT_NODE
+          edge ROOT_NODE -> @mod.lexical_out
+      }
+      (module (_)@stmt) @mod {
+          node @stmt.lexical_in
+          node @stmt.lexical_out
+          edge @stmt.lexical_in -> @mod.lexical_in
+          edge @mod.lexical_out -> @stmt.lexical_out
+      }
+      (module (_)@left . (_)@right) {
+          edge @right.lexical_in -> @left.lexical_out
+      }
+      (expression_statement (assignment left:(identifier)@name))@stmt {
+          node @name.def
+          attr (@name.def) type = "pop_symbol", symbol = (source-text @name), source_node = @name, is_definition
+          edge @stmt.lexical_out -> @name.def
+      }
+      [
+        (expression_statement (assignment right:(identifier)@name))@stmt
+        (expression_statement (identifier)@name)@stmt
+      ] {
+          node @name.ref
+          attr (@name.ref) type = "push_symbol", symbol = (source-text @name), source_node = @name, is_reference
+          edge @name.ref -> @stmt.lexical_in
+      }
+    "#;
+}
+
+fn build_stack_graph_into(
+    graph: &mut StackGraph,
+    file: Handle<File>,
+    python_source: &str,
+    tsg_source: &str,
+) -> Result<(), LoadError> {
+    let functions = Functions::stdlib();
+    let mut language =
+        StackGraphLanguage::from_str(tree_sitter_python::language(), tsg_source, functions)
+            .unwrap();
+    let mut globals = Variables::new();
+    language.build_stack_graph_into(graph, file, python_source, &mut globals)?;
+    Ok(())
+}
+
+fn check_test(
+    python_source: &str,
+    tsg_source: &str,
+    expected_successes: usize,
+    expected_failures: usize,
+) {
+    let mut test = Test::from_source("test.py", python_source).expect("Could not parse test");
+    let assertion_count: usize = test.files.iter().map(|f| f.assertions.len()).sum();
+    assert_eq!(
+        expected_successes + expected_failures,
+        assertion_count,
+        "expected {} assertions, got {}",
+        expected_successes + expected_failures,
+        assertion_count,
+    );
+    for test_file in &test.files {
+        build_stack_graph_into(
+            &mut test.graph,
+            test_file.file,
+            &test_file.source,
+            tsg_source,
+        )
+        .expect("Could not load stack graph");
+    }
+    let results = test.run();
+    assert_eq!(
+        expected_successes,
+        results.success_count(),
+        "expected {} successes, got {}",
+        expected_successes,
+        results.success_count()
+    );
+    assert_eq!(
+        expected_failures,
+        results.failure_count(),
+        "expected {} failures, got {}",
+        expected_failures,
+        results.failure_count()
+    );
+}
+
+#[test]
+fn aligns_correctly_with_unicode() {
+    let python = r#"
+      x = 1;
+      m = {};
+
+      # multi code unit character in assertion line
+      m[" "] = x;
+      #  §   # ^ defined: 2
+
+      # multi code point character in source line
+      m["§"] = x;
+      #      # ^ defined: 2
+
+      # multi code point character in assertion line
+      m[" "] = x;
+      #  g̈   # ^ defined: 2
+
+      # multi code point character in source line
+      m["g̈"] = x;
+      #      # ^ defined: 2
+    "#;
+    check_test(python, &TSG, 4, 0);
+}
+
+#[test]
+fn test_can_be_multi_file() {
+    let python = r#"
+      # --- path: a.py ---
+      x = 1;
+
+      # --- path: b.py ---
+        x;
+      # ^ defined: 3
+    "#;
+    check_test(python, &TSG, 1, 0);
+}


### PR DESCRIPTION
This adds language loading and test parsing & running to the library, and a test command to the CLI.

Example output of a test run:

```
✓ ../tree-sitter-code-nav/test/typescript/statements/import-as-namespace.ts: 3/3 assertions
✓ ../tree-sitter-code-nav/test/typescript/statements/import-indirectly-exported-variable.ts: 4/4 assertions
✓ ../tree-sitter-code-nav/test/typescript/statements/let-without-value.ts: 3/3 assertions
✓ ../tree-sitter-code-nav/test/typescript/statements/import-from-subdirectory.ts: 3/3 assertions
✗ ../tree-sitter-code-nav/test/typescript/statements/shadowing.ts: 0/6 assertions
  ../tree-sitter-code-nav/test/typescript/statements/shadowing.ts:6:8: definition(s) for reference(s) ‘T’ found unexpected ‘T’ on lines(s) 1
  ../tree-sitter-code-nav/test/typescript/statements/shadowing.ts:8:7: definition(s) for reference(s) ‘x’ found unexpected ‘x’ on lines(s) 3
  ../tree-sitter-code-nav/test/typescript/statements/shadowing.ts:14:5: definition(s) for reference(s) ‘x’ found unexpected ‘x’ on lines(s) 3
  ../tree-sitter-code-nav/test/typescript/statements/shadowing.ts:20:10: definition(s) for reference(s) ‘T’ found unexpected ‘T’ on lines(s) 1
  ../tree-sitter-code-nav/test/typescript/statements/shadowing.ts:22:5: definition(s) for reference(s) ‘x’ found unexpected ‘x’ on lines(s) 3
  ../tree-sitter-code-nav/test/typescript/statements/shadowing.ts:27:5: definition(s) for reference(s) ‘x’ found unexpected ‘x’ on lines(s) 3
  Visualization: ../tree-sitter-code-nav/test/typescript/statements/shadowing.html
✓ ../tree-sitter-code-nav/test/typescript/statements/coverage.ts: 77/77 assertions
✓ ../tree-sitter-code-nav/test/typescript/statements/namespace-type-export.ts: 4/4 assertions
Error: 6 assertions failed
```

Example output when a syntax error is encountered:

```
Error: Error running test ../tree-sitter-code-nav/typescript-dev/playground.ts

Caused by:
      ../tree-sitter-code-nav/typescript-dev/playground.ts:3:17: Unexpected syntax: f
      ../tree-sitter-code-nav/typescript-dev/playground.ts:9:5: Unexpected syntax: .
```