### PR TITLE
Add support fer globals in tests and builtins

### DIFF
--- a/tree-sitter-stack-graphs/CHANGELOG.md
+++ b/tree-sitter-stack-graphs/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Library
+
+#### Changed
+
+- The TSG reader function passed to `loader::Loader::from_*` may now return any `std::error::Error` and does not require the specific `anyhow::Error` anymore.
+
+#### Added
+
+- Tests can specify global variables that are passed to the TSG rules using `--- global: NAME+VALUE ---` in comments.
+- `loader::Loader` reads global variables for the builtins from an optional `queries/builtins.cfg` configuration file in the language repository when loading TSG files. API users can call `loader::Loader::load_config_from_*` methods to read configuration files.
+
 ## 0.3.1 -- 2022-09-07
 
 ### Library

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -35,6 +35,7 @@ lazy_static = "1.4"
 log = "0.4"
 lsp-positions = { version="0.3", path="../lsp-positions" }
 regex = "1"
+rust-ini = "0.18"
 stack-graphs = { version="0.10", path="../stack-graphs" }
 thiserror = "1.0"
 tree-sitter = ">= 0.19"

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/loader.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/loader.rs
@@ -5,14 +5,13 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-use anyhow::Context;
-use anyhow::Result;
 use clap::Args;
 use std::path::Path;
 use std::path::PathBuf;
 use tree_sitter::Language;
 use tree_sitter_config::Config as TsConfig;
 use tree_sitter_graph::ast::File as TsgFile;
+use tree_sitter_stack_graphs::loader::LoadError;
 use tree_sitter_stack_graphs::loader::Loader;
 
 #[derive(Args)]
@@ -33,7 +32,7 @@ pub struct LoaderArgs {
 }
 
 impl LoaderArgs {
-    pub fn new_loader(&self) -> Result<Loader> {
+    pub fn new_loader(&self) -> Result<Loader, LoadError> {
         let tsg_path = self.tsg.clone();
         let tsg = move |language| {
             if let Some(tsg_path) = &tsg_path {
@@ -46,18 +45,21 @@ impl LoaderArgs {
         let loader = if !self.grammar.is_empty() {
             Loader::from_paths(self.grammar.clone(), self.scope.clone(), tsg)?
         } else {
-            let loader_config = TsConfig::load()?.get()?;
+            let loader_config = TsConfig::load()
+                .and_then(|v| v.get())
+                .map_err(LoadError::TreeSitter)?;
             Loader::from_config(&loader_config, self.scope.clone(), tsg)?
         };
         Ok(loader)
     }
 
-    fn load_tsg_from_path(language: Language, tsg_path: &Path) -> Result<TsgFile> {
-        let tsg_source = std::fs::read(tsg_path)
-            .with_context(|| format!("Failed to read {}", tsg_path.display()))?;
+    fn load_tsg_from_path(
+        language: Language,
+        tsg_path: &Path,
+    ) -> Result<TsgFile, Box<dyn std::error::Error + Send + Sync>> {
+        let tsg_source = std::fs::read(tsg_path)?;
         let tsg_source = String::from_utf8(tsg_source)?;
-        let tsg = TsgFile::from_str(language, &tsg_source)
-            .with_context(|| format!("Failed to parse {}", tsg_path.display()))?;
+        let tsg = TsgFile::from_str(language, &tsg_source)?;
         return Ok(tsg);
     }
 }

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/loader.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/loader.rs
@@ -57,8 +57,7 @@ impl LoaderArgs {
         language: Language,
         tsg_path: &Path,
     ) -> Result<TsgFile, Box<dyn std::error::Error + Send + Sync>> {
-        let tsg_source = std::fs::read(tsg_path)?;
-        let tsg_source = String::from_utf8(tsg_source)?;
+        let tsg_source = std::fs::read_to_string(tsg_path)?;
         let tsg = TsgFile::from_str(language, &tsg_source)?;
         return Ok(tsg);
     }

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
@@ -196,7 +196,7 @@ impl Command {
         test_path: &Path,
         loader: &mut Loader,
     ) -> anyhow::Result<usize> {
-        let source = String::from_utf8(std::fs::read(test_path)?)?;
+        let source = std::fs::read_to_string(test_path)?;
         let sgl = match loader.load_for_file(test_path, Some(&source), &NoCancellation)? {
             Some(sgl) => sgl,
             None => {

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -245,7 +245,7 @@ impl Loader {
                 let mut globals = Variables::new();
                 let globals_path = language.root_path.join("queries/builtins.cfg");
                 if globals_path.exists() {
-                    self.load_cfg_into(&globals_path, &mut globals)?;
+                    self.load_config_from_path(&globals_path, &mut globals)?;
                 }
                 sgl.build_stack_graph_into(&mut graph, file, &source, &globals, cancellation_flag)?;
             }
@@ -254,8 +254,25 @@ impl Loader {
         Ok(())
     }
 
-    fn load_cfg_into(&self, path: &Path, globals: &mut Variables) -> Result<(), LoadError> {
+    pub fn load_config_from_path(
+        &self,
+        path: &Path,
+        globals: &mut Variables,
+    ) -> Result<(), LoadError> {
         let conf = Ini::load_from_file(path)?;
+        self.load_config(&conf, globals)
+    }
+
+    pub fn load_config_from_str(
+        &self,
+        config: &str,
+        globals: &mut Variables,
+    ) -> Result<(), LoadError> {
+        let conf = Ini::load_from_str(config).map_err(ini::Error::Parse)?;
+        self.load_config(&conf, globals)
+    }
+
+    fn load_config(&self, conf: &Ini, globals: &mut Variables) -> Result<(), LoadError> {
         if let Some(globals_section) = conf.section(Some("globals")) {
             for (name, value) in globals_section.iter() {
                 globals.add(name.into(), value.into()).map_err(|_| {

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -229,6 +229,9 @@ impl Loader {
         return Err(LoadError::NoTsgFound);
     }
 
+    // Builtins are loaded from queries/builtins.EXT and an optional queries/builtins.cfg configuration.
+    // In the future, we may extend this to support builtins spread over multiple files queries/builtins/NAME.EXT
+    // and optional corresponding configuration files queries/builtins/NAME.cfg.
     fn load_builtins(
         &self,
         language: &SupplementedLanguage,

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -27,7 +27,6 @@ use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::path::Path;
 use std::path::PathBuf;
-use std::string::FromUtf8Error;
 use thiserror::Error;
 use tree_sitter::Language;
 use tree_sitter_graph::ast::File as TsgFile;
@@ -220,8 +219,7 @@ impl Loader {
 
         let tsg_path = language.root_path.join("queries/stack-graphs.tsg");
         if tsg_path.exists() {
-            let tsg_source = std::fs::read(tsg_path.clone())?;
-            let tsg_source = String::from_utf8(tsg_source)?;
+            let tsg_source = std::fs::read_to_string(tsg_path.clone())?;
             let tsg = TsgFile::from_str(language.language, &tsg_source)?;
             return Ok(tsg);
         }
@@ -243,8 +241,7 @@ impl Loader {
             let path = language.root_path.join(format!("queries/builtins.{}", ext));
             if path.exists() {
                 let file = graph.add_file(&path.to_string_lossy()).unwrap();
-                let source = std::fs::read(path.clone())?;
-                let source = String::from_utf8(source)?;
+                let source = std::fs::read_to_string(path.clone())?;
                 let mut globals = Variables::new();
                 let globals_path = language.root_path.join("queries/builtins.cfg");
                 if globals_path.exists() {
@@ -294,8 +291,6 @@ pub enum LoadError {
     TsgParse(#[from] tree_sitter_graph::ParseError),
     #[error(transparent)]
     TreeSitter(anyhow::Error),
-    #[error(transparent)]
-    Utf8(#[from] FromUtf8Error),
 }
 
 impl From<crate::LoadError> for LoadError {


### PR DESCRIPTION
TSG files can declare global variables hey expect to be set in the environment by the
caller. Tree-sitter-stack-graphs sets a few of these by default, such as `ROOT_NODE` and
`FILE_PATH`. There was no way of specifying other global variables, which made TSG files which
require more variables than those untestable.

This PR adds support for setting global variables in two situations:

1. In tests files, global variables can be set in comments. For example:

       # --- PKG: some_pkg ---
       pass

2. Global variables for the builtins loaded from the grammar repository can be specified in an
   optional configuration file `queries/builtins.cfg` alongside the builtins file itself. For
   example:

       [globals]
       PKG=std
