### PR TITLE
Release stack-graphs 0.10.1 and tree-sitter-stack-graphs 0.3.1

### DIFF
--- a/stack-graphs/CHANGELOG.md
+++ b/stack-graphs/CHANGELOG.md
@@ -9,31 +9,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The amount of work done in `PartialPaths::find_all_partial_paths_in_file` is reduced. The documentation now makes it clear that the function itself is responsible for returning a set that is big enough to cover all complete paths. Callers should not have to filter this set further anymore, and any visitors filtering with `PartialPath::is_complete_as_possible` or `PartialPath::is_productive` should remove those checks, as they may interfere with future ompitmizations of this fynction.
+- The amount of work done in `PartialPaths::find_all_partial_paths_in_file`
+  is reduced. The documentation now makes it clear that the
+  function itself is responsible for returning a set that is big
+  enough to cover all complete paths. Callers should not have to
+  filter this set further anymore, and any visitors filtering with
+  `PartialPath::is_complete_as_possible` or `PartialPath::is_productive`
+  should remove those checks, as they may interfere with future
+  ompitmizations of this fynction.
 
 ## 0.10.0 -- 2022-08-23
 
 ### Added
 
-- Cancellation of potentially long-running operations is now supported by passing an implementation of the `CancellationFlag` trait. The `NoCancellation` type provides a noop implementation.
+- Cancellation of potentially long-running operations is now supported
+  by passing an implementation of the `CancellationFlag` trait. The
+  `NoCancellation` type provides a noop implementation.
 
 ### Changed
 
 - `Assertion::run` requires an extra cancellation flag parameter.
-- `PartialPaths::find_all_partial_paths_in_file`, `Paths::find_all_paths`, `Paths::remove_shadowed_paths`, `PathStitcher::find_all_complete_paths` and `ForwardPartialPathStitcher::find_all_complete_partial_paths` require an extra cancellation flag parameter and now return a `Result` to indicate if the computation was successful or cancelled.
-- C API functions `sg_path_arena_find_all_complete_paths` and `sg_partial_path_arena_find_partial_paths_in_file` require an extra `const size_t *cancellation_flag` parameter and return an `sg_result` value to indicate if the operation was successful or cancelled. A null pointer can be passed if no cancellation is necessary.
+- `PartialPaths::find_all_partial_paths_in_file`, `Paths::find_all_paths`,
+  `Paths::remove_shadowed_paths`, `PathStitcher::find_all_complete_paths`
+  and `ForwardPartialPathStitcher::find_all_complete_partial_paths`
+  require an extra cancellation flag parameter and now return a `Result`
+  to indicate if the computation was successful or cancelled.
+- C API functions `sg_path_arena_find_all_complete_paths` and
+  `sg_partial_path_arena_find_partial_paths_in_file` require an extra
+  parameter `const size_t *cancellation_flag` parameter and return an
+  `sg_result` value to indicate if the operation was successful or
+  cancelled. A null pointer can be passed if no cancellation is necessary.
 
 ## stack-graphs 0.9.0 - 2022-06-29
 
 ### Added
 
-- C API functions `sg_partial_path_database_ensure_both_directions` and `sg_partial_path_database_ensure_forwards` to ensure the available directions of deques in partial paths in a database.
+- C API functions `sg_partial_path_database_ensure_both_directions` and
+  `sg_partial_path_database_ensure_forwards` to ensure the available
+  directions of deques in partial paths in a database.
 
 ## stack-graphs 0.8.0 - 2022-05-19
 
 ### Added
 
-- Source info field `definiens_span` for the source span that corresponds to the definiens of a function declaration (i.e. the body of a function declaration, not an assignment).
+- Source info field `definiens_span` for the source span that corresponds
+  to the definiens of a function declaration (i.e. the body of a function
+  declaration, not an assignment).
 
 ## stack-graphs 0.7.3 -- 2022-05-17
 

--- a/stack-graphs/CHANGELOG.md
+++ b/stack-graphs/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.10.1 -- 2022-09-07
 
 ### Changed
 

--- a/stack-graphs/Cargo.toml
+++ b/stack-graphs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stack-graphs"
-version = "0.10.0"
+version = "0.10.1"
 description = "Name binding for arbitrary programming languages"
 homepage = "https://github.com/github/stack-graphs/tree/main/stack-graphs"
 repository = "https://github.com/github/stack-graphs/"

--- a/tree-sitter-stack-graphs/CHANGELOG.md
+++ b/tree-sitter-stack-graphs/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.3.1 -- 2022-09-07
 
 ### Library
 

--- a/tree-sitter-stack-graphs/CHANGELOG.md
+++ b/tree-sitter-stack-graphs/CHANGELOG.md
@@ -11,11 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
-- Executing a `StackGraphLanguage` for a `File` for which the `StackGraph` already contains nodes does not crash anymore.
+- Cancellation errors from `tree_sitter_graph` execution are not wrapped
+  but propagated as cancellations.
+- Executing a `StackGraphLanguage` for a `File` for which the `StackGraph`
+  already contains nodes does not crash anymore.
 
 #### Added
 
-- The `StackGraphLanguage::builder_into_stack_graph` method can be used to create a `Builer` that allows injecting preexisting `StackGraph` nodes using `Builder::inject_node` to obtain `tree_sitter_graph::graph::Value` instances. These can be used for global variables such that the TSG rules can refer to stack graph nodes that were not created by them.
+- The `StackGraphLanguage::builder_into_stack_graph` method can be used to
+  create a `Builer` that allows injecting preexisting `StackGraph` nodes
+  using `Builder::inject_node` to obtain `tree_sitter_graph::graph::Value`
+  instances. These can be used for global variables such that the TSG
+  rules can refer to stack graph nodes that were not created by them.
 
 #### Changed
 

--- a/tree-sitter-stack-graphs/CHANGELOG.md
+++ b/tree-sitter-stack-graphs/CHANGELOG.md
@@ -27,9 +27,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Changed
 
-- `StackGraphLanguage` instances can now safely be shared between threads. The `StackGraphLanguage::build_stack_graph_into` does not require a mutable instance anymore.
-- `StackGraphLanguage::build_stack_graph_into` and `loader::Loader::load_for_file` now supports cancellation by passing an instance of `CancellationFlag`. The `NoCancellation` type provides a noop implementation.
-- `test::Test::run` now supports cancellation by passing an instance of `CancellationFlag` and returns a `Result` indicating whether the test was canceled or not.
+- `StackGraphLanguage` instances can now safely be shared between
+  threads. The `StackGraphLanguage::build_stack_graph_into` does not
+  require a mutable instance anymore.
+- `StackGraphLanguage::build_stack_graph_into` and
+  `loader::Loader::load_for_file` now supports cancellation by passing
+  an instance of `CancellationFlag`. The `NoCancellation` type provides
+  a noop implementation.
+- `test::Test::run` now supports cancellation by passing an instance of
+  `CancellationFlag` and returns a `Result` indicating whether the test
+  was canceled or not.
 - Depend on `stack-graphs` version 0.10 and `tree-sitter-graph` version 0.6.
 
 ## 0.2.0 -- 2022-06-29
@@ -42,9 +49,12 @@ Depend on `stack-graphs` version 0.9.
 
 #### Added
 
-- `StackGraphLanguage` data type that handles parsing sources, executing the tree-sitter-graph rules, and constructing the resulting stack graph.
-- `test` module that defines data types for parsing and running stack graph tests.
-- `loader` module that defines data types for loading stack graph languages for source files.
+- `StackGraphLanguage` data type that handles parsing sources, executing
+  the tree-sitter-graph rules, and constructing the resulting stack graph.
+- `test` module that defines data types for parsing and running stack
+  graph tests.
+- `loader` module that defines data types for loading stack graph
+  languages for source files.
 
 ### CLI
 

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-stack-graphs"
-version = "0.3.0"
+version = "0.3.1"
 description = "Create stack graphs using tree-sitter parsers"
 homepage = "https://github.com/github/stack-graphs/tree/main/tree-sitter-stack-graphs"
 repository = "https://github.com/github/stack-graphs/"


### PR DESCRIPTION
Minor releases so they are available for use in tree-sitter-code-nav.