### PR TITLE
Fix Edge Definition in Docs

### DIFF
--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -184,7 +184,7 @@
 //! (function_definition name: (identifier) @id) @func {
 //!   node def
 //!   attr (def) type = "pop_symbol", symbol = (source-text @id), source_node = @func, is_definition
-//!   edge (ROOT_NODE -> def)
+//!   edge ROOT_NODE -> def
 //! }
 //! ```
 //!


### PR DESCRIPTION
Previously, under the  "Referring to the singleton nodes" section, the documentation says to create an edge from ROOT_NODE to a defition node with a tsg_source you must write `edge (ROOT_NODE -> def)`, however, this throws a `ParseError` because *as I understand* the parenthesis are used to reference already created nodes/edges. A simple fix in the documentation from `edge (ROOT_NODE -> def)` to `edge ROOT_NODE -> def` should help out someone new who might get a slight headache trying to figure out why the code in the docs isn't working.