### PR TITLE
Add actions to publish crates on tags push

### DIFF
--- a/.github/workflows/publish-lsp-positions-crate.yml
+++ b/.github/workflows/publish-lsp-positions-crate.yml
@@ -1,0 +1,31 @@
+name: Publish lsp-positions on crates.io
+
+on:
+  push:
+    tags:
+      - lsp-positions-v*'
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CRATE_DIR: './lsp-positions'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Rust environment
+        uses: hecrj/setup-rust-action@v1
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      # TODO Verify the crate version matches the tag
+      - name: Verify publish crate
+        uses: katyo/publish-crates@v1
+        with:
+          path: ${{ env.CRATE_DIR }}
+          dry-run: true
+      - name: Publish crate
+        uses: katyo/publish-crates@v1
+        with:
+          path: ${{ env.CRATE_DIR }}
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-stack-graphs-crate.yml
+++ b/.github/workflows/publish-stack-graphs-crate.yml
@@ -1,0 +1,31 @@
+name: Publish stack-graphs on crates.io
+
+on:
+  push:
+    tags:
+      - stack-graphs-v*'
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CRATE_DIR: './stack-graphs'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Rust environment
+        uses: hecrj/setup-rust-action@v1
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      # TODO Verify the crate version matches the tag
+      - name: Verify publish crate
+        uses: katyo/publish-crates@v1
+        with:
+          path: ${{ env.CRATE_DIR }}
+          dry-run: true
+      - name: Publish crate
+        uses: katyo/publish-crates@v1
+        with:
+          path: ${{ env.CRATE_DIR }}
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-tree-sitter-stack-graphs-crate.yml
+++ b/.github/workflows/publish-tree-sitter-stack-graphs-crate.yml
@@ -1,0 +1,31 @@
+name: Publish tree-sitter-stack-graphs on crates.io
+
+on:
+  push:
+    tags:
+      - tree-sitter-stack-graphs-v*'
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CRATE_DIR: './tree-sitter-stack-graphs'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Rust environment
+        uses: hecrj/setup-rust-action@v1
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      # TODO Verify the crate version matches the tag
+      - name: Verify publish crate
+        uses: katyo/publish-crates@v1
+        with:
+          path: ${{ env.CRATE_DIR }}
+          dry-run: true
+      - name: Publish crate
+        uses: katyo/publish-crates@v1
+        with:
+          path: ${{ env.CRATE_DIR }}
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
This adds actions that publish the crate when a `CRATE_NAME-v*` tag is pushed.

Docs for the publish action: https://github.com/marketplace/actions/publish-crates

It would be nice to verify that the tag matches the version of the crate, but I couldn't quickly figure out a way to do that.
