### PR TITLE
Only compute partial paths from references

### DIFF
--- a/stack-graphs/CHANGELOG.md
+++ b/stack-graphs/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- The amount of work done in `PartialPaths::find_all_partial_paths_in_file` is reduced. The documentation now makes it clear that the function itself is responsible for returning a set that is big enough to cover all complete paths. Callers should not have to filter this set further anymore, and any visitors filtering with `PartialPath::is_complete_as_possible` or `PartialPath::is_productive` should remove those checks, as they may interfere with future ompitmizations of this fynction.
+
 ## 0.10.0 -- 2022-08-23
 
 ### Added

--- a/stack-graphs/src/c.rs
+++ b/stack-graphs/src/c.rs
@@ -1581,13 +1581,7 @@ pub extern "C" fn sg_partial_path_arena_find_partial_paths_in_file(
             graph,
             file,
             &AtomicUsizeCancellationFlag(cancellation_flag),
-            |graph, partials, mut path| {
-                if !path.is_complete_as_possible(graph) {
-                    return;
-                }
-                if !path.is_productive(partials) {
-                    return;
-                }
+            |_graph, partials, mut path| {
                 path.ensure_both_directions(partials);
                 partial_path_list.partial_paths.push(path);
             },

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -2417,6 +2417,9 @@ impl PartialPath {
 impl PartialPaths {
     /// Finds all partial paths in a file, calling the `visit` closure for each one.
     ///
+    /// This function ensures that the set of visited partial paths covers all complete
+    /// paths, from references to definitions, when used for path stitching.
+    ///
     /// This function will not return until all reachable partial paths have been processed, so
     /// `graph` must already contain a complete stack graph.  If you have a very large stack graph
     /// stored in some other storage system, and want more control over lazily loading only the

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -2454,7 +2454,9 @@ impl PartialPaths {
                 continue;
             }
             path.extend_from_file(graph, self, file, &mut queue);
-            visit(graph, self, path);
+            if path.is_complete_as_possible(graph) && path.is_productive(self) {
+                visit(graph, self, path);
+            }
         }
         Ok(())
     }

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -2441,8 +2441,8 @@ impl PartialPaths {
             graph
                 .nodes_for_file(file)
                 .filter(|node| match &graph[*node] {
-                    Node::PushScopedSymbol(_) => true,
-                    Node::PushSymbol(_) => true,
+                    node @ Node::PushScopedSymbol(_) => node.is_reference(),
+                    node @ Node::PushSymbol(_) => node.is_reference(),
                     node @ Node::Scope(_) => node.is_exported_scope(),
                     _ => false,
                 })

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -2453,7 +2453,10 @@ impl PartialPaths {
             if !cycle_detector.should_process_path(&path, |probe| probe.cmp(graph, self, &path)) {
                 continue;
             }
-            path.extend_from_file(graph, self, file, &mut queue);
+            let should_extend = path.end_node == path.start_node || !graph[path.end_node].is_root();
+            if should_extend {
+                path.extend_from_file(graph, self, file, &mut queue);
+            }
             if path.is_complete_as_possible(graph) && path.is_productive(self) {
                 visit(graph, self, path);
             }

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -2418,7 +2418,10 @@ impl PartialPaths {
     /// Finds all partial paths in a file, calling the `visit` closure for each one.
     ///
     /// This function ensures that the set of visited partial paths covers all complete
-    /// paths, from references to definitions, when used for path stitching.
+    /// paths, from references to definitions, when used for path stitching. Callers are
+    /// advised _not_ to filter this set in the visitor using functions like
+    /// [`PartialPath::is_complete_as_possible`][] or [`PartialPath::is_productive`][] as
+    /// that may interfere with implementation changes of this function.
     ///
     /// This function will not return until all reachable partial paths have been processed, so
     /// `graph` must already contain a complete stack graph.  If you have a very large stack graph

--- a/stack-graphs/tests/it/can_find_local_nodes.rs
+++ b/stack-graphs/tests/it/can_find_local_nodes.rs
@@ -21,12 +21,6 @@ fn check_local_nodes(graph: &StackGraph, file: &str, expected_local_nodes: &[&st
     let mut database = Database::new();
     partials
         .find_all_partial_paths_in_file(graph, file, &NoCancellation, |graph, partials, path| {
-            if !path.is_complete_as_possible(graph) {
-                return;
-            }
-            if !path.is_productive(partials) {
-                return;
-            }
             database.add_partial_path(graph, partials, path);
         })
         .expect("should never be cancelled");

--- a/stack-graphs/tests/it/can_find_node_partial_paths_in_database.rs
+++ b/stack-graphs/tests/it/can_find_node_partial_paths_in_database.rs
@@ -30,12 +30,6 @@ fn check_node_partial_paths(
     let mut database = Database::new();
     partials
         .find_all_partial_paths_in_file(graph, file, &NoCancellation, |graph, partials, path| {
-            if !path.is_complete_as_possible(graph) {
-                return;
-            }
-            if !path.is_productive(partials) {
-                return;
-            }
             database.add_partial_path(graph, partials, path);
         })
         .expect("should never be cancelled");

--- a/stack-graphs/tests/it/can_find_partial_paths_in_file.rs
+++ b/stack-graphs/tests/it/can_find_partial_paths_in_file.rs
@@ -20,12 +20,6 @@ fn check_partial_paths_in_file(graph: &StackGraph, file: &str, expected_paths: &
     let mut results = BTreeSet::new();
     partials
         .find_all_partial_paths_in_file(graph, file, &NoCancellation, |graph, partials, path| {
-            if !path.is_complete_as_possible(graph) {
-                return;
-            }
-            if !path.is_productive(partials) {
-                return;
-            }
             results.insert(path.display(graph, partials).to_string());
         })
         .expect("should never be cancelled");

--- a/stack-graphs/tests/it/can_find_root_partial_paths_in_database.rs
+++ b/stack-graphs/tests/it/can_find_root_partial_paths_in_database.rs
@@ -34,12 +34,6 @@ fn check_root_partial_paths(
     let mut database = Database::new();
     partials
         .find_all_partial_paths_in_file(graph, file, &NoCancellation, |graph, partials, path| {
-            if !path.is_complete_as_possible(graph) {
-                return;
-            }
-            if !path.is_productive(partials) {
-                return;
-            }
             database.add_partial_path(graph, partials, path);
         })
         .expect("should never be cancelled");

--- a/stack-graphs/tests/it/can_jump_to_definition_with_forward_partial_path_stitching.rs
+++ b/stack-graphs/tests/it/can_jump_to_definition_with_forward_partial_path_stitching.rs
@@ -28,12 +28,6 @@ fn check_jump_to_definition(graph: &StackGraph, expected_partial_paths: &[&str])
                 file,
                 &NoCancellation,
                 |graph, partials, path| {
-                    if !path.is_complete_as_possible(graph) {
-                        return;
-                    }
-                    if !path.is_productive(partials) {
-                        return;
-                    }
                     db.add_partial_path(graph, partials, path);
                 },
             )

--- a/stack-graphs/tests/it/can_jump_to_definition_with_forward_path_stitching.rs
+++ b/stack-graphs/tests/it/can_jump_to_definition_with_forward_path_stitching.rs
@@ -30,12 +30,6 @@ fn check_jump_to_definition(graph: &StackGraph, expected_paths: &[&str]) {
                 file,
                 &NoCancellation,
                 |graph, partials, path| {
-                    if !path.is_complete_as_possible(graph) {
-                        return;
-                    }
-                    if !path.is_productive(partials) {
-                        return;
-                    }
                     db.add_partial_path(graph, partials, path);
                 },
             )


### PR DESCRIPTION
Partial paths are now computed from references only, instead of from any push node. This aligns with the existing behavior for scopes, where only exported scopes are used as start nodes.