### PR TITLE
Adds fields for definiens

### DIFF
--- a/stack-graphs/include/stack-graphs.h
+++ b/stack-graphs/include/stack-graphs.h
@@ -255,6 +255,9 @@ struct sg_source_info {
     // The full content of the line containing this node in its source file.
     sg_string_handle containing_line;
     // The location in its containing file of the source code that this node's definiens represents.
+    // This is used for things like the bodies of functions, rather than the RHSes of equations.
+    // If you need one of these to make the type checker happy, but you don't have one, just use
+    // sg_span::default(), as this will correspond to the all-0s spans which mean "no definiens".
     struct sg_span definiens_span;
 };
 

--- a/stack-graphs/include/stack-graphs.h
+++ b/stack-graphs/include/stack-graphs.h
@@ -254,6 +254,8 @@ struct sg_source_info {
     sg_string_handle syntax_type;
     // The full content of the line containing this node in its source file.
     sg_string_handle containing_line;
+    // The location in its containing file of the source code that this node's definiens represents.
+    struct sg_span definiens_span;
 };
 
 // An array of all of the source information in a stack graph.  Source information is associated

--- a/stack-graphs/src/c.rs
+++ b/stack-graphs/src/c.rs
@@ -629,6 +629,8 @@ pub struct sg_source_info {
     pub syntax_type: sg_string_handle,
     /// The full content of the line containing this node in its source file.
     pub containing_line: sg_string_handle,
+    /// The location in its containing file of the source code that this node's definiens represents.
+    pub definiens_span: sg_span,
 }
 
 /// All of the position information that we have about a range of content in a source file

--- a/stack-graphs/src/c.rs
+++ b/stack-graphs/src/c.rs
@@ -629,7 +629,11 @@ pub struct sg_source_info {
     pub syntax_type: sg_string_handle,
     /// The full content of the line containing this node in its source file.
     pub containing_line: sg_string_handle,
+
     /// The location in its containing file of the source code that this node's definiens represents.
+    /// This is used for things like the bodies of functions, rather than the RHSes of equations.
+    /// If you need one of these to make the type checker happy, but you don't have one, just use
+    /// sg_span::default(), as this will correspond to the all-0s spans which mean "no definiens".
     pub definiens_span: sg_span,
 }
 

--- a/stack-graphs/src/graph.rs
+++ b/stack-graphs/src/graph.rs
@@ -1333,7 +1333,11 @@ pub struct SourceInfo {
     pub syntax_type: Option<Handle<InternedString>>,
     /// The full content of the line containing this node in its source file.
     pub containing_line: ControlledOption<Handle<InternedString>>,
+    
     /// The location in its containing file of the source code that this node's definiens represents.
+    /// This is used for things like the bodies of functions, rather than the RHSes of equations.
+    /// If you need one of these to make the type checker happy, but you don't have one, just use
+    /// lsp_positions::Span::default(), as this will correspond to the all-0s spans which mean "no definiens".
     pub definiens_span: lsp_positions::Span,
 }
 

--- a/stack-graphs/src/graph.rs
+++ b/stack-graphs/src/graph.rs
@@ -1333,6 +1333,8 @@ pub struct SourceInfo {
     pub syntax_type: Option<Handle<InternedString>>,
     /// The full content of the line containing this node in its source file.
     pub containing_line: ControlledOption<Handle<InternedString>>,
+    /// The location in its containing file of the source code that this node's definiens represents.
+    pub definiens_span: lsp_positions::Span,
 }
 
 impl StackGraph {

--- a/stack-graphs/src/graph.rs
+++ b/stack-graphs/src/graph.rs
@@ -1333,7 +1333,6 @@ pub struct SourceInfo {
     pub syntax_type: Option<Handle<InternedString>>,
     /// The full content of the line containing this node in its source file.
     pub containing_line: ControlledOption<Handle<InternedString>>,
-    
     /// The location in its containing file of the source code that this node's definiens represents.
     /// This is used for things like the bodies of functions, rather than the RHSes of equations.
     /// If you need one of these to make the type checker happy, but you don't have one, just use

--- a/stack-graphs/src/graph.rs
+++ b/stack-graphs/src/graph.rs
@@ -1533,6 +1533,7 @@ impl StackGraph {
                             .into_option()
                             .map(|cl| self.add_string(&other[cl]))
                             .into(),
+                        definiens_span: source_info.definiens_span.clone(),
                     };
                 }
                 if let Some(debug_info) = other.debug_info(other_node) {

--- a/stack-graphs/tests/it/c/nodes.rs
+++ b/stack-graphs/tests/it/c/nodes.rs
@@ -681,6 +681,7 @@ fn can_create_source_info() {
             span: sg_span::default(),
             syntax_type,
             containing_line,
+            definiens_span: sg_span::default(),
         },
     }];
     infos[0].source_info.span.start.line = 17;

--- a/stack-graphs/tests/it/test_graphs/simple.rs
+++ b/stack-graphs/tests/it/test_graphs/simple.rs
@@ -76,6 +76,7 @@ pub fn new() -> StackGraph {
         },
         syntax_type: str_var.into(),
         containing_line: str_line0.into(),
+        definiens_span: Span::default(),
     };
     *graph.source_info_mut(ref_x) = SourceInfo {
         span: Span {
@@ -102,6 +103,7 @@ pub fn new() -> StackGraph {
         },
         syntax_type: str_var.into(),
         containing_line: str_line1.into(),
+        definiens_span: Span::default(),
     };
 
     let str_dsl_var = graph.add_string("dsl_var");


### PR DESCRIPTION
This PR adds definiens nodes for the bodies of defined functions and so forth.

This is will let us start tracking hierarchical TOCs and function calls for richer vulnerability flagging.