### PR TITLE
Use fixed-size chunks in arenas

### DIFF
--- a/stack-graphs/CHANGELOG.md
+++ b/stack-graphs/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Each arena now allocates memory in fixed-sized chunks, instead of in a single
+  growable array.  Rust code should be unaffected, but consumers of the C API
+  must use new indexing logic to access the contents of an arena.
+
 ## stack-graphs 0.7.2 -- 2022-05-09
 
 ### Added

--- a/stack-graphs/Cargo.toml
+++ b/stack-graphs/Cargo.toml
@@ -31,6 +31,7 @@ lsp-positions = { version="0.3", path="../lsp-positions" }
 serde = { version="1.0", optional=true }
 serde_json = { version="1.0", optional=true }
 smallvec = { version="1.6", features=["union"] }
+static_assertions = "1.1"
 thiserror = { version="1.0", optional=true }
 
 [dev-dependencies]

--- a/stack-graphs/include/stack-graphs.h
+++ b/stack-graphs/include/stack-graphs.h
@@ -9,6 +9,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#define SG_ARENA_CHUNK_SIZE 512
+
 // The null value for all of our handles.
 #define SG_NULL_HANDLE 0
 
@@ -90,11 +92,11 @@ struct sg_symbol {
     size_t symbol_len;
 };
 
-// An array of all of the symbols in a stack graph.  Symbol handles are indices into this array.
+// Holds all of the symbols in a stack graph.  Symbol handles are indices into these arrays.
 // There will never be a valid symbol at index 0; a handle with the value 0 represents a missing
 // symbol.
 struct sg_symbols {
-    const struct sg_symbol *symbols;
+    const struct sg_symbol *const *symbols;
     size_t count;
 };
 
@@ -111,11 +113,11 @@ struct sg_string {
     size_t length;
 };
 
-// An array of all of the interned strings in a stack graph.  String handles are indices into this
-// array. There will never be a valid string at index 0; a handle with the value 0 represents a
+// Holds of all of the interned strings in a stack graph.  String handles are indices into these
+// arrays.  There will never be a valid string at index 0; a handle with the value 0 represents a
 // missing string.
 struct sg_strings {
-    const struct sg_string *strings;
+    const struct sg_string *const *strings;
     size_t count;
 };
 
@@ -138,11 +140,10 @@ struct sg_file {
     size_t name_len;
 };
 
-// An array of all of the files in a stack graph.  File handles are indices into this array.
-// There will never be a valid file at index 0; a handle with the value 0 represents a missing
-// file.
+// Holds all of the files in a stack graph.  File handles are indices into these arrays.  There
+// will never be a valid file at index 0; a handle with the value 0 represents a missing file.
 struct sg_files {
-    const struct sg_file *files;
+    const struct sg_file *const *files;
     size_t count;
 };
 
@@ -181,11 +182,10 @@ struct sg_node {
     bool is_endpoint;
 };
 
-// An array of all of the nodes in a stack graph.  Node handles are indices into this array.
-// There will never be a valid node at index 0; a handle with the value 0 represents a missing
-// node.
+// Holds all of the nodes in a stack graph.  Node handles are indices into these arrays.  There
+// will never be a valid node at index 0; a handle with the value 0 represents a missing node.
 struct sg_nodes {
-    const struct sg_node *nodes;
+    const struct sg_node *const *nodes;
     size_t count;
 };
 
@@ -256,16 +256,16 @@ struct sg_source_info {
     sg_string_handle containing_line;
 };
 
-// An array of all of the source information in a stack graph.  Source information is associated
-// with nodes, so node handles are indices into this array.  It is _not_ guaranteed that there
-// will an entry in this array for every node handle; if you have a node handle whose value is
-// larger than `count`, then use a 0-valued `sg_source_info` if you need source information for
-// that node.
+// Holds all of the source information in a stack graph.  Source information is associated with
+// nodes, so node handles are indices into these arrays.  It is _not_ guaranteed that there will
+// an entry in this array for every node handle; if you have a node handle whose value is larger
+// than `count`, then use a 0-valued `sg_source_info` if you need source information for that
+// node.
 //
 // There will never be a valid entry at index 0; a handle with the value 0 represents a missing
 // node.
 struct sg_source_infos {
-    const struct sg_source_info *infos;
+    const struct sg_source_info *const *infos;
     size_t count;
 };
 
@@ -307,9 +307,9 @@ struct sg_symbol_stack_cell {
     sg_symbol_stack_cell_handle tail;
 };
 
-// The array of all of the symbol stack content in a path arena.
+// Holds all of the symbol stack content in a path arena.
 struct sg_symbol_stack_cells {
-    const struct sg_symbol_stack_cell *cells;
+    const struct sg_symbol_stack_cell *const *cells;
     size_t count;
 };
 
@@ -331,9 +331,9 @@ struct sg_scope_stack_cell {
     sg_scope_stack_cell_handle tail;
 };
 
-// The array of all of the scope stack content in a path arena.
+// Holds all of the scope stack content in a path arena.
 struct sg_scope_stack_cells {
-    const struct sg_scope_stack_cell *cells;
+    const struct sg_scope_stack_cell *const *cells;
     size_t count;
 };
 
@@ -358,9 +358,9 @@ struct sg_path_edge_list_cell {
     sg_path_edge_list_cell_handle reversed;
 };
 
-// The array of all of the path edge list content in a path arena.
+// Holds all of the path edge list content in a path arena.
 struct sg_path_edge_list_cells {
-    const struct sg_path_edge_list_cell *cells;
+    const struct sg_path_edge_list_cell *const *cells;
     size_t count;
 };
 
@@ -427,9 +427,9 @@ struct sg_partial_symbol_stack_cell {
     sg_partial_symbol_stack_cell_handle reversed;
 };
 
-// The array of all of the partial symbol stack content in a partial path arena.
+// Holds all of the partial symbol stack content in a partial path arena.
 struct sg_partial_symbol_stack_cells {
-    const struct sg_partial_symbol_stack_cell *cells;
+    const struct sg_partial_symbol_stack_cell *const *cells;
     size_t count;
 };
 
@@ -468,9 +468,9 @@ struct sg_partial_scope_stack_cell {
     sg_path_edge_list_cell_handle reversed;
 };
 
-// The array of all of the partial scope stack content in a partial path arena.
+// Holds all of the partial scope stack content in a partial path arena.
 struct sg_partial_scope_stack_cells {
-    const struct sg_partial_scope_stack_cell *cells;
+    const struct sg_partial_scope_stack_cell *const *cells;
     size_t count;
 };
 
@@ -495,9 +495,9 @@ struct sg_partial_path_edge_list_cell {
     sg_partial_path_edge_list_cell_handle reversed;
 };
 
-// The array of all of the partial path edge list content in a partial path arena.
+// Holds all of the partial path edge list content in a partial path arena.
 struct sg_partial_path_edge_list_cells {
-    const struct sg_partial_path_edge_list_cell *cells;
+    const struct sg_partial_path_edge_list_cell *const *cells;
     size_t count;
 };
 
@@ -537,11 +537,11 @@ struct sg_partial_path {
     struct sg_partial_path_edge_list edges;
 };
 
-// An array of all of the partial paths in a partial path database.  Partial path handles are
-// indices into this array.  There will never be a valid partial path at index 0; a handle with
-// the value 0 represents a missing partial path.
+// Holds all of the partial paths in a partial path database.  Partial path handles are indices
+// into these arrays.  There will never be a valid partial path at index 0; a handle with the
+// value 0 represents a missing partial path.
 struct sg_partial_paths {
-    const struct sg_partial_path *paths;
+    const struct sg_partial_path *const *paths;
     size_t count;
 };
 

--- a/stack-graphs/src/graph.rs
+++ b/stack-graphs/src/graph.rs
@@ -317,6 +317,7 @@ impl Handle<InternedString> {
 /// choice.  If your files belong to packages or repositories, they should include the package or
 /// repository IDs to make sure that files in different packages or repositories don't clash with
 /// each other.
+#[repr(C)]
 pub struct File {
     /// The name of this source file.
     name: InternedStringContent,

--- a/stack-graphs/tests/it/arena.rs
+++ b/stack-graphs/tests/it/arena.rs
@@ -28,6 +28,16 @@ fn can_allocate_in_arena() {
     assert_ne!(arena.get(hello2), arena.get(there));
 }
 
+const CHUNK_SIZE: usize = 512;
+
+#[test]
+fn can_allocate_full_chunk() {
+    let mut arena = Arena::new();
+    for _ in 1..CHUNK_SIZE {
+        arena.add("hello".to_string());
+    }
+}
+
 #[test]
 fn can_allocate_in_supplemental_arena() {
     let mut arena = Arena::<u32>::new();

--- a/stack-graphs/tests/it/c/paths.rs
+++ b/stack-graphs/tests/it/c/paths.rs
@@ -37,11 +37,21 @@ use stack_graphs::c::sg_stack_graph_new;
 use stack_graphs::c::sg_symbol_handle;
 use stack_graphs::c::sg_symbol_stack;
 use stack_graphs::c::sg_symbol_stack_cells;
+use stack_graphs::c::SG_ARENA_CHUNK_SIZE;
 use stack_graphs::c::SG_LIST_EMPTY_HANDLE;
 use stack_graphs::c::SG_NULL_HANDLE;
 use stack_graphs::paths::PathEdgeList;
 use stack_graphs::paths::ScopeStack;
 use stack_graphs::paths::SymbolStack;
+
+fn index_chunked<'a, T>(chunks: *const *const T, index: usize) -> &'a T {
+    let chunk_index = index / SG_ARENA_CHUNK_SIZE;
+    let item_index = index % SG_ARENA_CHUNK_SIZE;
+    let chunks = unsafe { std::slice::from_raw_parts(chunks, chunk_index + 1) };
+    let chunk = chunks[chunk_index];
+    let items = unsafe { std::slice::from_raw_parts(chunk, item_index + 1) };
+    &items[item_index]
+}
 
 fn add_file(graph: *mut sg_stack_graph, filename: &str) -> sg_file_handle {
     let lengths = [filename.len()];
@@ -108,13 +118,12 @@ fn symbol_stack_contains(
     stack: &sg_symbol_stack,
     expected: &[sg_scoped_symbol],
 ) -> bool {
-    let cells = unsafe { std::slice::from_raw_parts(cells.cells, cells.count) };
     let mut current = stack.cells;
     for node in expected {
         if current == SG_LIST_EMPTY_HANDLE {
             return false;
         }
-        let cell = &cells[current as usize];
+        let cell = index_chunked(cells.cells, current as usize);
         if cell.head != *node {
             return false;
         }
@@ -197,13 +206,12 @@ fn scope_stack_contains(
     stack: &sg_scope_stack,
     expected: &[sg_node_handle],
 ) -> bool {
-    let cells = unsafe { std::slice::from_raw_parts(cells.cells, cells.count) };
     let mut current = stack.cells;
     for node in expected {
         if current == SG_LIST_EMPTY_HANDLE {
             return false;
         }
-        let cell = &cells[current as usize];
+        let cell = index_chunked(cells.cells, current as usize);
         if cell.head != *node {
             return false;
         }
@@ -276,7 +284,6 @@ fn path_edge_list_contains(
     list: &sg_path_edge_list,
     expected: &[sg_path_edge],
 ) -> bool {
-    let cells = unsafe { std::slice::from_raw_parts(cells.cells, cells.count) };
     let mut current = list.cells;
     let expected = if list.direction == sg_deque_direction::SG_DEQUE_FORWARDS {
         Either::Left(expected.iter())
@@ -287,7 +294,7 @@ fn path_edge_list_contains(
         if current == SG_LIST_EMPTY_HANDLE {
             return false;
         }
-        let cell = &cells[current as usize];
+        let cell = index_chunked(cells.cells, current as usize);
         if cell.head != *node {
             return false;
         }
@@ -300,12 +307,11 @@ fn path_edge_list_available_in_both_directions(
     cells: &sg_path_edge_list_cells,
     list: &sg_path_edge_list,
 ) -> bool {
-    let cells = unsafe { std::slice::from_raw_parts(cells.cells, cells.count) };
     let head = list.cells;
     if head == SG_LIST_EMPTY_HANDLE {
         return true;
     }
-    let cell = &cells[head as usize];
+    let cell = index_chunked(cells.cells, head as usize);
     cell.reversed != SG_NULL_HANDLE
 }
 


### PR DESCRIPTION
Before, our arenas would allocate memory using a single `Vec`.  This is optimally cache-friendly, and provides the simplest indexing logic for finding the instance for a particular handle.  But we suspect that is results in a lot of memory fragmentation over time, since the arrays can get quite large, and there's a lot of variance in size across requests.

This patch switches the arena implementation to use a growable array of fixed-size chunks.  Each chunk is (effectively) a `Box<[T; CHUNK_SIZE]>` heap-allocated fixed-size array.  No matter how large the arena grows, every chunk (for a particular type) will have exactly the same size, which should make them much more directly reusable across different requests.  The outer array can grow arbitrary large, but it now only contains `n / CHUNK_SIZE` pointers, instead of `n` instances of the allocated type — and so will be much smaller than the arrays we were allocating before.
