### PR TITLE
Add stack graph assertions

### DIFF
--- a/lsp-positions/src/lib.rs
+++ b/lsp-positions/src/lib.rs
@@ -258,6 +258,14 @@ impl<'a> PositionedSubstring<'a> {
         }
     }
 
+    // Returns an iterator over the lines of the given string.
+    pub fn lines_iter(string: &'a str) -> Lines<'a> {
+        Lines {
+            string,
+            next_utf8_offset: 0,
+        }
+    }
+
     /// Trims ASCII whitespace from both ends of a substring.
     pub fn trim_whitespace(&mut self) {
         let leading_whitespace = self
@@ -290,6 +298,24 @@ impl<'a> PositionedSubstring<'a> {
         self.utf16_length -= utf16_len(right_whitespace);
         self.grapheme_length -= grapheme_len(left_whitespace);
         self.grapheme_length -= grapheme_len(right_whitespace);
+    }
+}
+
+pub struct Lines<'a> {
+    string: &'a str,
+    next_utf8_offset: usize,
+}
+
+impl<'a> Iterator for Lines<'a> {
+    type Item = PositionedSubstring<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.string.len() <= self.next_utf8_offset {
+            return None;
+        }
+        let next = PositionedSubstring::from_line(self.string, self.next_utf8_offset);
+        self.next_utf8_offset = next.utf8_bounds.end + 1;
+        Some(next)
     }
 }
 

--- a/lsp-positions/src/lib.rs
+++ b/lsp-positions/src/lib.rs
@@ -235,9 +235,9 @@ impl<'a> PositionedSubstring<'a> {
     /// Constructs a new positioned substring for a newline-terminated line within a file.  You
     /// provide the byte offset of the start of the line, and we automatically find the end of the
     /// line.
-    pub fn from_line(file: &'a str, line_utf8_offset: usize) -> PositionedSubstring<'a> {
+    pub fn from_line(string: &'a str, line_utf8_offset: usize) -> PositionedSubstring<'a> {
         // The line's byte index lets us trim all preceding lines in the file.
-        let line_plus_others = &file[line_utf8_offset..];
+        let line_plus_others = &string[line_utf8_offset..];
 
         // The requested line stops at the first newline, or at the end of the file if there aren't
         // any newlines.
@@ -293,9 +293,9 @@ impl<'a> PositionedSubstring<'a> {
     }
 }
 
-/// Automates the construction of [`Span`][] instances for content within a source file.
+/// Automates the construction of [`Span`][] instances for content within a string.
 pub struct SpanCalculator<'a> {
-    source: &'a str,
+    string: &'a str,
     containing_line: Option<PositionedSubstring<'a>>,
     trimmed_line: Option<PositionedSubstring<'a>>,
     columns: Vec<Offset>,
@@ -309,18 +309,18 @@ pub struct SpanCalculator<'a> {
 // revisit a line!
 
 impl<'a> SpanCalculator<'a> {
-    /// Creates a new span calculator for locations within the given source file.
-    pub fn new(source: &'a str) -> SpanCalculator<'a> {
+    /// Creates a new span calculator for locations within the given string.
+    pub fn new(string: &'a str) -> SpanCalculator<'a> {
         SpanCalculator {
-            source,
+            string,
             containing_line: None,
             trimmed_line: None,
             columns: Vec::new(),
         }
     }
 
-    /// Constructs a [`Position`][] instance for a particular line and column in the source file.
-    /// You must provide the 0-indexed line number, the byte offset of the line within the file,
+    /// Constructs a [`Position`][] instance for a particular line and column in the string.
+    /// You must provide the 0-indexed line number, the byte offset of the line within the string,
     /// and the UTF-8 byte offset of the character within the line.
     pub fn for_line_and_column(
         &mut self,
@@ -358,8 +358,8 @@ impl<'a> SpanCalculator<'a> {
         self.for_line_and_column(position.row, line_utf8_offset, position.column)
     }
 
-    /// Constructs a [`Position`][] instance for a particular line and column in the source file.
-    /// You must provide the 0-indexed line number, the byte offset of the line within the file,
+    /// Constructs a [`Position`][] instance for a particular line and column in the string.
+    /// You must provide the 0-indexed line number, the byte offset of the line within the string,
     /// and the grapheme offset of the character within the line.
     pub fn for_line_and_grapheme(
         &mut self,
@@ -384,7 +384,7 @@ impl<'a> SpanCalculator<'a> {
                 return;
             }
         }
-        let line = PositionedSubstring::from_line(self.source, line_utf8_offset);
+        let line = PositionedSubstring::from_line(self.string, line_utf8_offset);
         self.columns.clear();
         self.columns.extend(Offset::all_chars(line.content));
         let mut trimmed = line.clone();

--- a/lsp-positions/src/lib.rs
+++ b/lsp-positions/src/lib.rs
@@ -112,13 +112,13 @@ pub struct Span {
 }
 
 impl Span {
-    pub fn contains(&self, position: Position) -> bool {
-        self.start <= position && self.end > position
+    pub fn contains(&self, position: &Position) -> bool {
+        &self.start <= position && &self.end > position
     }
 
     #[cfg(feature = "tree-sitter")]
-    pub fn contains_point(&self, point: tree_sitter::Point) -> bool {
-        self.start <= point && self.end > point
+    pub fn contains_point(&self, point: &tree_sitter::Point) -> bool {
+        &self.start <= point && &self.end > point
     }
 }
 

--- a/stack-graphs/Cargo.toml
+++ b/stack-graphs/Cargo.toml
@@ -25,6 +25,7 @@ bitvec = "0.22"
 controlled-option = "0.4"
 either = "1.6"
 fxhash = "0.2"
+itertools = "0.10"
 libc = "0.2"
 lsp-positions = { version="0.2", path="../lsp-positions" }
 serde = { version="1.0", optional=true }

--- a/stack-graphs/src/assert.rs
+++ b/stack-graphs/src/assert.rs
@@ -1,0 +1,136 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2022, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! Defines assertions that can be run against a stack graph.
+
+use itertools::Itertools;
+use lsp_positions::Position;
+
+use crate::arena::Handle;
+use crate::graph::File;
+use crate::graph::Node;
+use crate::graph::StackGraph;
+use crate::graph::Symbol;
+use crate::paths::Path;
+use crate::paths::Paths;
+
+/// A stack graph assertion
+#[derive(Debug, Clone)]
+pub enum Assertion {
+    Defined {
+        source: AssertionSource,
+        targets: Vec<AssertionTarget>,
+    },
+}
+
+/// Source position of an assertion
+#[derive(Debug, Clone)]
+pub struct AssertionSource {
+    pub file: Handle<File>,
+    pub position: Position,
+}
+
+/// Target line of an assertion
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AssertionTarget {
+    pub file: Handle<File>,
+    pub line: usize,
+}
+
+impl AssertionTarget {
+    /// Checks if the target matches the node corresponding to the handle in the given graph.
+    pub fn matches_node(&self, node: Handle<Node>, graph: &StackGraph) -> bool {
+        let file = graph[node].file().unwrap();
+        let si = graph.source_info(node).unwrap();
+        let start_line = si.span.start.line;
+        let end_line = si.span.end.line;
+        file == self.file && start_line <= self.line && self.line <= end_line
+    }
+}
+
+/// Error describing assertion failures.
+#[derive(Clone)]
+pub enum AssertionError {
+    NoReferences {
+        source: AssertionSource,
+    },
+    IncorrectDefinitions {
+        source: AssertionSource,
+        symbols: Vec<Handle<Symbol>>,
+        missing_targets: Vec<AssertionTarget>,
+        unexpected_paths: Vec<Path>,
+    },
+}
+
+impl Assertion {
+    /// Run this assertion against the given graph, using the given paths object for path search.
+    pub fn run(&self, graph: &StackGraph, paths: &mut Paths) -> Result<(), AssertionError> {
+        match self {
+            Assertion::Defined {
+                source,
+                targets: expected_targets,
+            } => {
+                let references = graph
+                    .nodes_for_file(source.file)
+                    .filter(|n| {
+                        graph[*n].is_reference()
+                            && graph
+                                .source_info(*n)
+                                .map(|s| s.span.contains(&source.position))
+                                .unwrap_or(false)
+                    })
+                    .collect::<Vec<_>>();
+                if references.is_empty() {
+                    Err(AssertionError::NoReferences {
+                        source: source.clone(),
+                    })
+                } else {
+                    let mut actual_paths = Vec::new();
+                    paths.find_all_paths(graph, references.clone(), |g, _ps, p| {
+                        if p.is_complete(g) {
+                            actual_paths.push(p);
+                        }
+                    });
+                    let missing_targets = expected_targets
+                        .iter()
+                        .filter(|t| {
+                            !actual_paths
+                                .iter()
+                                .any(|p| t.matches_node(p.end_node, graph))
+                        })
+                        .cloned()
+                        .unique()
+                        .collect::<Vec<_>>();
+                    let unexpected_paths = actual_paths
+                        .iter()
+                        .filter(|p| {
+                            !expected_targets
+                                .iter()
+                                .any(|t| t.matches_node(p.end_node, graph))
+                        })
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    if missing_targets.is_empty() && unexpected_paths.is_empty() {
+                        Ok(())
+                    } else {
+                        let symbols = references
+                            .iter()
+                            .map(|r| graph[*r].symbol().unwrap())
+                            .unique()
+                            .collect::<Vec<_>>();
+                        Err(AssertionError::IncorrectDefinitions {
+                            source: source.clone(),
+                            symbols,
+                            missing_targets,
+                            unexpected_paths,
+                        })
+                    }
+                }
+            }
+        }
+    }
+}

--- a/stack-graphs/src/lib.rs
+++ b/stack-graphs/src/lib.rs
@@ -56,6 +56,7 @@
 //! original source file.  (a.k.a., it’s incremental!)
 
 pub mod arena;
+pub mod assert;
 pub mod c;
 pub mod cycles;
 #[macro_use]


### PR DESCRIPTION
Adds assertions that can be run against a stack graph.  This is only
responsible for the stack graph side of testing, i.e., determining paths
and checking of assertions hold.  The `tree-sitter-stack-graphs` test
functionality builds on this by providing a format for writing tests in
source.
