### PR TITLE
Get rid of shared `Parser` instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Rust build stuff
 Cargo.lock
 /target/
+*/target/
 
 # Locally installed binaries
 /.crates.toml


### PR DESCRIPTION
The `StackGraphLanguage` would hold an instance of `tree_sitter::Parser`. Because `StackGraphLanguage` was shared between threads and `Parser` should not, and the FFI incorrectly disregarded the `mut` requirement, this was leading to memory problems.

This PR changes `StackGraphLanguage` such that it does not require `&mut self` anymore, instead creating a `Parser` each time. This is probably okay, but if parser creation turns out to be expensive part of total runtime, we can reconsider the API so that the user has more control over parser sharing.