### PR TITLE
Remove extra work from find qualified defs test

### DIFF
--- a/stack-graphs/tests/it/c/can_find_qualified_definitions_with_phased_partial_path_stitching.rs
+++ b/stack-graphs/tests/it/c/can_find_qualified_definitions_with_phased_partial_path_stitching.rs
@@ -133,28 +133,6 @@ fn check_find_qualified_definitions(
         );
     }
 
-    // Seed the database with the partial paths that start at any of the starting nodes.
-    copious_debugging!(
-        "==> Add initial partial paths for <{}>",
-        partial_symbol_stack.display(rust_graph, rust_partials),
-    );
-    storage_layer.add_to_database(graph.graph, partials, db, |partial_path| {
-        if partial_path.start_node != StackGraph::root_node() {
-            return false;
-        }
-
-        let mut symbol_bindings = PartialSymbolStackBindings::new();
-        let mut scope_bindings = PartialScopeStackBindings::new();
-        partial_symbol_stack
-            .unify(
-                rust_partials,
-                partial_path.symbol_stack_precondition,
-                &mut symbol_bindings,
-                &mut scope_bindings,
-            )
-            .is_ok()
-    });
-
     // Create the forward partial path stitcher.
     let initial_partial_path = PartialPath {
         start_node: StackGraph::root_node(),


### PR DESCRIPTION
Turns out we don't need this step — the initial partial paths show up as the “previous phase” and so we'll load in their extensions in the while loop below.