### PR TITLE
Add CLI options to control output files

### DIFF
--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/loader.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/loader.rs
@@ -17,21 +17,18 @@ use tree_sitter_stack_graphs::loader::Loader;
 
 #[derive(Args)]
 pub struct LoaderArgs {
-    /// The TSG file to use for stack graph construction
-    #[clap(long)]
-    #[clap(name = "TSG_PATH")]
+    /// The TSG file to use for stack graph construction.
+    #[clap(long, value_name = "TSG_PATH")]
     tsg: Option<PathBuf>,
 
     /// The path to look for tree-sitter grammars.
     /// Can be specified multiple times.
-    #[clap(long)]
-    #[clap(name = "GRAMMAR_PATH")]
+    #[clap(long, value_name = "GRAMMAR_PATH")]
     grammar: Vec<PathBuf>,
 
     /// The scope of the tree-sitter grammar.
     /// See https://tree-sitter.github.io/tree-sitter/syntax-highlighting#basics for details.
-    #[clap(long)]
-    #[clap(name = "SCOPE")]
+    #[clap(long, value_name = "SCOPE")]
     scope: Option<String>,
 }
 

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/main.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/main.rs
@@ -12,8 +12,7 @@ use clap::Subcommand;
 pub(crate) const MAX_PARSE_ERRORS: usize = 5;
 
 #[derive(Parser)]
-#[clap(about)]
-#[clap(version)]
+#[clap(about, version)]
 struct Cli {
     #[clap(subcommand)]
     command: Commands,

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
@@ -154,15 +154,13 @@ impl Command {
                     .filter(|e| e.file_type().is_file())
                 {
                     let test_path = test_entry.path();
-                    total_failure_count += self
-                        .run_test(test_root, test_path, &mut loader)
-                        .with_context(|| format!("Error running test {}", test_path.display()))?;
+                    total_failure_count +=
+                        self.run_test_with_context(test_root, test_path, &mut loader)?;
                 }
             } else {
                 let test_root = test_path.parent().unwrap();
-                total_failure_count += self
-                    .run_test(test_root, test_path, &mut loader)
-                    .with_context(|| format!("Error running test {}", test_path.display()))?;
+                total_failure_count +=
+                    self.run_test_with_context(test_root, test_path, &mut loader)?;
             }
         }
 
@@ -177,6 +175,18 @@ impl Command {
         Ok(())
     }
 
+    /// Run test file and add error context to any failures that are returned.
+    fn run_test_with_context(
+        &self,
+        test_root: &Path,
+        test_path: &Path,
+        loader: &mut Loader,
+    ) -> anyhow::Result<usize> {
+        self.run_test(test_root, test_path, loader)
+            .with_context(|| format!("Error running test {}", test_path.display()))
+    }
+
+    /// Run test file.
     fn run_test(
         &self,
         test_root: &Path,

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
@@ -123,7 +123,7 @@ pub struct Command {
     save_visualization: Option<PathSpec>,
 
     /// Controls when graphs, paths, or visualization are saved.
-    #[clap(long, arg_enum, require_equals = true, default_value_t = OutputMode::OnFailure)]
+    #[clap(long, arg_enum, default_value_t = OutputMode::OnFailure)]
     output_mode: OutputMode,
 }
 

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
@@ -79,7 +79,9 @@ pub struct Command {
     #[clap(long)]
     show_ignored: bool,
 
-    /// Save graph.
+    /// Save graph for tests matching output mode.
+    /// Takes an optional path specification argument for the output file. [default: %n.graph.json]
+    /// Note: if used as the last flag without a path specification, add "--" before the test paths.
     #[clap(
         long,
         short = 'G',
@@ -89,7 +91,9 @@ pub struct Command {
     )]
     save_graph: Option<Vec<PathSpec>>,
 
-    /// Save paths.
+    /// Save paths for tests matching output mode.
+    /// Takes an optional path specification argument for the output file [default: %n.paths.json].
+    /// Note: if used as the last flag without a path specification, add "--" before the test paths.
     #[clap(
         long,
         short = 'P',
@@ -99,7 +103,9 @@ pub struct Command {
     )]
     save_paths: Option<Vec<PathSpec>>,
 
-    /// Save visualization.
+    /// Save visualization for tests matching output mode.
+    /// Takes an optional path specification argument for the output file [default: %n.html].
+    /// Note: if used as the last flag without a path specification, add "--" before the test paths.
     #[clap(
         long,
         short = 'V',

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
@@ -49,8 +49,7 @@ pub struct Command {
     loader: LoaderArgs,
 
     /// Source paths to test.
-    #[clap(name = "PATHS")]
-    #[clap(required = true)]
+    #[clap(value_name = "PATHS", required = true)]
     sources: Vec<PathBuf>,
 
     /// Hide passing tests.
@@ -66,24 +65,19 @@ pub struct Command {
     show_ignored: bool,
 
     /// Save graph.
-    #[clap(short = 'G')]
-    #[clap(long)]
+    #[clap(long, short = 'G')]
     save_graph: bool,
 
     /// Save paths.
-    #[clap(short = 'P')]
-    #[clap(long)]
+    #[clap(long, short = 'P')]
     save_paths: bool,
 
     /// Save visualization.
-    #[clap(short = 'V')]
-    #[clap(long)]
+    #[clap(long, short = 'V')]
     save_visualization: bool,
 
     /// Controls when graphs, paths, or visualization are saved.
-    #[clap(long)]
-    #[clap(arg_enum)]
-    #[clap(default_value_t = OutputMode::OnFailure)]
+    #[clap(long, arg_enum, default_value_t = OutputMode::OnFailure)]
     output_mode: OutputMode,
 }
 

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
@@ -81,8 +81,8 @@ pub struct Command {
     show_ignored: bool,
 
     /// Save graph for tests matching output mode.
-    /// Takes an optional path specification argument for the output file. [default: %n.graph.json]
-    /// Note: if used as the last flag without a path specification, add "--" before the test paths.
+    /// Takes an optional path specification argument for the output file.
+    /// [default: %n.graph.json]
     #[clap(
         long,
         short = 'G',
@@ -95,8 +95,8 @@ pub struct Command {
     save_graph: Option<PathSpec>,
 
     /// Save paths for tests matching output mode.
-    /// Takes an optional path specification argument for the output file [default: %n.paths.json].
-    /// Note: if used as the last flag without a path specification, add "--" before the test paths.
+    /// Takes an optional path specification argument for the output file.
+    /// [default: %n.paths.json]
     #[clap(
         long,
         short = 'P',
@@ -109,8 +109,8 @@ pub struct Command {
     save_paths: Option<PathSpec>,
 
     /// Save visualization for tests matching output mode.
-    /// Takes an optional path specification argument for the output file [default: %n.html].
-    /// Note: if used as the last flag without a path specification, add "--" before the test paths.
+    /// Takes an optional path specification argument for the output file.
+    /// [default: %n.html]
     #[clap(
         long,
         short = 'V',

--- a/tree-sitter-stack-graphs/src/functions.rs
+++ b/tree-sitter-stack-graphs/src/functions.rs
@@ -40,7 +40,7 @@ pub mod path {
         functions.add("path-join".into(), PathJoin);
         functions.add(
             "path-normalize".into(),
-            path_fn(|p| Some(normalize_path(p).as_os_str().to_os_string())),
+            path_fn(|p| Some(normalize(p).as_os_str().to_os_string())),
         );
         functions.add("path-split".into(), PathSplit);
     }
@@ -129,7 +129,7 @@ pub mod path {
     // Copied from Cargo
     // https://github.com/rust-lang/cargo/blob/e515c3277bf0681bfc79a9e763861bfe26bb05db/crates/cargo-util/src/paths.rs#L73-L106
     // Licensed under MIT license & Apache License (Version 2.0)
-    fn normalize_path(path: &Path) -> PathBuf {
+    pub fn normalize(path: &Path) -> PathBuf {
         let mut components = path.components().peekable();
         let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
             components.next();


### PR DESCRIPTION
Currently any file output produced by the CLI is put next to the input file it relates to. This PR adds optional arguments to the `--save-*` flags to specify the filename. Placeholders can be used that are substituted based on the input path.

The default changed to saving the file in the current directory, using the same name as the test file, but excluding directories. For example, `%n.html` for visualization.

One notable change is that `--save-*` take their argument with equals signs instead of using a separate argument. So, `--save-graph=%n.html` instead of `--save-graph %n.html`. This is to prevent accidental overwriting of user files when a user issues a command such as `tree-sitter-stack-graphs test --save-graph first.py second.py` where `first.py` would unintentionally be interpreted as the path to use for saving the visualization, instead of the first test path.

Fixes https://github.com/github/semantic-code/issues/299.

<details>
<summary>Output of `tree-sitter-stack-graphs test --help`</summary>

```
tree-sitter-stack-graphs-test
Run tests

USAGE:
    tree-sitter-stack-graphs test [OPTIONS] <TEST_PATH>...

ARGS:
    <TEST_PATH>...    Test file or directory paths

OPTIONS:
    -G, --save-graph[=<PATH_SPEC>...]
            Save graph for tests matching output mode. Takes an optional path specification argument
            for the output file. [default: %n.graph.json]

        --grammar <GRAMMAR_PATH>
            The path to look for tree-sitter grammars. Can be specified multiple times

    -h, --help
            Print help information

        --hide-failure-errors
            Hide failure error details

        --hide-passing
            Hide passing tests

        --output-mode <OUTPUT_MODE>
            Controls when graphs, paths, or visualization are saved [default: on-failure] [possible
            values: always, on-failure]

    -P, --save-paths[=<PATH_SPEC>...]
            Save paths for tests matching output mode. Takes an optional path specification argument
            for the output file. [default: %n.paths.json]

        --scope <SCOPE>
            The scope of the tree-sitter grammar. See https://tree-sitter.github.io/tree-
            sitter/syntax-highlighting#basics for details

        --show-ignored
            Show ignored files in output

        --tsg <TSG_PATH>
            The TSG file to use for stack graph construction

    -V, --save-visualization[=<PATH_SPEC>...]
            Save visualization for tests matching output mode. Takes an optional path specification
            argument for the output file. [default: %n.html]

PATH SPECIFICATIONS:
    Output filenames can be specified using placeholders based on the input file. The
    following placeholders are supported:
         %r   the root path, which is the directory argument which contains the file,
              or the directory of the file argument
         %d   the path directories relative to the root
         %n   the name of the file
         %e   the file extension (including the preceding dot)
         %%   a literal percentage sign
    Empty directory placeholders (%r and %d) are replaced by "." so that the shape of
    the path is not accidently changed. For example, "test -V %d/%n.html mytest.py"
    results in "./mytest.html" instead of the unintented "/mytest.html".
```
</details>