### PR TITLE
Bound the amount of work performed in each phase

### DIFF
--- a/stack-graphs/include/stack-graphs.h
+++ b/stack-graphs/include/stack-graphs.h
@@ -591,6 +591,9 @@ struct sg_forward_path_stitcher {
     // The number of new candidate paths that were discovered in the most recent phase.  If this
     // is 0, then the path stitching algorithm is complete.
     size_t previous_phase_paths_length;
+    // Whether the stitching algorithm is complete.  You should keep calling
+    // `sg_forward_path_stitcher_process_next_phase` until this field is true.
+    bool is_complete;
 };
 
 // Implements a phased forward partial path stitching algorithm.
@@ -615,6 +618,9 @@ struct sg_forward_partial_path_stitcher {
     // The number of new candidate partial paths that were discovered in the most recent phase.
     // If this is 0, then the partial path stitching algorithm is complete.
     size_t previous_phase_partial_paths_length;
+    // Whether the stitching algorithm is complete.  You should keep calling
+    // `sg_forward_partial_path_stitcher_process_next_phase` until this field is true.
+    bool is_complete;
 };
 
 // The handle of the singleton root node.
@@ -998,6 +1004,14 @@ struct sg_forward_path_stitcher *sg_forward_path_stitcher_new(const struct sg_st
                                                               size_t count,
                                                               const sg_node_handle *starting_nodes);
 
+// Sets the maximum amount of work that can be performed during each phase of the algorithm. By
+// bounding our work this way, you can ensure that it's not possible for our CPU-bound algorithm
+// to starve any worker threads or processes that you might be using.  If you don't call this
+// method, then we allow ourselves to process all of the extensions of all of the paths found in
+// the previous phase, with no additional bound.
+void sg_forward_path_stitcher_set_max_work_per_phase(struct sg_forward_path_stitcher *stitcher,
+                                                     size_t max_work);
+
 // Runs the next phase of the path-stitching algorithm.  We will have built up a set of
 // incomplete paths during the _previous_ phase.  Before calling this function, you must
 // ensure that `db` contains all of the possible partial paths that we might want to extend
@@ -1030,6 +1044,14 @@ struct sg_forward_partial_path_stitcher *sg_forward_partial_path_stitcher_new(co
                                                                               struct sg_partial_path_database *db,
                                                                               size_t count,
                                                                               const sg_node_handle *starting_nodes);
+
+// Sets the maximum amount of work that can be performed during each phase of the algorithm. By
+// bounding our work this way, you can ensure that it's not possible for our CPU-bound algorithm
+// to starve any worker threads or processes that you might be using.  If you don't call this
+// method, then we allow ourselves to process all of the extensions of all of the paths found in
+// the previous phase, with no additional bound.
+void sg_forward_partial_path_stitcher_set_max_work_per_phase(struct sg_forward_partial_path_stitcher *stitcher,
+                                                             size_t max_work);
 
 // Runs the next phase of the algorithm.  We will have built up a set of incomplete partial paths
 // during the _previous_ phase.  Before calling this function, you must ensure that `db` contains

--- a/stack-graphs/tests/it/c/can_jump_to_definition_with_phased_partial_path_stitching.rs
+++ b/stack-graphs/tests/it/c/can_jump_to_definition_with_phased_partial_path_stitching.rs
@@ -11,6 +11,7 @@ use pretty_assertions::assert_eq;
 use stack_graphs::c::sg_forward_partial_path_stitcher_free;
 use stack_graphs::c::sg_forward_partial_path_stitcher_new;
 use stack_graphs::c::sg_forward_partial_path_stitcher_process_next_phase;
+use stack_graphs::c::sg_forward_partial_path_stitcher_set_max_work_per_phase;
 use stack_graphs::c::sg_partial_path;
 use stack_graphs::c::sg_partial_path_arena;
 use stack_graphs::c::sg_partial_path_arena_find_partial_paths_in_file;
@@ -134,11 +135,12 @@ fn check_jump_to_definition(graph: &TestGraph, file: &str, expected_partial_path
         references.len(),
         references.as_ptr() as *const _,
     );
+    sg_forward_partial_path_stitcher_set_max_work_per_phase(stitcher, 1);
     let rust_stitcher = unsafe { &mut *stitcher };
 
     // Keep processing phases until the stitching algorithm is done.
     let mut results = BTreeSet::new();
-    while rust_stitcher.previous_phase_partial_paths_length > 0 {
+    while !rust_stitcher.is_complete {
         let partial_paths_slice = unsafe {
             std::slice::from_raw_parts(
                 rust_stitcher.previous_phase_partial_paths as *const PartialPath,

--- a/stack-graphs/tests/it/c/can_jump_to_definition_with_phased_path_stitching.rs
+++ b/stack-graphs/tests/it/c/can_jump_to_definition_with_phased_path_stitching.rs
@@ -11,6 +11,7 @@ use pretty_assertions::assert_eq;
 use stack_graphs::c::sg_forward_path_stitcher_free;
 use stack_graphs::c::sg_forward_path_stitcher_new;
 use stack_graphs::c::sg_forward_path_stitcher_process_next_phase;
+use stack_graphs::c::sg_forward_path_stitcher_set_max_work_per_phase;
 use stack_graphs::c::sg_partial_path;
 use stack_graphs::c::sg_partial_path_arena;
 use stack_graphs::c::sg_partial_path_arena_find_partial_paths_in_file;
@@ -140,11 +141,12 @@ fn check_jump_to_definition(graph: &TestGraph, file: &str, expected_paths: &[&st
         references.len(),
         references.as_ptr() as *const _,
     );
+    sg_forward_path_stitcher_set_max_work_per_phase(stitcher, 1);
     let rust_stitcher = unsafe { &mut *stitcher };
 
     // Keep processing phases until the stitching algorithm is done.
     let mut results = BTreeSet::new();
-    while rust_stitcher.previous_phase_paths_length > 0 {
+    while !rust_stitcher.is_complete {
         let paths_slice = unsafe {
             std::slice::from_raw_parts(
                 rust_stitcher.previous_phase_paths as *const Path,


### PR DESCRIPTION
In our phased path stitching algorithms, you can now bound the total amount of work that can be performed in each phase.

The mechanics of using the stitching classes are exactly the same — check which paths were newly discovered in the previous phase, and load any possible extensions of them into the database before starting the next phase.

The limit is configurable, and defaults to the previous behavior of no additional bound.  (There is always _some_ limit on the amount of work performed, since we only process extensions of paths found in previous phases.)