### PR TITLE
Support builtins

### DIFF
--- a/stack-graphs/CHANGELOG.md
+++ b/stack-graphs/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Method `StackGraph::add_from_graph` to copy the one graph into another.
+
 ## stack-graphs 0.7.0 - 2022-04-19
 
 ### Added

--- a/stack-graphs/src/graph.rs
+++ b/stack-graphs/src/graph.rs
@@ -1412,7 +1412,7 @@ impl StackGraph {
 
     /// Copies the given stack graph into this stack graph. Panics if any of the files
     /// in the other stack graph are already defined in the current one.
-    pub fn add_graph(&mut self, other: &StackGraph) -> Result<(), Handle<File>> {
+    pub fn add_from_graph(&mut self, other: &StackGraph) -> Result<(), Handle<File>> {
         let mut files = HashMap::new();
         for other_file in other.iter_files() {
             let file = self.add_file(other[other_file].name())?;

--- a/stack-graphs/src/graph.rs
+++ b/stack-graphs/src/graph.rs
@@ -49,6 +49,7 @@
 //! [`Edge`]: struct.Edge.html
 //! [`File`]: struct.File.html
 
+use std::collections::HashMap;
 use std::fmt::Display;
 use std::num::NonZeroU32;
 use std::ops::Index;
@@ -1407,6 +1408,155 @@ impl StackGraph {
     /// Creates a new, initially empty stack graph.
     pub fn new() -> StackGraph {
         StackGraph::default()
+    }
+
+    /// Copies the given stack graph into this stack graph. Panics if any of the files
+    /// in the other stack graph are already defined in the current one.
+    pub fn add_graph(&mut self, other: &StackGraph) -> Result<(), Handle<File>> {
+        let mut files = HashMap::new();
+        for other_file in other.iter_files() {
+            let file = self.add_file(other[other_file].name())?;
+            files.insert(other_file, file);
+        }
+        let node_id = |other_node_id: NodeID| {
+            if other_node_id.is_root() {
+                NodeID::root()
+            } else if other_node_id.is_jump_to() {
+                NodeID::jump_to()
+            } else {
+                NodeID::new_in_file(
+                    files[&other_node_id.file.into_option().unwrap()],
+                    other_node_id.local_id,
+                )
+            }
+        };
+        let mut nodes = HashMap::new();
+        nodes.insert(Self::root_node(), Self::root_node());
+        nodes.insert(Self::jump_to_node(), Self::jump_to_node());
+        for other_file in files.keys().cloned() {
+            let file = files[&other_file];
+            for other_node in other.nodes_for_file(other_file) {
+                let value: Node = match other[other_node] {
+                    Node::DropScopes(DropScopesNode { id, .. }) => DropScopesNode {
+                        id: NodeID::new_in_file(file, id.local_id),
+                        _symbol: ControlledOption::default(),
+                        _scope: NodeID::default(),
+                        _is_endpoint: bool::default(),
+                    }
+                    .into(),
+                    Node::JumpTo(JumpToNode { .. }) => JumpToNode {
+                        id: NodeID::jump_to(),
+                        _symbol: ControlledOption::default(),
+                        _scope: NodeID::default(),
+                        _is_endpoint: bool::default(),
+                    }
+                    .into(),
+                    Node::PopScopedSymbol(PopScopedSymbolNode {
+                        id,
+                        symbol,
+                        is_definition,
+                        ..
+                    }) => PopScopedSymbolNode {
+                        id: NodeID::new_in_file(file, id.local_id),
+                        symbol: self.add_symbol(&other[symbol]),
+                        _scope: NodeID::default(),
+                        is_definition: is_definition,
+                    }
+                    .into(),
+                    Node::PopSymbol(PopSymbolNode {
+                        id,
+                        symbol,
+                        is_definition,
+                        ..
+                    }) => PopSymbolNode {
+                        id: NodeID::new_in_file(file, id.local_id),
+                        symbol: self.add_symbol(&other[symbol]),
+                        _scope: NodeID::default(),
+                        is_definition: is_definition,
+                    }
+                    .into(),
+                    Node::PushScopedSymbol(PushScopedSymbolNode {
+                        id,
+                        symbol,
+                        scope,
+                        is_reference,
+                        ..
+                    }) => PushScopedSymbolNode {
+                        id: NodeID::new_in_file(file, id.local_id),
+                        symbol: self.add_symbol(&other[symbol]),
+                        scope: node_id(scope),
+                        is_reference: is_reference,
+                        _phantom: (),
+                    }
+                    .into(),
+                    Node::PushSymbol(PushSymbolNode {
+                        id,
+                        symbol,
+                        is_reference,
+                        ..
+                    }) => PushSymbolNode {
+                        id: NodeID::new_in_file(file, id.local_id),
+                        symbol: self.add_symbol(&other[symbol]),
+                        _scope: NodeID::default(),
+                        is_reference: is_reference,
+                    }
+                    .into(),
+                    Node::Root(RootNode { .. }) => RootNode {
+                        id: NodeID::root(),
+                        _symbol: ControlledOption::default(),
+                        _scope: NodeID::default(),
+                        _is_endpoint: bool::default(),
+                    }
+                    .into(),
+                    Node::Scope(ScopeNode {
+                        id, is_exported, ..
+                    }) => ScopeNode {
+                        id: NodeID::new_in_file(file, id.local_id),
+                        _symbol: ControlledOption::default(),
+                        _scope: NodeID::default(),
+                        is_exported: is_exported,
+                    }
+                    .into(),
+                };
+                let node = self.add_node(value.id(), value).unwrap();
+                nodes.insert(other_node, node);
+                if let Some(source_info) = other.source_info(other_node) {
+                    *self.source_info_mut(node) = SourceInfo {
+                        span: source_info.span.clone(),
+                        syntax_type: source_info
+                            .syntax_type
+                            .map(|st| self.add_string(&other[st])),
+                        containing_line: source_info
+                            .containing_line
+                            .into_option()
+                            .map(|cl| self.add_string(&other[cl]))
+                            .into(),
+                    };
+                }
+                if let Some(debug_info) = other.debug_info(other_node) {
+                    *self.debug_info_mut(node) = DebugInfo {
+                        entries: debug_info
+                            .entries
+                            .iter()
+                            .map(|e| DebugEntry {
+                                key: self.add_string(&other[e.key]),
+                                value: self.add_string(&other[e.value]),
+                            })
+                            .collect::<Vec<_>>(),
+                    };
+                }
+            }
+            for other_node in nodes.keys().cloned() {
+                for other_edge in other.outgoing_edges(other_node) {
+                    self.add_edge(
+                        nodes[&other_edge.source],
+                        nodes[&other_edge.sink],
+                        other_edge.precedence,
+                    );
+                }
+            }
+        }
+        Ok(())
     }
 }
 

--- a/stack-graphs/tests/it/graph.rs
+++ b/stack-graphs/tests/it/graph.rs
@@ -10,6 +10,7 @@ use std::collections::HashSet;
 use maplit::hashset;
 use stack_graphs::graph::StackGraph;
 
+use crate::test_graphs;
 use crate::test_graphs::CreateStackGraph;
 
 #[test]
@@ -175,4 +176,29 @@ fn singleton_nodes_have_correct_ids() {
     assert!(root.id().is_root());
     assert_eq!(root.display(&graph).to_string(), "[root]");
     assert_eq!(root.id().display(&graph).to_string(), "[root]");
+}
+
+#[test]
+fn can_add_graph_to_empty_graph() {
+    let mut graph = StackGraph::new();
+    let other = test_graphs::simple::new();
+    graph.add_graph(&other).expect("Adding graph failed");
+
+    for other_file in other.iter_files() {
+        let file = graph.get_file_unchecked(other[other_file].name());
+        assert_eq!(
+            graph.nodes_for_file(file).count(),
+            other.nodes_for_file(other_file).count()
+        );
+        assert_eq!(
+            graph
+                .nodes_for_file(file)
+                .map(|n| graph.outgoing_edges(n).count())
+                .sum::<usize>(),
+            other
+                .nodes_for_file(other_file)
+                .map(|n| graph.outgoing_edges(n).count())
+                .sum::<usize>()
+        );
+    }
 }

--- a/stack-graphs/tests/it/graph.rs
+++ b/stack-graphs/tests/it/graph.rs
@@ -182,7 +182,7 @@ fn singleton_nodes_have_correct_ids() {
 fn can_add_graph_to_empty_graph() {
     let mut graph = StackGraph::new();
     let other = test_graphs::simple::new();
-    graph.add_graph(&other).expect("Adding graph failed");
+    graph.add_from_graph(&other).expect("Adding graph failed");
 
     for other_file in other.iter_files() {
         let file = graph.get_file_unchecked(other[other_file].name());

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
@@ -236,7 +236,7 @@ impl Command {
         sgl: &mut StackGraphLanguage,
         graph: &mut StackGraph,
     ) -> anyhow::Result<()> {
-        if let Err(h) = graph.add_graph(sgl.builtins()) {
+        if let Err(h) = graph.add_from_graph(sgl.builtins()) {
             return Err(anyhow!("Duplicate builtin file {}", &graph[h]));
         }
         Ok(())

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -364,6 +364,7 @@ pub struct StackGraphLanguage {
     parser: Parser,
     tsg: tree_sitter_graph::ast::File,
     functions: Functions,
+    builtins: StackGraph,
 }
 
 impl StackGraphLanguage {
@@ -380,6 +381,7 @@ impl StackGraphLanguage {
             parser,
             tsg,
             functions: Self::default_functions(),
+            builtins: StackGraph::new(),
         })
     }
 
@@ -396,6 +398,7 @@ impl StackGraphLanguage {
             parser,
             tsg,
             functions: Self::default_functions(),
+            builtins: StackGraph::new(),
         })
     }
 
@@ -407,6 +410,14 @@ impl StackGraphLanguage {
 
     pub fn functions_mut(&mut self) -> &mut tree_sitter_graph::functions::Functions {
         &mut self.functions
+    }
+
+    pub fn builtins(&self) -> &StackGraph {
+        &self.builtins
+    }
+
+    pub fn builtins_mut(&mut self) -> &mut StackGraph {
+        &mut self.builtins
     }
 }
 

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -224,7 +224,7 @@ impl Loader {
                     .map_err(LoadError::other)?;
             }
         }
-        sgl.builtins_mut().add_graph(&graph).unwrap();
+        sgl.builtins_mut().add_from_graph(&graph).unwrap();
         Ok(())
     }
 }

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -228,6 +228,7 @@ impl LoadError {
         Self::Other(error.into())
     }
 }
+
 // ------------------------------------------------------------------------------------------------
 // tree_sitter_loader supplements
 


### PR DESCRIPTION
This PR adds support for loading builtins automatically from the grammar repository.

## Solution

Builtins are loaded from `GRAMMAR_REPO/queries/builtins.EXT` for any of the grammar extensions.

Builtins are expected to be source files in the target language, which will be parsed and processed using the language's TSG file to get the corresponding stack graph.

## Implementation

Builtins are added as a field on stack graph languages.
A method `StackGraph::add_graph` is added to copy the content of one graph into another.