### PR TITLE
Add path functions

### DIFF
--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
@@ -167,12 +167,6 @@ impl Command {
         graph: &mut StackGraph,
     ) -> anyhow::Result<()> {
         let mut globals = Variables::new();
-        globals
-            .add(
-                "FILE_PATH".into(),
-                format!("{}", source_path.display()).into(),
-            )
-            .expect("Failed to set FILE_PATH");
         match sgl.build_stack_graph_into(
             graph,
             test_fragment.file,

--- a/tree-sitter-stack-graphs/src/functions.rs
+++ b/tree-sitter-stack-graphs/src/functions.rs
@@ -1,0 +1,101 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use tree_sitter_graph::functions::Functions;
+
+pub fn add_path_functions(functions: &mut Functions) {
+    functions.add("normalize-path".into(), path::NormalizePath);
+    functions.add("resolve-path".into(), path::ResolvePath);
+}
+
+pub mod path {
+    use std::path::Component;
+    use std::path::Path;
+    use std::path::PathBuf;
+    use tree_sitter_graph::functions::Function;
+    use tree_sitter_graph::functions::Parameters;
+    use tree_sitter_graph::graph::Graph;
+    use tree_sitter_graph::graph::Value;
+    use tree_sitter_graph::ExecutionError;
+
+    pub struct NormalizePath;
+
+    impl Function for NormalizePath {
+        fn call(
+            &mut self,
+            _graph: &mut Graph,
+            _source: &str,
+            parameters: &mut dyn Parameters,
+        ) -> Result<Value, ExecutionError> {
+            let path = parameters.param()?.into_string()?;
+            parameters.finish()?;
+
+            let path = Path::new(&path);
+            let path = normalize_path(&path.to_path_buf());
+
+            Ok(path.to_str().unwrap().into())
+        }
+    }
+
+    pub struct ResolvePath;
+
+    impl Function for ResolvePath {
+        fn call(
+            &mut self,
+            _graph: &mut Graph,
+            _source: &str,
+            parameters: &mut dyn Parameters,
+        ) -> Result<Value, ExecutionError> {
+            let base_path = parameters.param()?.into_string()?;
+            let path = parameters.param()?.into_string()?;
+            parameters.finish()?;
+
+            // FIXME .parent() assumes this is a file path, this API needs some thought
+            let path = Path::new(&base_path).parent().unwrap().join(path);
+
+            Ok(path.to_str().unwrap().into())
+        }
+    }
+
+    /// Normalize a path, removing things like `.` and `..`.
+    ///
+    /// CAUTION: This does not resolve symlinks (unlike
+    /// [`std::fs::canonicalize`]). This may cause incorrect or surprising
+    /// behavior at times. This should be used carefully. Unfortunately,
+    /// [`std::fs::canonicalize`] can be hard to use correctly, since it can often
+    /// fail, or on Windows returns annoying device paths. This is a problem Cargo
+    /// needs to improve on.
+    // Copied from Cargo
+    // https://github.com/rust-lang/cargo/blob/e515c3277bf0681bfc79a9e763861bfe26bb05db/crates/cargo-util/src/paths.rs#L73-L106
+    // Licensed under MIT license & Apache License (Version 2.0)
+    pub fn normalize_path(path: &PathBuf) -> PathBuf {
+        let mut components = path.components().peekable();
+        let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
+            components.next();
+            PathBuf::from(c.as_os_str())
+        } else {
+            PathBuf::new()
+        };
+
+        for component in components {
+            match component {
+                Component::Prefix(..) => unreachable!(),
+                Component::RootDir => {
+                    ret.push(component.as_os_str());
+                }
+                Component::CurDir => {}
+                Component::ParentDir => {
+                    ret.pop();
+                }
+                Component::Normal(c) => {
+                    ret.push(c);
+                }
+            }
+        }
+        ret
+    }
+}

--- a/tree-sitter-stack-graphs/src/functions.rs
+++ b/tree-sitter-stack-graphs/src/functions.rs
@@ -5,11 +5,15 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+//! Define tree-sitter-graph functions
+
 use tree_sitter_graph::functions::Functions;
 
 pub fn add_path_functions(functions: &mut Functions) {
     functions.add("path-dir".into(), path::PathDir);
+    functions.add("path-fileext".into(), path::PathFileExt);
     functions.add("path-filename".into(), path::PathFileName);
+    functions.add("path-filestem".into(), path::PathFileStem);
     functions.add("path-join".into(), path::PathJoin);
     functions.add("path-normalize".into(), path::PathNormalize);
     functions.add("path-split".into(), path::PathSplit);
@@ -25,7 +29,9 @@ pub mod path {
     use tree_sitter_graph::ExecutionError;
 
     pub struct PathDir;
+    pub struct PathFileExt;
     pub struct PathFileName;
+    pub struct PathFileStem;
     pub struct PathJoin;
     pub struct PathNormalize;
     pub struct PathSplit;
@@ -47,6 +53,23 @@ pub mod path {
         }
     }
 
+    impl Function for PathFileExt {
+        fn call(
+            &mut self,
+            _graph: &mut Graph,
+            _source: &str,
+            parameters: &mut dyn Parameters,
+        ) -> Result<Value, ExecutionError> {
+            let path = PathBuf::from(parameters.param()?.into_string()?);
+            parameters.finish()?;
+
+            let path = path.extension();
+            Ok(path
+                .map(|p| p.to_str().unwrap().into())
+                .unwrap_or(Value::Null))
+        }
+    }
+
     impl Function for PathFileName {
         fn call(
             &mut self,
@@ -58,6 +81,23 @@ pub mod path {
             parameters.finish()?;
 
             let path = path.file_name();
+            Ok(path
+                .map(|p| p.to_str().unwrap().into())
+                .unwrap_or(Value::Null))
+        }
+    }
+
+    impl Function for PathFileStem {
+        fn call(
+            &mut self,
+            _graph: &mut Graph,
+            _source: &str,
+            parameters: &mut dyn Parameters,
+        ) -> Result<Value, ExecutionError> {
+            let path = PathBuf::from(parameters.param()?.into_string()?);
+            parameters.finish()?;
+
+            let path = path.file_stem();
             Ok(path
                 .map(|p| p.to_str().unwrap().into())
                 .unwrap_or(Value::Null))

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -188,6 +188,51 @@
 //! }
 //! ```
 //!
+//! ### Working with paths
+//!
+//! Built-in path functions are available to compute symbols that depend on path information, such as
+//! module names or imports. The path of the file is provided in the global variable `FILE_PATH`.
+//!
+//! The following path functions are available:
+//! - `path-dir`: get the path consisting of all but the last component of the argument path, or `#null` if it ends in root
+//! - `path-fileext`: get the file extension, i.e. everything after the final `.` of the file name of the argument path, or `#null` if it has extension
+//! - `path-filename`: get the last component of the argument path, or `#null` if it has no final component
+//! - `path-filestem`: get the file stem of the argument path, i.e., everything before the extension, or `#null` if it has no file name
+//! - `path-join`: join all argument paths together
+//! - `path-normalize`: normalize the argument path by eliminating `.` and `..` components where possible
+//! - `path-split`: split the argument path into a list of its components
+//!
+//! The following example computes a module name from a file path:
+//!
+//! ``` skip
+//! global FILE_PATH
+//!
+//! (program)@prog {
+//!   ; ...
+//!   let dir = (path-dir FILE_PATH)
+//!   let stem = (path-filestem FILE_PATH)
+//!   let mod_name = (path-join dir stem)
+//!   node mod_def
+//!   attr mod_def type = "pop_symbol", symbol = mod_name, is_definition, source_node = @prog
+//!   ; ...
+//! }
+//! ```
+//!
+//! The following example resolves an import relative to the current file:
+//!
+//! ``` skip
+//! global FILE_PATH
+//!
+//! (import name:(_)@name)@import {
+//!   ; ...
+//!   let dir = (path-dir FILE_PATH)
+//!   let mod_name = (path-normalize (path-join dir (Source-text @name)))
+//!   node mod_def
+//!   attr mod_def type = "pop_symbol", symbol = mod_name, is_definition, source_node = @prog
+//!   ; ...
+//! }
+//! ```
+//!
 //! ## Using this crate from Rust
 //!
 //! If you need very fine-grained control over how to use the resulting stack graphs, you can

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -253,6 +253,7 @@ use tree_sitter_graph::parse_error::TreeWithParseErrorVec;
 use tree_sitter_graph::ExecutionConfig;
 use tree_sitter_graph::Variables;
 
+pub mod functions;
 pub mod loader;
 pub mod test;
 

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -267,8 +267,7 @@
 //! "#;
 //! let grammar = tree_sitter_python::language();
 //! let tsg_source = STACK_GRAPH_RULES;
-//! let functions = Functions::stdlib();
-//! let mut language = StackGraphLanguage::from_str(grammar, tsg_source, functions)?;
+//! let mut language = StackGraphLanguage::from_str(grammar, tsg_source)?;
 //! let mut stack_graph = StackGraph::new();
 //! let file_handle = stack_graph.get_or_create_file("test.py");
 //! let mut globals = Variables::new();
@@ -356,7 +355,6 @@ impl StackGraphLanguage {
     pub fn new(
         language: tree_sitter::Language,
         tsg: tree_sitter_graph::ast::File,
-        functions: tree_sitter_graph::functions::Functions,
     ) -> Result<StackGraphLanguage, LanguageError> {
         debug_assert_eq!(language, tsg.language);
         let mut parser = Parser::new();
@@ -364,7 +362,7 @@ impl StackGraphLanguage {
         Ok(StackGraphLanguage {
             parser,
             tsg,
-            functions,
+            functions: Self::default_functions(),
         })
     }
 
@@ -373,7 +371,6 @@ impl StackGraphLanguage {
     pub fn from_str(
         language: tree_sitter::Language,
         tsg_source: &str,
-        functions: tree_sitter_graph::functions::Functions,
     ) -> Result<StackGraphLanguage, LanguageError> {
         let mut parser = Parser::new();
         parser.set_language(language)?;
@@ -381,8 +378,18 @@ impl StackGraphLanguage {
         Ok(StackGraphLanguage {
             parser,
             tsg,
-            functions,
+            functions: Self::default_functions(),
         })
+    }
+
+    fn default_functions() -> tree_sitter_graph::functions::Functions {
+        let mut functions = tree_sitter_graph::functions::Functions::stdlib();
+        crate::functions::add_path_functions(&mut functions);
+        functions
+    }
+
+    pub fn functions_mut(&mut self) -> &mut tree_sitter_graph::functions::Functions {
+        &mut self.functions
     }
 }
 

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -341,6 +341,7 @@ static PRECEDENCE_ATTR: &'static str = "precedence";
 // Global variables
 static ROOT_NODE_VAR: &'static str = "ROOT_NODE";
 static JUMP_TO_SCOPE_NODE_VAR: &'static str = "JUMP_TO_SCOPE_NODE";
+static FILE_PATH_VAR: &'static str = "FILE_PATH";
 
 /// Holds information about how to construct stack graphs for a particular language
 pub struct StackGraphLanguage {
@@ -420,10 +421,16 @@ impl StackGraphLanguage {
         let mut graph = Graph::new();
         globals
             .add(ROOT_NODE_VAR.into(), graph.add_graph_node().into())
-            .unwrap();
+            .expect("Failed to set ROOT_NODE");
         globals
             .add(JUMP_TO_SCOPE_NODE_VAR.into(), graph.add_graph_node().into())
-            .unwrap();
+            .expect("Failed to set JUMP_TO_SCOPE_NODE");
+        globals
+            .add(
+                FILE_PATH_VAR.into(),
+                format!("{}", &stack_graph[file]).into(),
+            )
+            .expect("Failed to set FILE_PATH");
         let mut config = ExecutionConfig::new(&mut self.functions, &globals).lazy(true);
         self.tsg
             .execute_into(&mut graph, &tree, source, &mut config)?;

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -29,7 +29,6 @@ use std::path::PathBuf;
 use thiserror::Error;
 use tree_sitter::Language;
 use tree_sitter_graph::ast::File as TsgFile;
-use tree_sitter_graph::functions::Functions;
 use tree_sitter_loader::Config as TsConfig;
 use tree_sitter_loader::LanguageConfiguration;
 use tree_sitter_loader::Loader as TsLoader;
@@ -113,11 +112,9 @@ impl Loader {
         let index = match index {
             Some(index) => index,
             None => {
-                let mut functions = Functions::stdlib();
-                crate::functions::add_path_functions(&mut functions);
                 let tsg = self.load_tsg_for_language(&language)?;
-                let sgl = StackGraphLanguage::new(language.language, tsg, functions)
-                    .map_err(LoadError::other)?;
+                let sgl =
+                    StackGraphLanguage::new(language.language, tsg).map_err(LoadError::other)?;
                 self.cache.push((language.language, sgl));
 
                 self.cache.len() - 1

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -113,7 +113,8 @@ impl Loader {
         let index = match index {
             Some(index) => index,
             None => {
-                let functions = Functions::stdlib();
+                let mut functions = Functions::stdlib();
+                crate::functions::add_path_functions(&mut functions);
                 let tsg = self.load_tsg_for_language(&language)?;
                 let sgl = StackGraphLanguage::new(language.language, tsg, functions)
                     .map_err(LoadError::other)?;

--- a/tree-sitter-stack-graphs/tests/it/edges.rs
+++ b/tree-sitter-stack-graphs/tests/it/edges.rs
@@ -9,16 +9,13 @@ use std::collections::BTreeSet;
 
 use pretty_assertions::assert_eq;
 use stack_graphs::graph::StackGraph;
-use tree_sitter_graph::functions::Functions;
 use tree_sitter_graph::Variables;
 use tree_sitter_stack_graphs::LoadError;
 use tree_sitter_stack_graphs::StackGraphLanguage;
 
 fn build_stack_graph(python_source: &str, tsg_source: &str) -> Result<StackGraph, LoadError> {
-    let functions = Functions::stdlib();
     let mut language =
-        StackGraphLanguage::from_str(tree_sitter_python::language(), tsg_source, functions)
-            .unwrap();
+        StackGraphLanguage::from_str(tree_sitter_python::language(), tsg_source).unwrap();
     let mut graph = StackGraph::new();
     let file = graph.get_or_create_file("test.py");
     let mut globals = Variables::new();

--- a/tree-sitter-stack-graphs/tests/it/nodes.rs
+++ b/tree-sitter-stack-graphs/tests/it/nodes.rs
@@ -7,16 +7,13 @@
 
 use pretty_assertions::assert_eq;
 use stack_graphs::graph::StackGraph;
-use tree_sitter_graph::functions::Functions;
 use tree_sitter_graph::Variables;
 use tree_sitter_stack_graphs::LoadError;
 use tree_sitter_stack_graphs::StackGraphLanguage;
 
 fn build_stack_graph(python_source: &str, tsg_source: &str) -> Result<StackGraph, LoadError> {
-    let functions = Functions::stdlib();
     let mut language =
-        StackGraphLanguage::from_str(tree_sitter_python::language(), tsg_source, functions)
-            .unwrap();
+        StackGraphLanguage::from_str(tree_sitter_python::language(), tsg_source).unwrap();
     let mut graph = StackGraph::new();
     let file = graph.get_or_create_file("test.py");
     let mut globals = Variables::new();

--- a/tree-sitter-stack-graphs/tests/it/test.rs
+++ b/tree-sitter-stack-graphs/tests/it/test.rs
@@ -12,7 +12,6 @@ use stack_graphs::graph::File;
 use stack_graphs::graph::StackGraph;
 use std::path::Path;
 use std::path::PathBuf;
-use tree_sitter_graph::functions::Functions;
 use tree_sitter_graph::Variables;
 use tree_sitter_stack_graphs::test::Test;
 use tree_sitter_stack_graphs::LoadError;
@@ -58,10 +57,8 @@ fn build_stack_graph_into(
     python_source: &str,
     tsg_source: &str,
 ) -> Result<(), LoadError> {
-    let functions = Functions::stdlib();
     let mut language =
-        StackGraphLanguage::from_str(tree_sitter_python::language(), tsg_source, functions)
-            .unwrap();
+        StackGraphLanguage::from_str(tree_sitter_python::language(), tsg_source).unwrap();
     let mut globals = Variables::new();
     language.build_stack_graph_into(graph, file, python_source, &mut globals)?;
     Ok(())


### PR DESCRIPTION
This PR improves the path functions that are provided.

The current functions are:
- `normalize`, which normalizes a path be removing `.` and `..` components
- `resolve`, which takes two paths and resolves the second relative to _the parent of_ the first.

The `resolve` function does too many things, and doesn't give the use enough control. I have split it up and created now the following functions (following what several API's do for paths): `path-dir`, `path-filext`, `path-filename`, `path-filestem`, `path-join`, `path-normalize` (as it was), and `path-split`.