### PR TITLE
Allow stitching from arbitrary partial paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
             ${{ runner.OS }}-cargo-
       - name: Install cargo-valgrind
         run: |
+          sudo apt-get update
           sudo apt-get install -y valgrind
           cargo install cargo-valgrind
       - name: Build library

--- a/stack-graphs/CHANGELOG.md
+++ b/stack-graphs/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- The new `ForwardPartialPathStitcher::from_partial_paths` constructor lets you
+  seed a path stitching search with a specific list of partial paths (which need
+  not be in the `Database`).  This can be used, for instance, to implement “find
+  qualified definitions”, where we look for any definition of a fully qualified
+  name (expressed as a symbol stack).  There is a new test case that shows an
+  example implementation.
+
+### Changed
+
+- The `ForwardPartialPathStitcher::new` constructor has been renamed to
+  `from_nodes`, to be more consistent with the new `from_partial_paths`
+  constructor.
+
 ## stack-graphs 0.5.0 - 2022-02-17
 
 ### Added

--- a/stack-graphs/include/stack-graphs.h
+++ b/stack-graphs/include/stack-graphs.h
@@ -1039,11 +1039,24 @@ void sg_forward_path_stitcher_free(struct sg_forward_path_stitcher *stitcher);
 // must ensure that `db` contains all possible extensions of any of those initial partial paths.
 // You can retrieve a list of those extensions via the `previous_phase_partial_paths` and
 // `previous_phase_partial_paths_length` fields.
-struct sg_forward_partial_path_stitcher *sg_forward_partial_path_stitcher_new(const struct sg_stack_graph *graph,
-                                                                              struct sg_partial_path_arena *partials,
-                                                                              struct sg_partial_path_database *db,
-                                                                              size_t count,
-                                                                              const sg_node_handle *starting_nodes);
+struct sg_forward_partial_path_stitcher *sg_forward_partial_path_stitcher_from_nodes(const struct sg_stack_graph *graph,
+                                                                                     struct sg_partial_path_arena *partials,
+                                                                                     struct sg_partial_path_database *db,
+                                                                                     size_t count,
+                                                                                     const sg_node_handle *starting_nodes);
+
+// Creates a new forward partial path stitcher that is "seeded" with a set of initial partial
+// paths.
+//
+// Before calling `sg_forward_partial_path_stitcher_process_next_phase` for the first time, you
+// must ensure that `db` contains all possible extensions of any of those initial partial paths.
+// You can retrieve a list of those extensions via the `previous_phase_partial_paths` and
+// `previous_phase_partial_paths_length` fields.
+struct sg_forward_partial_path_stitcher *sg_forward_partial_path_stitcher_from_partial_paths(const struct sg_stack_graph *_graph,
+                                                                                             struct sg_partial_path_arena *partials,
+                                                                                             struct sg_partial_path_database *_db,
+                                                                                             size_t count,
+                                                                                             const struct sg_partial_path *initial_partial_paths);
 
 // Sets the maximum amount of work that can be performed during each phase of the algorithm. By
 // bounding our work this way, you can ensure that it's not possible for our CPU-bound algorithm

--- a/stack-graphs/src/c.rs
+++ b/stack-graphs/src/c.rs
@@ -1918,7 +1918,7 @@ impl InternalForwardPartialPathStitcher {
 /// You can retrieve a list of those extensions via the `previous_phase_partial_paths` and
 /// `previous_phase_partial_paths_length` fields.
 #[no_mangle]
-pub extern "C" fn sg_forward_partial_path_stitcher_new(
+pub extern "C" fn sg_forward_partial_path_stitcher_from_nodes(
     graph: *const sg_stack_graph,
     partials: *mut sg_partial_path_arena,
     db: *mut sg_partial_path_database,
@@ -1929,12 +1929,36 @@ pub extern "C" fn sg_forward_partial_path_stitcher_new(
     let partials = unsafe { &mut (*partials).inner };
     let db = unsafe { &mut (*db).inner };
     let starting_nodes = unsafe { std::slice::from_raw_parts(starting_nodes, count) };
-    let stitcher = ForwardPartialPathStitcher::new(
+    let stitcher = ForwardPartialPathStitcher::from_nodes(
         graph,
         partials,
         db,
         starting_nodes.iter().copied().map(sg_node_handle::into),
     );
+    Box::into_raw(Box::new(InternalForwardPartialPathStitcher::new(
+        stitcher, partials,
+    ))) as *mut _
+}
+
+/// Creates a new forward partial path stitcher that is "seeded" with a set of initial partial
+/// paths.
+///
+/// Before calling `sg_forward_partial_path_stitcher_process_next_phase` for the first time, you
+/// must ensure that `db` contains all possible extensions of any of those initial partial paths.
+/// You can retrieve a list of those extensions via the `previous_phase_partial_paths` and
+/// `previous_phase_partial_paths_length` fields.
+#[no_mangle]
+pub extern "C" fn sg_forward_partial_path_stitcher_from_partial_paths(
+    _graph: *const sg_stack_graph,
+    partials: *mut sg_partial_path_arena,
+    _db: *mut sg_partial_path_database,
+    count: usize,
+    initial_partial_paths: *const sg_partial_path,
+) -> *mut sg_forward_partial_path_stitcher {
+    let partials = unsafe { &mut (*partials).inner };
+    let initial_partial_paths =
+        unsafe { std::slice::from_raw_parts(initial_partial_paths as *const PartialPath, count) };
+    let stitcher = ForwardPartialPathStitcher::from_partial_paths(initial_partial_paths.to_vec());
     Box::into_raw(Box::new(InternalForwardPartialPathStitcher::new(
         stitcher, partials,
     ))) as *mut _

--- a/stack-graphs/tests/it/c/mod.rs
+++ b/stack-graphs/tests/it/c/mod.rs
@@ -8,6 +8,7 @@
 mod can_create_graph;
 mod can_find_local_nodes;
 mod can_find_partial_paths_in_file;
+mod can_find_qualified_definitions_with_phased_partial_path_stitching;
 mod can_jump_to_definition;
 mod can_jump_to_definition_with_phased_partial_path_stitching;
 mod can_jump_to_definition_with_phased_path_stitching;


### PR DESCRIPTION
You can now instantiate the forward partial path stitcher with an explicit list of initial partial paths.  From there, the phased algorithm proceeds exactly as before.  This lets us implement “find qualified definitions”, where we look for any definition that is reachable from a particular fully qualified name (expressed as a symbol stack).