### PR TITLE
Don't add divergent partial paths to database

### DIFF
--- a/stack-graphs/CHANGELOG.md
+++ b/stack-graphs/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- We no longer add divergent partial paths to a `Database`.  A divergent partial
+  path starts at the root node and has an empty symbol stack precondition.  That
+  empty precondition means that it can be concatenated to _any_ path that
+  currently ends at the root node — including the result of that concatenation!
+  That gives us a divergence, since we can continually prepend the path's
+  postcondition to the current symbol stack, forever.  To avoid this divergence,
+  we skip these partial paths when constructing a database.
+
 ## stack-graphs 0.7.2 -- 2022-05-09
 
 ### Added

--- a/stack-graphs/src/stitching.rs
+++ b/stack-graphs/src/stitching.rs
@@ -121,8 +121,10 @@ impl Database {
                 self,
                 symbol_stack_precondition,
             );
-            let key_handle = key.back_handle();
-            self.root_paths_by_precondition[key_handle].push(handle);
+            if !key.is_empty() {
+                let key_handle = key.back_handle();
+                self.root_paths_by_precondition[key_handle].push(handle);
+            }
         } else {
             // Otherwise index it by its source node.
             self.paths_by_start_node[start_node].push(handle);
@@ -317,6 +319,10 @@ impl SymbolStackKey {
         SymbolStackKey {
             symbols: List::empty(),
         }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.symbols.is_empty()
     }
 
     /// Pushes a new symbol onto the back of this symbol stack key.


### PR DESCRIPTION
A divergent partial path is one that starts at the root node and has an empty symbol stack precondition.  That empty precondition means that it can be concatenated to _any_ path that currently ends at the root node — including the result of that concatenation!  That gives us a divergence, since we can continually prepend the path's postcondition to the current symbol stack, forever.

This patch adds a check that ensures that we never add this kind of partial path to a `Database` instance.  (Without this check, we would end up allocating an unusably large amount of memory, since we're currently representing empty lists with a `u32::max` arena handle!)