### PR TITLE
Add methods and C API function to change deque direction of paths in the database

### DIFF
--- a/stack-graphs/include/stack-graphs.h
+++ b/stack-graphs/include/stack-graphs.h
@@ -661,6 +661,14 @@ struct sg_partial_path_database *sg_partial_path_database_new(void);
 // Frees a partial path database, and all of its contents.
 void sg_partial_path_database_free(struct sg_partial_path_database *db);
 
+// Ensures all partial paths in the database are availabe in both forwards and backwards orientation.
+void sg_partial_path_database_ensure_both_directions(struct sg_partial_path_database *db,
+                                                     struct sg_partial_path_arena *partials);
+
+// Ensures all partial paths in the database are in forwards orientation.
+void sg_partial_path_database_ensure_forwards(struct sg_partial_path_database *db,
+                                              struct sg_partial_path_arena *partials);
+
 // Returns a reference to the array of symbol data in this stack graph.  The resulting array
 // pointer is only valid until the next call to any function that mutates the stack graph.
 struct sg_symbols sg_stack_graph_symbols(const struct sg_stack_graph *graph);

--- a/stack-graphs/src/c.rs
+++ b/stack-graphs/src/c.rs
@@ -142,6 +142,28 @@ impl Default for sg_deque_direction {
     }
 }
 
+/// Ensures all partial paths in the database are availabe in both forwards and backwards orientation.
+#[no_mangle]
+pub extern "C" fn sg_partial_path_database_ensure_both_directions(
+    db: *mut sg_partial_path_database,
+    partials: *mut sg_partial_path_arena,
+) {
+    let db = unsafe { &mut (*db).inner };
+    let partials = unsafe { &mut (*partials).inner };
+    db.ensure_both_directions(partials);
+}
+
+/// Ensures all partial paths in the database are in forwards orientation.
+#[no_mangle]
+pub extern "C" fn sg_partial_path_database_ensure_forwards(
+    db: *mut sg_partial_path_database,
+    partials: *mut sg_partial_path_arena,
+) {
+    let db = unsafe { &mut (*db).inner };
+    let partials = unsafe { &mut (*partials).inner };
+    db.ensure_forwards(partials);
+}
+
 //-------------------------------------------------------------------------------------------------
 // Symbols
 

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -999,6 +999,11 @@ impl PartialSymbolStack {
         self.symbols
             .ensure_forwards(&mut partials.partial_symbol_stacks);
     }
+
+    fn ensure_forwards(&mut self, partials: &mut PartialPaths) {
+        self.symbols
+            .ensure_forwards(&mut partials.partial_symbol_stacks);
+    }
 }
 
 impl DisplayWithPartialPaths for PartialSymbolStack {
@@ -1408,6 +1413,11 @@ impl PartialScopeStack {
     fn ensure_both_directions(&mut self, partials: &mut PartialPaths) {
         self.scopes
             .ensure_backwards(&mut partials.partial_scope_stacks);
+        self.scopes
+            .ensure_forwards(&mut partials.partial_scope_stacks);
+    }
+
+    fn ensure_forwards(&mut self, partials: &mut PartialPaths) {
         self.scopes
             .ensure_forwards(&mut partials.partial_scope_stacks);
     }
@@ -1829,6 +1839,10 @@ impl PartialPathEdgeList {
             .ensure_backwards(&mut partials.partial_path_edges);
         self.edges.ensure_forwards(&mut partials.partial_path_edges);
     }
+
+    fn ensure_forwards(&mut self, partials: &mut PartialPaths) {
+        self.edges.ensure_forwards(&mut partials.partial_path_edges);
+    }
 }
 
 impl DisplayWithPartialPaths for PartialPathEdgeList {
@@ -2092,6 +2106,29 @@ impl PartialPath {
         while let Some(symbol) = stack.pop_front(partials) {
             if let Some(mut scopes) = symbol.scopes.into_option() {
                 scopes.ensure_both_directions(partials);
+            }
+        }
+    }
+
+    /// Ensures that the content of this partial path is in forwards direction.
+    pub fn ensure_forwards(&mut self, partials: &mut PartialPaths) {
+        self.symbol_stack_precondition.ensure_forwards(partials);
+        self.symbol_stack_postcondition.ensure_forwards(partials);
+        self.scope_stack_precondition.ensure_forwards(partials);
+        self.scope_stack_postcondition.ensure_forwards(partials);
+        self.edges.ensure_forwards(partials);
+
+        let mut stack = self.symbol_stack_precondition;
+        while let Some(symbol) = stack.pop_front(partials) {
+            if let Some(mut scopes) = symbol.scopes.into_option() {
+                scopes.ensure_forwards(partials);
+            }
+        }
+
+        let mut stack = self.symbol_stack_postcondition;
+        while let Some(symbol) = stack.pop_front(partials) {
+            if let Some(mut scopes) = symbol.scopes.into_option() {
+                scopes.ensure_forwards(partials);
             }
         }
     }

--- a/stack-graphs/src/stitching.rs
+++ b/stack-graphs/src/stitching.rs
@@ -294,9 +294,7 @@ impl Database {
 
     pub fn ensure_forwards(&mut self, partials: &mut PartialPaths) {
         for path in self.partial_paths.iter_handles() {
-            self.partial_paths
-                .get_mut(path)
-                .ensure_both_directions(partials);
+            self.partial_paths.get_mut(path).ensure_forwards(partials);
         }
     }
 }

--- a/stack-graphs/src/stitching.rs
+++ b/stack-graphs/src/stitching.rs
@@ -283,6 +283,22 @@ impl Database {
     pub fn iter_partial_paths(&self) -> impl Iterator<Item = Handle<PartialPath>> {
         self.partial_paths.iter_handles()
     }
+
+    pub fn ensure_both_directions(&mut self, partials: &mut PartialPaths) {
+        for path in self.partial_paths.iter_handles() {
+            self.partial_paths
+                .get_mut(path)
+                .ensure_both_directions(partials);
+        }
+    }
+
+    pub fn ensure_forwards(&mut self, partials: &mut PartialPaths) {
+        for path in self.partial_paths.iter_handles() {
+            self.partial_paths
+                .get_mut(path)
+                .ensure_both_directions(partials);
+        }
+    }
 }
 
 impl Index<Handle<PartialPath>> for Database {


### PR DESCRIPTION
This adds methods and C API functions that allow changing the deque direction for paths in the path database.

Paths have internal components that can be represented forwards or backwards in the arena.
When a deque is reversed so that it is backwards, a pointer is stored to the reversed (i.e., forward) chain of cells.
However, the reverse pointer is not preserved when pushing to a backwards list.
It was not easy for consumers of the C API to get the forwards list from such a backwards list.

This PR adds functions to the C API that ensure that all paths in the database have either a forwards direction, or both directions available.
