### PR TITLE
Support includes

### DIFF
--- a/stack-graphs/src/graph.rs
+++ b/stack-graphs/src/graph.rs
@@ -49,6 +49,7 @@
 //! [`Edge`]: struct.Edge.html
 //! [`File`]: struct.File.html
 
+use std::collections::HashMap;
 use std::fmt::Display;
 use std::num::NonZeroU32;
 use std::ops::Index;
@@ -1407,6 +1408,155 @@ impl StackGraph {
     /// Creates a new, initially empty stack graph.
     pub fn new() -> StackGraph {
         StackGraph::default()
+    }
+
+    /// Copies the given stack graph into this stack graph. Panics if any of the files
+    /// in the other stack graph are already defined in the current one.
+    pub fn add_graph(&mut self, other: &StackGraph) -> Result<(), Handle<File>> {
+        let mut files = HashMap::new();
+        for other_file in other.iter_files() {
+            let file = self.add_file(other[other_file].name())?;
+            files.insert(other_file, file);
+        }
+        let node_id = |other_node_id: NodeID| {
+            if other_node_id.is_root() {
+                NodeID::root()
+            } else if other_node_id.is_jump_to() {
+                NodeID::jump_to()
+            } else {
+                NodeID::new_in_file(
+                    files[&other_node_id.file.into_option().unwrap()],
+                    other_node_id.local_id,
+                )
+            }
+        };
+        let mut nodes = HashMap::new();
+        nodes.insert(Self::root_node(), Self::root_node());
+        nodes.insert(Self::jump_to_node(), Self::jump_to_node());
+        for other_file in files.keys().cloned() {
+            let file = files[&other_file];
+            for other_node in other.nodes_for_file(other_file) {
+                let value: Node = match other[other_node] {
+                    Node::DropScopes(DropScopesNode { id, .. }) => DropScopesNode {
+                        id: NodeID::new_in_file(file, id.local_id),
+                        _symbol: ControlledOption::default(),
+                        _scope: NodeID::default(),
+                        _is_endpoint: bool::default(),
+                    }
+                    .into(),
+                    Node::JumpTo(JumpToNode { .. }) => JumpToNode {
+                        id: NodeID::jump_to(),
+                        _symbol: ControlledOption::default(),
+                        _scope: NodeID::default(),
+                        _is_endpoint: bool::default(),
+                    }
+                    .into(),
+                    Node::PopScopedSymbol(PopScopedSymbolNode {
+                        id,
+                        symbol,
+                        is_definition,
+                        ..
+                    }) => PopScopedSymbolNode {
+                        id: NodeID::new_in_file(file, id.local_id),
+                        symbol: self.add_symbol(&other[symbol]),
+                        _scope: NodeID::default(),
+                        is_definition: is_definition,
+                    }
+                    .into(),
+                    Node::PopSymbol(PopSymbolNode {
+                        id,
+                        symbol,
+                        is_definition,
+                        ..
+                    }) => PopSymbolNode {
+                        id: NodeID::new_in_file(file, id.local_id),
+                        symbol: self.add_symbol(&other[symbol]),
+                        _scope: NodeID::default(),
+                        is_definition: is_definition,
+                    }
+                    .into(),
+                    Node::PushScopedSymbol(PushScopedSymbolNode {
+                        id,
+                        symbol,
+                        scope,
+                        is_reference,
+                        ..
+                    }) => PushScopedSymbolNode {
+                        id: NodeID::new_in_file(file, id.local_id),
+                        symbol: self.add_symbol(&other[symbol]),
+                        scope: node_id(scope),
+                        is_reference: is_reference,
+                        _phantom: (),
+                    }
+                    .into(),
+                    Node::PushSymbol(PushSymbolNode {
+                        id,
+                        symbol,
+                        is_reference,
+                        ..
+                    }) => PushSymbolNode {
+                        id: NodeID::new_in_file(file, id.local_id),
+                        symbol: self.add_symbol(&other[symbol]),
+                        _scope: NodeID::default(),
+                        is_reference: is_reference,
+                    }
+                    .into(),
+                    Node::Root(RootNode { .. }) => RootNode {
+                        id: NodeID::root(),
+                        _symbol: ControlledOption::default(),
+                        _scope: NodeID::default(),
+                        _is_endpoint: bool::default(),
+                    }
+                    .into(),
+                    Node::Scope(ScopeNode {
+                        id, is_exported, ..
+                    }) => ScopeNode {
+                        id: NodeID::new_in_file(file, id.local_id),
+                        _symbol: ControlledOption::default(),
+                        _scope: NodeID::default(),
+                        is_exported: is_exported,
+                    }
+                    .into(),
+                };
+                let node = self.add_node(value.id(), value).unwrap();
+                nodes.insert(other_node, node);
+                if let Some(source_info) = other.source_info(other_node) {
+                    *self.source_info_mut(node) = SourceInfo {
+                        span: source_info.span.clone(),
+                        syntax_type: source_info
+                            .syntax_type
+                            .map(|st| self.add_string(&other[st])),
+                        containing_line: source_info
+                            .containing_line
+                            .into_option()
+                            .map(|cl| self.add_string(&other[cl]))
+                            .into(),
+                    };
+                }
+                if let Some(debug_info) = other.debug_info(other_node) {
+                    *self.debug_info_mut(node) = DebugInfo {
+                        entries: debug_info
+                            .entries
+                            .iter()
+                            .map(|e| DebugEntry {
+                                key: self.add_string(&other[e.key]),
+                                value: self.add_string(&other[e.value]),
+                            })
+                            .collect::<Vec<_>>(),
+                    };
+                }
+            }
+            for other_node in nodes.keys().cloned() {
+                for other_edge in other.outgoing_edges(other_node) {
+                    self.add_edge(
+                        nodes[&other_edge.source],
+                        nodes[&other_edge.sink],
+                        other_edge.precedence,
+                    );
+                }
+            }
+        }
+        Ok(())
     }
 }
 

--- a/stack-graphs/tests/it/graph.rs
+++ b/stack-graphs/tests/it/graph.rs
@@ -10,6 +10,7 @@ use std::collections::HashSet;
 use maplit::hashset;
 use stack_graphs::graph::StackGraph;
 
+use crate::test_graphs;
 use crate::test_graphs::CreateStackGraph;
 
 #[test]
@@ -175,4 +176,29 @@ fn singleton_nodes_have_correct_ids() {
     assert!(root.id().is_root());
     assert_eq!(root.display(&graph).to_string(), "[root]");
     assert_eq!(root.id().display(&graph).to_string(), "[root]");
+}
+
+#[test]
+fn can_add_graph_to_empty_graph() {
+    let mut graph = StackGraph::new();
+    let other = test_graphs::simple::new();
+    graph.add_graph(&other).expect("Adding graph failed");
+
+    for other_file in other.iter_files() {
+        let file = graph.get_file_unchecked(other[other_file].name());
+        assert_eq!(
+            graph.nodes_for_file(file).count(),
+            other.nodes_for_file(other_file).count()
+        );
+        assert_eq!(
+            graph
+                .nodes_for_file(file)
+                .map(|n| graph.outgoing_edges(n).count())
+                .sum::<usize>(),
+            other
+                .nodes_for_file(other_file)
+                .map(|n| graph.outgoing_edges(n).count())
+                .sum::<usize>()
+        );
+    }
 }

--- a/stack-graphs/tests/it/json.rs
+++ b/stack-graphs/tests/it/json.rs
@@ -6,6 +6,8 @@
 // ------------------------------------------------------------------------------------------------
 
 use serde_json::json;
+use stack_graphs::arena::Handle;
+use stack_graphs::graph::File;
 use stack_graphs::graph::StackGraph;
 use stack_graphs::paths::Paths;
 
@@ -14,7 +16,10 @@ use crate::test_graphs;
 #[test]
 fn can_serialize_graph() {
     let graph: StackGraph = test_graphs::simple::new();
-    let actual = graph.to_json().to_value().expect("Cannot serialize graph");
+    let actual = graph
+        .to_json(&|_: &StackGraph, _: &Handle<File>| true)
+        .to_value()
+        .expect("Cannot serialize graph");
     // formatted using: json_pp -json_opt utf8,canoncical,pretty,indent_length=4
     let expected = json!(
         {
@@ -483,7 +488,7 @@ fn can_serialize_paths() {
     let graph: StackGraph = test_graphs::simple::new();
     let mut paths = Paths::new();
     let actual = paths
-        .to_json(&graph, |_, _, _| true)
+        .to_json(&graph, &|_: &StackGraph, _: &Handle<File>| true)
         .to_value()
         .expect("Cannot serialize paths");
     // formatted using: json_pp -json_opt utf8,canoncical,pretty,indent_length=4

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
@@ -149,8 +149,6 @@ fn path_exists(path: &OsStr) -> anyhow::Result<PathBuf> {
 impl Command {
     pub fn run(&self) -> anyhow::Result<()> {
         let mut loader = self.loader.new_loader()?;
-        let includes = self.load_includes(&mut loader)?;
-
         let mut total_failure_count = 0;
         for test_path in &self.tests {
             if test_path.is_dir() {
@@ -163,12 +161,12 @@ impl Command {
                 {
                     let test_path = test_entry.path();
                     total_failure_count +=
-                        self.run_test_with_context(test_root, test_path, &includes, &mut loader)?;
+                        self.run_test_with_context(test_root, test_path, &mut loader)?;
                 }
             } else {
                 let test_root = test_path.parent().unwrap();
                 total_failure_count +=
-                    self.run_test_with_context(test_root, test_path, &includes, &mut loader)?;
+                    self.run_test_with_context(test_root, test_path, &mut loader)?;
             }
         }
 
@@ -183,34 +181,14 @@ impl Command {
         Ok(())
     }
 
-    /// Run test file.
-    fn load_includes(&self, loader: &mut Loader) -> anyhow::Result<StackGraph> {
-        let mut graph = StackGraph::new();
-        for path in &self.includes {
-            let content = String::from_utf8(std::fs::read(path)?)?;
-            let sgl = loader.load_for_file(path, Some(&content))?.ok_or_else(|| {
-                anyhow!(
-                    "Cannot determine stack graph language for include {}",
-                    path.display()
-                )
-            })?;
-            let file = graph
-                .add_file(&path.to_string_lossy())
-                .map_err(|_| anyhow!("File {} already exists in graph", path.display()))?;
-            self.build_stack_graph_into(path, file, &content, sgl, &mut graph)?;
-        }
-        Ok(graph)
-    }
-
     /// Run test file and add error context to any failures that are returned.
     fn run_test_with_context(
         &self,
         test_root: &Path,
         test_path: &Path,
-        includes: &StackGraph,
         loader: &mut Loader,
     ) -> anyhow::Result<usize> {
-        self.run_test(test_root, test_path, includes, loader)
+        self.run_test(test_root, test_path, loader)
             .with_context(|| format!("Error running test {}", test_path.display()))
     }
 
@@ -218,7 +196,6 @@ impl Command {
         &self,
         test_root: &Path,
         test_path: &Path,
-        includes: &StackGraph,
         loader: &mut Loader,
     ) -> anyhow::Result<usize> {
         let source = String::from_utf8(std::fs::read(test_path)?)?;
@@ -235,9 +212,8 @@ impl Command {
         let mut test = Test::from_source(&test_path, &source, default_fragment_path)?;
         self.load_builtins_into(sgl, &mut test.graph)
             .with_context(|| format!("Loading builtins into {}", test_path.display()))?;
-        test.graph
-            .add_graph(includes)
-            .map_err(|_| anyhow!("Loading includes into test {} failed", test_path.display()))?;
+        self.load_includes_into(sgl, &mut test.graph)
+            .with_context(|| format!("Loading includes into {}", test_path.display()))?;
         for test_fragment in &test.fragments {
             let fragment_path = Path::new(test.graph[test_fragment.file].name()).to_path_buf();
             if test_path.extension() != fragment_path.extension() {
@@ -278,6 +254,21 @@ impl Command {
     ) -> anyhow::Result<()> {
         if let Err(h) = graph.add_graph(sgl.builtins()) {
             return Err(anyhow!("Duplicate builtin file {}", &graph[h]));
+        }
+        Ok(())
+    }
+
+    fn load_includes_into(
+        &self,
+        sgl: &mut StackGraphLanguage,
+        graph: &mut StackGraph,
+    ) -> anyhow::Result<()> {
+        for path in &self.includes {
+            let content = String::from_utf8(std::fs::read(path)?)?;
+            let include_graph = sgl.get_or_load(path, &content)?;
+            if let Err(h) = graph.add_graph(include_graph) {
+                return Err(anyhow!("Duplicate include file {}", &graph[h]));
+            }
         }
         Ok(())
     }

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
@@ -11,6 +11,7 @@ use clap::ArgEnum;
 use clap::ValueHint;
 use colored::Colorize as _;
 use stack_graphs::graph::StackGraph;
+use stack_graphs::json::Filter;
 use stack_graphs::paths::Paths;
 use std::ffi::OsStr;
 use std::ffi::OsString;
@@ -226,7 +227,15 @@ impl Command {
         let result = test.run();
         let success = self.handle_result(test_path, &result)?;
         if self.output_mode.test(!success) {
-            self.save_output(test_root, test_path, &test.graph, &mut test.paths, success)?;
+            let files = test.fragments.iter().map(|f| f.file).collect::<Vec<_>>();
+            self.save_output(
+                test_root,
+                test_path,
+                &test.graph,
+                &mut test.paths,
+                &|_: &StackGraph, h: &Handle<File>| files.contains(h),
+                success,
+            )?;
         }
         Ok(result.failure_count())
     }
@@ -319,6 +328,7 @@ impl Command {
         test_path: &Path,
         graph: &StackGraph,
         paths: &mut Paths,
+        filter: &dyn Filter,
         success: bool,
     ) -> anyhow::Result<()> {
         if let Some(path) = self
@@ -326,7 +336,7 @@ impl Command {
             .as_ref()
             .map(|spec| spec.format(test_root, test_path))
         {
-            self.save_graph(&path, &graph)?;
+            self.save_graph(&path, &graph, filter)?;
             if !success || !self.hide_passing {
                 println!("  Graph: {}", path.display());
             }
@@ -336,7 +346,7 @@ impl Command {
             .as_ref()
             .map(|spec| spec.format(test_root, test_path))
         {
-            self.save_paths(&path, paths, graph)?;
+            self.save_paths(&path, paths, graph, filter)?;
             if !success || !self.hide_passing {
                 println!("  Paths: {}", path.display());
             }
@@ -346,7 +356,7 @@ impl Command {
             .as_ref()
             .map(|spec| spec.format(test_root, test_path))
         {
-            self.save_visualization(&path, paths, graph, &test_path)?;
+            self.save_visualization(&path, paths, graph, filter, &test_path)?;
             if !success || !self.hide_passing {
                 println!("  Visualization: {}", path.display());
             }
@@ -354,8 +364,13 @@ impl Command {
         Ok(())
     }
 
-    fn save_graph(&self, path: &Path, graph: &StackGraph) -> anyhow::Result<()> {
-        let json = graph.to_json().to_string_pretty()?;
+    fn save_graph(
+        &self,
+        path: &Path,
+        graph: &StackGraph,
+        filter: &dyn Filter,
+    ) -> anyhow::Result<()> {
+        let json = graph.to_json(filter).to_string_pretty()?;
         if let Some(dir) = path.parent() {
             std::fs::create_dir_all(dir)?;
         }
@@ -364,8 +379,14 @@ impl Command {
         Ok(())
     }
 
-    fn save_paths(&self, path: &Path, paths: &mut Paths, graph: &StackGraph) -> anyhow::Result<()> {
-        let json = paths.to_json(graph, |_, _, _| true).to_string_pretty()?;
+    fn save_paths(
+        &self,
+        path: &Path,
+        paths: &mut Paths,
+        graph: &StackGraph,
+        filter: &dyn Filter,
+    ) -> anyhow::Result<()> {
+        let json = paths.to_json(graph, filter).to_string_pretty()?;
         if let Some(dir) = path.parent() {
             std::fs::create_dir_all(dir)?;
         }
@@ -379,9 +400,10 @@ impl Command {
         path: &Path,
         paths: &mut Paths,
         graph: &StackGraph,
+        filter: &dyn Filter,
         test_path: &Path,
     ) -> anyhow::Result<()> {
-        let html = graph.to_html_string(paths, &format!("{}", test_path.display()))?;
+        let html = graph.to_html_string(&format!("{}", test_path.display()), paths, filter)?;
         if let Some(dir) = path.parent() {
             std::fs::create_dir_all(dir)?;
         }

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -364,6 +364,7 @@ pub struct StackGraphLanguage {
     parser: Parser,
     tsg: tree_sitter_graph::ast::File,
     functions: Functions,
+    builtins: StackGraph,
 }
 
 impl StackGraphLanguage {
@@ -380,6 +381,7 @@ impl StackGraphLanguage {
             parser,
             tsg,
             functions: Self::default_functions(),
+            builtins: StackGraph::new(),
         })
     }
 
@@ -396,6 +398,7 @@ impl StackGraphLanguage {
             parser,
             tsg,
             functions: Self::default_functions(),
+            builtins: StackGraph::new(),
         })
     }
 
@@ -407,6 +410,14 @@ impl StackGraphLanguage {
 
     pub fn functions_mut(&mut self) -> &mut tree_sitter_graph::functions::Functions {
         &mut self.functions
+    }
+
+    pub fn builtins(&self) -> &StackGraph {
+        &self.builtins
+    }
+
+    pub fn builtins_mut(&mut self) -> &mut StackGraph {
+        &mut self.builtins
     }
 }
 

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -228,6 +228,7 @@ impl LoadError {
         Self::Other(error.into())
     }
 }
+
 // ------------------------------------------------------------------------------------------------
 // tree_sitter_loader supplements
 


### PR DESCRIPTION
This PR adds support adding includes on the command line.

## Solution

Includes are specified as paths to files. This may be too limited to generate faithful stack graphs for those files, since package name and source root information cannot be specified. See discussion in https://github.com/github/semantic-code/issues/301.

Includes are expected to be source files in the target language, which will be parsed and processed using the language's TSG file to get the corresponding stack graph.

## Implementation

To prevent reading, parsing, and generating the stack graph for includes for every test, a mechanism is added to cache file results in the `StackGraphLanguage`.
