### PR TITLE
Add argument to control the default test fragment path

### DIFF
--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
@@ -188,7 +188,8 @@ impl Command {
                 return Ok(0);
             }
         };
-        let mut test = Test::from_source(&test_path, &source)?;
+        let default_fragment_path = test_path.strip_prefix(test_root).unwrap();
+        let mut test = Test::from_source(&test_path, &source, default_fragment_path)?;
         for test_fragment in &test.fragments {
             let fragment_path = Path::new(test.graph[test_fragment.file].name()).to_path_buf();
             if test_path.extension() != fragment_path.extension() {

--- a/tree-sitter-stack-graphs/src/test.rs
+++ b/tree-sitter-stack-graphs/src/test.rs
@@ -118,12 +118,17 @@ pub struct TestFragment {
 }
 
 impl Test {
-    /// Creates a test from source.
-    pub fn from_source(path: &Path, source: &str) -> Result<Self, TestError> {
+    /// Creates a test from source. If the test contains no `path` sections,
+    /// the default fragment path is used for the test's single test fragment.
+    pub fn from_source(
+        path: &Path,
+        source: &str,
+        default_fragment_path: &Path,
+    ) -> Result<Self, TestError> {
         let mut graph = StackGraph::new();
         let mut fragments = Vec::new();
         let mut have_fragments = false;
-        let mut current_path = path.to_path_buf();
+        let mut current_path = default_fragment_path.to_path_buf();
         let mut current_source = String::new();
         let mut prev_source = String::new();
         let mut line_files = Vec::new();

--- a/tree-sitter-stack-graphs/tests/it/test.rs
+++ b/tree-sitter-stack-graphs/tests/it/test.rs
@@ -71,7 +71,8 @@ fn check_test(
     expected_successes: usize,
     expected_failures: usize,
 ) {
-    let mut test = Test::from_source(python_path, python_source).expect("Could not parse test");
+    let mut test =
+        Test::from_source(python_path, python_source, python_path).expect("Could not parse test");
     let assertion_count: usize = test.fragments.iter().map(|f| f.assertions.len()).sum();
     assert_eq!(
         expected_successes + expected_failures,
@@ -176,7 +177,7 @@ fn test_cannot_assert_on_first_line() {
     let python = r#"
       # ^ defined: 3
     "#;
-    if let Ok(_) = Test::from_source(&PATH, python) {
+    if let Ok(_) = Test::from_source(&PATH, python, &PATH) {
         panic!("Parsing test unexpectedly succeeded.");
     }
 }
@@ -189,7 +190,7 @@ fn test_cannot_assert_before_first_fragment() {
         x;
       # ^ defined: 1
     "#;
-    if let Ok(_) = Test::from_source(&PATH, python) {
+    if let Ok(_) = Test::from_source(&PATH, python, &PATH) {
         panic!("Parsing test unexpectedly succeeded.");
     }
 }


### PR DESCRIPTION
Test files that do not contain `--- path: XYZ ---` headers consist of a single test fragment.
Currently we use the source as the path of this fragment.
This may not always be desriable, e.g. we may want to use a path relative to a test root instead.
This PR adds an argument to `Test::from_source` to pass the path to be used for this single fragment.
