### PR TITLE
First tree-sitter-stack-graphs release (0.1.0)

### DIFF
--- a/tree-sitter-stack-graphs/CHANGELOG.md
+++ b/tree-sitter-stack-graphs/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.1.0 -- 2022-05-09
 
 ### Library
 

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-stack-graphs"
-version = "0.0.0"
+version = "0.1.0"
 description = "Create stack graphs using tree-sitter parsers"
 homepage = "https://github.com/github/stack-graphs/tree-sitter-stack-graphs"
 repository = "https://github.com/github/stack-graphs/"

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -39,7 +39,7 @@ stack-graphs = { version="0.7", path="../stack-graphs" }
 thiserror = "1.0"
 tree-sitter = ">= 0.19"
 tree-sitter-config = { version = "0.19", optional = true }
-tree-sitter-graph = "0.4"
+tree-sitter-graph = "0.5"
 tree-sitter-loader = "0.20"
 walkdir = { version = "2.3", optional = true }
 

--- a/tree-sitter-stack-graphs/README.md
+++ b/tree-sitter-stack-graphs/README.md
@@ -14,7 +14,7 @@ To use this library, add the following to your `Cargo.toml`:
 
 ``` toml
 [dependencies]
-tree-sitter-stack-graphs = "0.0"
+tree-sitter-stack-graphs = "0.1"
 ```
 
 Check out our [documentation](https://docs.rs/tree-sitter-stack-graphs/*/) for
@@ -25,22 +25,46 @@ more details on how to use this library.
 The command-line program for `tree-sitter-stack-graphs` lets you do stack
 graph based analysis and lookup from the command line.
 
-To run from source, run the following command:
+Install the program using `cargo install` as follows:
 
 ``` sh
-cargo run --bin tree-sitter-stack-graphs --features cli -- ARGS
+$ cargo install --features cli tree-sitter-stack-graphs
+$ tree-sitter-stack-graphs --help
 ```
 
-To install, run the following command:
+## Development
+
+The project is written in Rust, and requires a recent version installed.
+Rust can be installed and updated using [rustup][].
+
+[rustup]: https://rustup.rs/
+
+Build the project by running:
+
+```
+$ cargo build
+```
+
+Run the tests by running:
+
+```
+$ cargo test
+```
+
+The project consists of a library and a CLI.
+By default, running `cargo` only applies to the library.
+To run `cargo` commands on the CLI as well, add `--features cli` or `--all-features`.
+
+Run the CLI from source as follows:
 
 ``` sh
-cargo install --path TARGETDIR --bin tree-sitter-stack-graphs --features cli
+$ cargo run --features cli -- ARGS
 ```
 
-Run the program as follows to show the supported commands:
+Sources are formatted using the standard Rust formatted, which is applied by running:
 
-```sh
-tree-sitter-stack-graphs --help
+```
+$ cargo fmt
 ```
 
 ## License


### PR DESCRIPTION
- Bump tree-sitter-graph dependency to 0.5.0
- Bump tree-sitter-stack-graphs to 0.1.0 and update README
