### PR TITLE
Support preexisting nodes

### DIFF
--- a/tree-sitter-stack-graphs/CHANGELOG.md
+++ b/tree-sitter-stack-graphs/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Library
+
+#### Fixed
+
+- Executing a `StackGraphLanguage` for a `File` for which the `StackGraph` already contains nodes does not crash anymore.
+
+#### Added
+
+- The `StackGraphLanguage::builder_into_stack_graph` method can be used to create a `Builer` that allows injecting preexisting `StackGraph` nodes using `Builder::inject_node` to obtain `tree_sitter_graph::graph::Value` instances. These can be used for global variables such that the TSG rules can refer to stack graph nodes that were not created by them.
+
 ## 0.3.0 -- 2022-08-23
 
 ### Library

--- a/tree-sitter-stack-graphs/CHANGELOG.md
+++ b/tree-sitter-stack-graphs/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `StackGraphLanguage::builder_into_stack_graph` method can be used to create a `Builer` that allows injecting preexisting `StackGraph` nodes using `Builder::inject_node` to obtain `tree_sitter_graph::graph::Value` instances. These can be used for global variables such that the TSG rules can refer to stack graph nodes that were not created by them.
 
+#### Changed
+
+- Global `Variables` do not require a mutable reference anymore.
+
 ## 0.3.0 -- 2022-08-23
 
 ### Library

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
@@ -261,12 +261,12 @@ impl Command {
         test_fragment: &TestFragment,
         graph: &mut StackGraph,
     ) -> anyhow::Result<()> {
-        let mut globals = Variables::new();
+        let globals = Variables::new();
         match sgl.build_stack_graph_into(
             graph,
             test_fragment.file,
             &test_fragment.source,
-            &mut globals,
+            &globals,
             &NoCancellation,
         ) {
             Err(LoadError::ParseErrors(parse_errors)) => {

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -518,7 +518,7 @@ impl<'a> Builder<'a> {
         globals
             .add(JUMP_TO_SCOPE_NODE_VAR.into(), jump_to_scope_node.into())
             .expect("Failed to set JUMP_TO_SCOPE_NODE");
-        let file_name = format!("{}", &self.stack_graph[self.file]);
+        let file_name = self.stack_graph[self.file].to_string();
         globals
             .add(FILE_PATH_VAR.into(), file_name.into())
             .expect("Failed to set FILE_PATH");

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -446,10 +446,10 @@ impl StackGraphLanguage {
             .build(globals, cancellation_flag)
     }
 
-    /// Create a builder that will the graph construction rules for this language against a source
-    /// file, creating new nodes and edges in `stack_graph`.  Any new nodes that we create will
-    /// belong to `file`.  (The source file must be implemented in this language, otherwise you'll
-    /// probably get a parse error.)
+    /// Create a builder that will execute the graph construction rules for this language against
+    /// a source file, creating new nodes and edges in `stack_graph`.  Any new nodes created during
+    /// execution will belong to `file`.  (The source file must be implemented in this language,
+    /// otherwise you'll probably get a parse error.)
     pub fn builder_into_stack_graph<'a>(
         &'a self,
         stack_graph: &'a mut StackGraph,

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -657,9 +657,8 @@ impl<'a> Builder<'a> {
                 .insert(index, NodeID::new_in_file(self.file, next_local_id));
         }
 
-        // First create a stack graph node for each TSG node.  (The skip(2) is because the first
-        // two DSL nodes that we create are the proxies for the stack graph's “root” and “jump to
-        // scope” nodes.)
+        // First create a stack graph node for each TSG node.  (The filter(...) is because the first
+        // DSL nodes that we create are the proxies for the injected stack graph nodes.)
         let injected_node_count = self.injected_node_count;
         for node_ref in self
             .graph

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -557,7 +557,7 @@ struct StackGraphLoader<'a> {
     graph: &'a Graph<'a>,
     source: &'a str,
     span_calculator: SpanCalculator<'a>,
-    remapped_local_ids: HashMap<u32, u32>,
+    remapped_local_ids: HashMap<usize, NodeID>,
 }
 
 impl<'a> StackGraphLoader<'a> {
@@ -573,9 +573,13 @@ impl<'a> StackGraphLoader<'a> {
         // for local_ids that already exist in the graph---all other graph ids are mapped to
         // the same local_id.
         let mut remapped_local_ids = HashMap::new();
+        remapped_local_ids.insert(0usize, NodeID::root());
+        remapped_local_ids.insert(1usize, NodeID::jump_to());
         // remap beyond the range of graph nodes
-        let mut next_local_id = graph.node_count() as u32;
+        let mut next_local_id = (graph.node_count() as u32) - 2;
         for node in stack_graph.nodes_for_file(file) {
+            let local_id = stack_graph[node].id().local_id();
+            let index = (local_id as usize) + 2;
             // find next available id for which no stack graph node exists yet
             while stack_graph
                 .node_for_id(NodeID::new_in_file(file, next_local_id))
@@ -584,8 +588,7 @@ impl<'a> StackGraphLoader<'a> {
                 next_local_id += 1;
             }
             // remap occupied local_id to next available id
-            let local_id = stack_graph[node].id().local_id();
-            remapped_local_ids.insert(local_id, next_local_id);
+            remapped_local_ids.insert(index, NodeID::new_in_file(file, next_local_id));
         }
 
         StackGraphLoader {
@@ -680,15 +683,10 @@ fn get_node_type(node: &GraphNode) -> Result<NodeType, LoadError> {
 impl<'a> StackGraphLoader<'a> {
     fn node_id_for_graph_node(&mut self, node_ref: GraphNodeRef) -> NodeID {
         let index = node_ref.index();
-        if index == 0 {
-            NodeID::root()
-        } else if index == 1 {
-            NodeID::jump_to()
-        } else {
-            let local_id = (index - 2) as u32;
-            let local_id = *self.remapped_local_ids.get(&local_id).unwrap_or(&local_id);
-            NodeID::new_in_file(self.file, local_id)
-        }
+        self.remapped_local_ids.get(&index).map_or_else(
+            || NodeID::new_in_file(self.file, (index as u32) - 2),
+            |id| *id,
+        )
     }
 
     fn load_drop_scopes(&mut self, node_ref: GraphNodeRef) -> Handle<Node> {

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -442,7 +442,7 @@ impl StackGraphLanguage {
         globals: &'a mut Variables<'a>,
         cancellation_flag: &'a dyn CancellationFlag,
     ) -> Result<(), LoadError> {
-        self.into_stack_graph_builder(stack_graph, file, source)
+        self.builder_into_stack_graph(stack_graph, file, source)
             .build(globals, cancellation_flag)
     }
 
@@ -450,7 +450,7 @@ impl StackGraphLanguage {
     /// file, creating new nodes and edges in `stack_graph`.  Any new nodes that we create will
     /// belong to `file`.  (The source file must be implemented in this language, otherwise you'll
     /// probably get a parse error.)
-    pub fn into_stack_graph_builder<'a>(
+    pub fn builder_into_stack_graph<'a>(
         &'a self,
         stack_graph: &'a mut StackGraph,
         file: Handle<File>,

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -287,8 +287,8 @@
 //! let mut language = StackGraphLanguage::from_str(grammar, tsg_source)?;
 //! let mut stack_graph = StackGraph::new();
 //! let file_handle = stack_graph.get_or_create_file("test.py");
-//! let mut globals = Variables::new();
-//! language.build_stack_graph_into(&mut stack_graph, file_handle, python_source, &mut globals, &NoCancellation)?;
+//! let globals = Variables::new();
+//! language.build_stack_graph_into(&mut stack_graph, file_handle, python_source, &globals, &NoCancellation)?;
 //! # Ok(())
 //! # }
 //! ```
@@ -439,7 +439,7 @@ impl StackGraphLanguage {
         stack_graph: &'a mut StackGraph,
         file: Handle<File>,
         source: &'a str,
-        globals: &'a mut Variables<'a>,
+        globals: &'a Variables<'a>,
         cancellation_flag: &'a dyn CancellationFlag,
     ) -> Result<(), LoadError> {
         self.builder_into_stack_graph(stack_graph, file, source)
@@ -494,7 +494,7 @@ impl<'a> Builder<'a> {
     /// Executes this builder.
     pub fn build(
         mut self,
-        globals: &'a mut Variables<'a>,
+        globals: &'a Variables<'a>,
         cancellation_flag: &dyn CancellationFlag,
     ) -> Result<(), LoadError> {
         let mut parser = Parser::new();

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -222,15 +222,9 @@ impl Loader {
                 let source = std::fs::read(path.clone())
                     .with_context(|| format!("Failed to read {}", path.display()))?;
                 let source = String::from_utf8(source).map_err(LoadError::other)?;
-                let mut globals = Variables::new();
-                sgl.build_stack_graph_into(
-                    &mut graph,
-                    file,
-                    &source,
-                    &mut globals,
-                    cancellation_flag,
-                )
-                .map_err(LoadError::other)?;
+                let globals = Variables::new();
+                sgl.build_stack_graph_into(&mut graph, file, &source, &globals, cancellation_flag)
+                    .map_err(LoadError::other)?;
             }
         }
         sgl.builtins_mut().add_from_graph(&graph).unwrap();

--- a/tree-sitter-stack-graphs/tests/it/builder.rs
+++ b/tree-sitter-stack-graphs/tests/it/builder.rs
@@ -27,10 +27,10 @@ fn can_support_preexisting_nodes() {
     let node_id = graph.new_node_id(file);
     let _preexisting_node = graph.add_scope_node(node_id, true).unwrap();
 
-    let mut globals = Variables::new();
+    let globals = Variables::new();
     let language = StackGraphLanguage::from_str(tree_sitter_python::language(), tsg).unwrap();
     language
-        .build_stack_graph_into(&mut graph, file, python, &mut globals, &NoCancellation)
+        .build_stack_graph_into(&mut graph, file, python, &globals, &NoCancellation)
         .expect("Failed to build graph");
 }
 
@@ -59,7 +59,7 @@ fn can_support_injected_nodes() {
         .expect("Failed to add EXT_NODE variable");
 
     builder
-        .build(&mut globals, &NoCancellation)
+        .build(&globals, &NoCancellation)
         .expect("Failed to build graph");
 
     check_stack_graph_nodes(

--- a/tree-sitter-stack-graphs/tests/it/builder.rs
+++ b/tree-sitter-stack-graphs/tests/it/builder.rs
@@ -1,0 +1,73 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2022, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use stack_graphs::graph::StackGraph;
+use tree_sitter_graph::Variables;
+use tree_sitter_stack_graphs::NoCancellation;
+use tree_sitter_stack_graphs::StackGraphLanguage;
+
+use crate::edges::check_stack_graph_edges;
+use crate::nodes::check_stack_graph_nodes;
+
+#[test]
+fn can_support_preexisting_nodes() {
+    let tsg = r#"
+    (module)@mod {
+      node @mod.lexical_scope
+    }
+    "#;
+    let python = "pass";
+
+    let mut graph = StackGraph::new();
+    let file = graph.get_or_create_file("test.py");
+    let node_id = graph.new_node_id(file);
+    let _preexisting_node = graph.add_scope_node(node_id, true).unwrap();
+
+    let mut globals = Variables::new();
+    let language = StackGraphLanguage::from_str(tree_sitter_python::language(), tsg).unwrap();
+    language
+        .build_stack_graph_into(&mut graph, file, python, &mut globals, &NoCancellation)
+        .expect("Failed to build graph");
+}
+
+#[test]
+fn can_support_injected_nodes() {
+    let tsg = r#"
+    global EXT_NODE
+    (module)@mod {
+      node @mod.lexical_scope
+      edge @mod.lexical_scope -> EXT_NODE
+    }
+    "#;
+    let python = "pass";
+
+    let mut graph = StackGraph::new();
+    let file = graph.get_or_create_file("test.py");
+    let node_id = graph.new_node_id(file);
+    let _preexisting_node = graph.add_scope_node(node_id, true).unwrap();
+
+    let language = StackGraphLanguage::from_str(tree_sitter_python::language(), tsg).unwrap();
+    let mut builder = language.builder_into_stack_graph(&mut graph, file, python);
+
+    let mut globals = Variables::new();
+    globals
+        .add("EXT_NODE".into(), builder.inject_node(node_id).into())
+        .expect("Failed to add EXT_NODE variable");
+
+    builder
+        .build(&mut globals, &NoCancellation)
+        .expect("Failed to build graph");
+
+    check_stack_graph_nodes(
+        &graph,
+        &["[test.py(0) exported scope]", "[test.py(1) scope]"],
+    );
+    check_stack_graph_edges(
+        &graph,
+        &["[test.py(1) scope] -0-> [test.py(0) exported scope]"],
+    );
+}

--- a/tree-sitter-stack-graphs/tests/it/builder.rs
+++ b/tree-sitter-stack-graphs/tests/it/builder.rs
@@ -64,6 +64,7 @@ fn can_support_injected_nodes() {
 
     check_stack_graph_nodes(
         &graph,
+        file,
         &["[test.py(0) exported scope]", "[test.py(1) scope]"],
     );
     check_stack_graph_edges(

--- a/tree-sitter-stack-graphs/tests/it/edges.rs
+++ b/tree-sitter-stack-graphs/tests/it/edges.rs
@@ -16,7 +16,8 @@ fn build_and_check_stack_graph_edges(
     tsg_source: &str,
     expected_edges: &[&str],
 ) {
-    let graph = build_stack_graph(python_source, tsg_source).expect("Could not load stack graph");
+    let (graph, _) =
+        build_stack_graph(python_source, tsg_source).expect("Could not load stack graph");
     check_stack_graph_edges(&graph, expected_edges);
 }
 

--- a/tree-sitter-stack-graphs/tests/it/edges.rs
+++ b/tree-sitter-stack-graphs/tests/it/edges.rs
@@ -85,6 +85,9 @@ fn can_create_edges_with_precedence() {
 #[test]
 fn can_create_edges_to_singleton_nodes() {
     let tsg = r#"
+      global ROOT_NODE
+      global JUMP_TO_SCOPE_NODE
+
       (identifier) @id {
          node source
          attr (source) type = "push_symbol", symbol = (source-text @id), is_reference

--- a/tree-sitter-stack-graphs/tests/it/edges.rs
+++ b/tree-sitter-stack-graphs/tests/it/edges.rs
@@ -5,33 +5,22 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-use std::collections::BTreeSet;
-
 use pretty_assertions::assert_eq;
 use stack_graphs::graph::StackGraph;
-use tree_sitter_graph::Variables;
-use tree_sitter_stack_graphs::LoadError;
-use tree_sitter_stack_graphs::NoCancellation;
-use tree_sitter_stack_graphs::StackGraphLanguage;
+use std::collections::BTreeSet;
 
-fn build_stack_graph(python_source: &str, tsg_source: &str) -> Result<StackGraph, LoadError> {
-    let language =
-        StackGraphLanguage::from_str(tree_sitter_python::language(), tsg_source).unwrap();
-    let mut graph = StackGraph::new();
-    let file = graph.get_or_create_file("test.py");
-    let mut globals = Variables::new();
-    language.build_stack_graph_into(
-        &mut graph,
-        file,
-        python_source,
-        &mut globals,
-        &NoCancellation,
-    )?;
-    Ok(graph)
+use super::build_stack_graph;
+
+fn build_and_check_stack_graph_edges(
+    python_source: &str,
+    tsg_source: &str,
+    expected_edges: &[&str],
+) {
+    let graph = build_stack_graph(python_source, tsg_source).expect("Could not load stack graph");
+    check_stack_graph_edges(&graph, expected_edges);
 }
 
-fn check_stack_graph_edges(python_source: &str, tsg_source: &str, expected_edges: &[&str]) {
-    let graph = build_stack_graph(python_source, tsg_source).expect("Could not load stack graph");
+pub(super) fn check_stack_graph_edges(graph: &StackGraph, expected_edges: &[&str]) {
     let mut actual_edges = BTreeSet::new();
     for source in graph.iter_nodes() {
         for edge in graph.outgoing_edges(source) {
@@ -62,7 +51,7 @@ fn can_create_edges() {
       }
     "#;
     let python = "a";
-    check_stack_graph_edges(
+    build_and_check_stack_graph_edges(
         python,
         tsg,
         &[
@@ -84,7 +73,7 @@ fn can_create_edges_with_precedence() {
       }
     "#;
     let python = "a";
-    check_stack_graph_edges(
+    build_and_check_stack_graph_edges(
         python,
         tsg,
         &[
@@ -115,7 +104,7 @@ fn can_create_edges_to_singleton_nodes() {
       }
     "#;
     let python = "a";
-    check_stack_graph_edges(
+    build_and_check_stack_graph_edges(
         python,
         tsg,
         &[

--- a/tree-sitter-stack-graphs/tests/it/main.rs
+++ b/tree-sitter-stack-graphs/tests/it/main.rs
@@ -5,6 +5,8 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+use stack_graphs::arena::Handle;
+use stack_graphs::graph::File;
 use stack_graphs::graph::StackGraph;
 use tree_sitter_graph::Variables;
 use tree_sitter_stack_graphs::LoadError;
@@ -19,12 +21,12 @@ mod test;
 pub(self) fn build_stack_graph(
     python_source: &str,
     tsg_source: &str,
-) -> Result<StackGraph, LoadError> {
+) -> Result<(StackGraph, Handle<File>), LoadError> {
     let language =
         StackGraphLanguage::from_str(tree_sitter_python::language(), tsg_source).unwrap();
     let mut graph = StackGraph::new();
     let file = graph.get_or_create_file("test.py");
     let globals = Variables::new();
     language.build_stack_graph_into(&mut graph, file, python_source, &globals, &NoCancellation)?;
-    Ok(graph)
+    Ok((graph, file))
 }

--- a/tree-sitter-stack-graphs/tests/it/main.rs
+++ b/tree-sitter-stack-graphs/tests/it/main.rs
@@ -5,6 +5,32 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+use stack_graphs::graph::StackGraph;
+use tree_sitter_graph::Variables;
+use tree_sitter_stack_graphs::LoadError;
+use tree_sitter_stack_graphs::NoCancellation;
+use tree_sitter_stack_graphs::StackGraphLanguage;
+
+mod builder;
 mod edges;
 mod nodes;
 mod test;
+
+pub(self) fn build_stack_graph(
+    python_source: &str,
+    tsg_source: &str,
+) -> Result<StackGraph, LoadError> {
+    let language =
+        StackGraphLanguage::from_str(tree_sitter_python::language(), tsg_source).unwrap();
+    let mut graph = StackGraph::new();
+    let file = graph.get_or_create_file("test.py");
+    let mut globals = Variables::new();
+    language.build_stack_graph_into(
+        &mut graph,
+        file,
+        python_source,
+        &mut globals,
+        &NoCancellation,
+    )?;
+    Ok(graph)
+}

--- a/tree-sitter-stack-graphs/tests/it/main.rs
+++ b/tree-sitter-stack-graphs/tests/it/main.rs
@@ -24,13 +24,7 @@ pub(self) fn build_stack_graph(
         StackGraphLanguage::from_str(tree_sitter_python::language(), tsg_source).unwrap();
     let mut graph = StackGraph::new();
     let file = graph.get_or_create_file("test.py");
-    let mut globals = Variables::new();
-    language.build_stack_graph_into(
-        &mut graph,
-        file,
-        python_source,
-        &mut globals,
-        &NoCancellation,
-    )?;
+    let globals = Variables::new();
+    language.build_stack_graph_into(&mut graph, file, python_source, &globals, &NoCancellation)?;
     Ok(graph)
 }

--- a/tree-sitter-stack-graphs/tests/it/nodes.rs
+++ b/tree-sitter-stack-graphs/tests/it/nodes.rs
@@ -287,3 +287,26 @@ fn can_calculate_spans() {
     let trimmed_line = &python[source_info.span.start.trimmed_line.clone()];
     assert_eq!(trimmed_line, "a");
 }
+
+#[test]
+fn can_support_preexisting_nodes() {
+    let tsg = r#"
+    (module)@mod {
+      node @mod.lexical_scope
+    }
+    "#;
+    let python = "pass";
+
+    let mut graph = StackGraph::new();
+    let file = graph.get_or_create_file("test.py");
+    let node_id = graph.new_node_id(file);
+    let _preexisting_node = graph.add_scope_node(node_id, true).unwrap();
+
+    let mut globals = Variables::new();
+
+    let language = StackGraphLanguage::from_str(tree_sitter_python::language(), tsg).unwrap();
+
+    language
+        .build_stack_graph_into(&mut graph, file, python, &mut globals, &NoCancellation)
+        .expect("Failed to build graph");
+}

--- a/tree-sitter-stack-graphs/tests/it/test.rs
+++ b/tree-sitter-stack-graphs/tests/it/test.rs
@@ -60,8 +60,8 @@ fn build_stack_graph_into(
 ) -> Result<(), LoadError> {
     let language =
         StackGraphLanguage::from_str(tree_sitter_python::language(), tsg_source).unwrap();
-    let mut globals = Variables::new();
-    language.build_stack_graph_into(graph, file, python_source, &mut globals, &NoCancellation)?;
+    let globals = Variables::new();
+    language.build_stack_graph_into(graph, file, python_source, &globals, &NoCancellation)?;
     Ok(())
 }
 


### PR DESCRIPTION
It can be useful to be able to programatically create nodes and edges in the stack graph, and pass those to tree-sitter-stack-graph as globals, so they can be used in a TSG.

At the moment, this is not possible at all. If preexisting nodes even exist, loading the result from TSG into the stack graph fails.

This PR adds functionality to prevent crashes and support using references to existing nodes as global variables.

See reported issue in #104.

## Tasks

- [x] Prevent crashes during stack graph loading when a `File` has preexisting nodes.
- [x] Provide a mechanism to convert stack graph node references into valid tree-sitter-graph values.
