### PR TITLE
Release stack-graphs 0.7.2

### DIFF
--- a/stack-graphs/CHANGELOG.md
+++ b/stack-graphs/CHANGELOG.md
@@ -5,11 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## stack-graphs 0.7.2 -- 2022-05-09
 
 ### Added
 
 - Method `StackGraph::add_from_graph` to copy the one graph into another.
+
+## stack-graphs 0.7.1 - 2022-04-19
+
+### Fixes
+
+- Resolves build problems of version 0.7.0
 
 ## stack-graphs 0.7.0 - 2022-04-19
 

--- a/stack-graphs/Cargo.toml
+++ b/stack-graphs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stack-graphs"
-version = "0.7.1"
+version = "0.7.2"
 description = "Name binding for arbitrary programming languages"
 homepage = "https://github.com/github/stack-graphs/"
 repository = "https://github.com/github/stack-graphs/"


### PR DESCRIPTION
Release a patch version 0.7.2 of stack-graphs.

I've also added a changelog entry for version 0.7.1, which fixed some build issues in 0.7.0.
