### PR TITLE
Add command to show parse tree

### DIFF
--- a/tree-sitter-stack-graphs/examples/README.md
+++ b/tree-sitter-stack-graphs/examples/README.md
@@ -24,6 +24,12 @@ $ ../run
 
 To render HTML visualizations of the stack graphs for the tests in an example, add the `-V` flag to run.
 
+Print the parse tree of an example file by executing:
+
+```bash
+$ ./parse EXAMPLE_FILE
+```
+
 The following examples are available:
 
 - [Nested scoping](nested-scope/)

--- a/tree-sitter-stack-graphs/examples/parse
+++ b/tree-sitter-stack-graphs/examples/parse
@@ -1,0 +1,46 @@
+#!/usr/bin/env sh
+
+set -eu
+
+dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
+error() {
+    echo "Error: $1" 1>&2
+}
+
+usage() {
+    echo "Usage: $0 [-h|--help] EXAMPLE_FILE"
+}
+
+py_pkg="tree-sitter-python@0.20.1"
+py_dir="$dir/.$py_pkg"
+if [ ! -e "$py_dir" ]; then
+    echo "Missing Python grammar. Run bootstrap script to install."
+    exit 1
+fi
+
+while [ $# -gt 0 ]; do
+    arg="$1"
+    shift 1
+    case "$arg" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            example_file="$arg"
+            if [ $# -gt 0 ]; then
+                error "Too many positional arguments provided."
+                usage 1>&2
+                exit 1
+            fi
+            ;;
+    esac
+done
+
+if [ ! -e "$example_file" ]; then
+    error "Missing file $example_file."
+    exit 1
+fi
+
+cargo -q run --features=cli -- parse --grammar "$py_dir" "$example_file"

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/main.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/main.rs
@@ -19,16 +19,20 @@ struct Cli {
 }
 
 mod loader;
+mod parse;
 mod test;
+mod util;
 
 #[derive(Subcommand)]
 enum Commands {
+    Parse(parse::Command),
     Test(test::Command),
 }
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
     match &cli.command {
+        Commands::Parse(cmd) => cmd.run(),
         Commands::Test(cmd) => cmd.run(),
     }
 }

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/parse.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/parse.rs
@@ -1,0 +1,117 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use anyhow::anyhow;
+use anyhow::Context as _;
+use clap::ValueHint;
+use std::path::Path;
+use std::path::PathBuf;
+use tree_sitter::Parser;
+use tree_sitter_graph::parse_error::ParseError;
+use tree_sitter_stack_graphs::loader::Loader;
+use tree_sitter_stack_graphs::LoadError;
+
+use crate::loader::LoaderArgs;
+use crate::util::path_exists;
+
+/// Parse file
+#[derive(clap::Parser)]
+pub struct Command {
+    #[clap(flatten)]
+    loader: LoaderArgs,
+
+    /// Input file path.
+    #[clap(value_name = "FILE_PATH", required = true, value_hint = ValueHint::AnyPath, parse(from_os_str), validator_os = path_exists)]
+    file_path: PathBuf,
+}
+
+impl Command {
+    pub fn run(&self) -> anyhow::Result<()> {
+        let mut loader = self.loader.new_loader()?;
+        self.parse_file(&self.file_path, &mut loader)
+            .with_context(|| format!("Error parsing file {}", self.file_path.display()))?;
+        Ok(())
+    }
+
+    fn parse_file(&self, file_path: &Path, loader: &mut Loader) -> anyhow::Result<()> {
+        let source = std::fs::read_to_string(file_path)?;
+        let lang = match loader.load_tree_sitter_language_for_file(file_path, Some(&source))? {
+            Some(sgl) => sgl,
+            None => return Err(anyhow!("No stack graph language found")),
+        };
+
+        let mut parser = Parser::new();
+        parser.set_language(lang)?;
+        let tree = parser.parse(source, None).ok_or(LoadError::ParseError)?;
+        let parse_errors = ParseError::into_all(tree);
+        if parse_errors.errors().len() > 0 {
+            return Err(anyhow!(LoadError::ParseErrors(parse_errors)));
+        }
+        let tree = parse_errors.into_tree();
+        self.print_tree(tree);
+
+        Ok(())
+    }
+
+    // From: https://github.com/tree-sitter/tree-sitter/blob/master/cli/src/parse.rs
+    fn print_tree(&self, tree: tree_sitter::Tree) {
+        let mut cursor = tree.walk();
+
+        let mut needs_newline = false;
+        let mut indent_level = 0;
+        let mut did_visit_children = false;
+        loop {
+            let node = cursor.node();
+            let is_named = node.is_named();
+            if did_visit_children {
+                if is_named {
+                    print!(")");
+                    needs_newline = true;
+                }
+                if cursor.goto_next_sibling() {
+                    did_visit_children = false;
+                } else if cursor.goto_parent() {
+                    did_visit_children = true;
+                    indent_level -= 1;
+                } else {
+                    break;
+                }
+            } else {
+                if is_named {
+                    if needs_newline {
+                        print!("\n");
+                    }
+                    for _ in 0..indent_level {
+                        print!("  ");
+                    }
+                    let start = node.start_position();
+                    let end = node.end_position();
+                    if let Some(field_name) = cursor.field_name() {
+                        print!("{}: ", field_name);
+                    }
+                    print!(
+                        "({} [{}, {}] - [{}, {}]",
+                        node.kind(),
+                        start.row,
+                        start.column,
+                        end.row,
+                        end.column
+                    );
+                    needs_newline = true;
+                }
+                if cursor.goto_first_child() {
+                    did_visit_children = false;
+                    indent_level += 1;
+                } else {
+                    did_visit_children = true;
+                }
+            }
+        }
+        cursor.reset(tree.root_node());
+        println!("");
+    }
+}

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/test.rs
@@ -15,11 +15,8 @@ use stack_graphs::graph::File;
 use stack_graphs::graph::StackGraph;
 use stack_graphs::json::Filter;
 use stack_graphs::paths::Paths;
-use std::ffi::OsStr;
-use std::ffi::OsString;
 use std::path::Path;
 use std::path::PathBuf;
-use tree_sitter_graph::parse_error::TreeWithParseErrorVec;
 use tree_sitter_graph::Variables;
 use tree_sitter_stack_graphs::loader::Loader;
 use tree_sitter_stack_graphs::test::Test;
@@ -30,7 +27,9 @@ use tree_sitter_stack_graphs::StackGraphLanguage;
 use walkdir::WalkDir;
 
 use crate::loader::LoaderArgs;
-use crate::MAX_PARSE_ERRORS;
+use crate::util::map_parse_errors;
+use crate::util::path_exists;
+use crate::util::PathSpec;
 
 /// Flag to control output
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ArgEnum)]
@@ -133,14 +132,6 @@ pub struct Command {
     /// Controls when graphs, paths, or visualization are saved.
     #[clap(long, arg_enum, default_value_t = OutputMode::OnFailure)]
     output_mode: OutputMode,
-}
-
-fn path_exists(path: &OsStr) -> anyhow::Result<PathBuf> {
-    let path = PathBuf::from(path);
-    if !path.exists() {
-        return Err(anyhow!("path does not exist"));
-    }
-    Ok(path)
 }
 
 impl Command {
@@ -269,41 +260,11 @@ impl Command {
     ) -> anyhow::Result<()> {
         match sgl.build_stack_graph_into(graph, file, source, globals, &NoCancellation) {
             Err(LoadError::ParseErrors(parse_errors)) => {
-                Err(self.map_parse_errors(test_path, &parse_errors, source))
+                Err(map_parse_errors(test_path, &parse_errors, source))
             }
             Err(e) => Err(e.into()),
             Ok(_) => Ok(()),
         }
-    }
-
-    fn map_parse_errors(
-        &self,
-        test_path: &Path,
-        parse_errors: &TreeWithParseErrorVec,
-        source: &str,
-    ) -> anyhow::Error {
-        let mut error = String::new();
-        let parse_errors = parse_errors.errors();
-        for parse_error in parse_errors.iter().take(MAX_PARSE_ERRORS) {
-            let line = parse_error.node().start_position().row;
-            let column = parse_error.node().start_position().column;
-            error.push_str(&format!(
-                "  {}:{}:{}: {}\n",
-                test_path.display(),
-                line + 1,
-                column + 1,
-                parse_error.display(&source, false)
-            ));
-        }
-        if parse_errors.len() > MAX_PARSE_ERRORS {
-            let more_errors = parse_errors.len() - MAX_PARSE_ERRORS;
-            error.push_str(&format!(
-                "  {} more parse error{} omitted\n",
-                more_errors,
-                if more_errors > 1 { "s" } else { "" },
-            ));
-        }
-        anyhow!(error)
     }
 
     fn handle_result(&self, test_path: &Path, result: &TestResult) -> anyhow::Result<bool> {
@@ -413,102 +374,5 @@ impl Command {
         std::fs::write(&path, html)
             .with_context(|| format!("Unable to write graph {}", path.display()))?;
         Ok(())
-    }
-}
-
-/// A path specification that can be formatted into a path based on a root and path
-/// contained in that root.
-struct PathSpec {
-    spec: String,
-}
-
-impl PathSpec {
-    pub fn format(&self, root: &Path, full_path: &Path) -> PathBuf {
-        if !full_path.starts_with(root) {
-            panic!(
-                "Path {} not contained in root {}",
-                full_path.display(),
-                root.display()
-            );
-        }
-        let relative_path = full_path.strip_prefix(root).unwrap();
-        if relative_path.is_absolute() {
-            panic!(
-                "Path {} not relative to root {}",
-                full_path.display(),
-                root.display()
-            );
-        }
-        self.format_path(
-            &self.dir_os_str(Some(root)),
-            &self.dir_os_str(relative_path.parent()),
-            relative_path.file_stem(),
-            relative_path.extension(),
-        )
-    }
-
-    /// Convert an optional directory path to an OsString representation. If the
-    /// path is missing or empty, we return `.`.
-    fn dir_os_str(&self, path: Option<&Path>) -> OsString {
-        let s = path.map_or("".into(), |p| p.as_os_str().to_os_string());
-        let s = if s.is_empty() { ".".into() } else { s };
-        s
-    }
-
-    fn format_path(
-        &self,
-        root: &OsStr,
-        dirs: &OsStr,
-        name: Option<&OsStr>,
-        ext: Option<&OsStr>,
-    ) -> PathBuf {
-        let mut path = OsString::new();
-        let mut in_placeholder = false;
-        for c in self.spec.chars() {
-            if in_placeholder {
-                in_placeholder = false;
-                match c {
-                    '%' => path.push("%"),
-                    'd' => {
-                        path.push(dirs);
-                    }
-                    'e' => {
-                        if let Some(ext) = ext {
-                            path.push(".");
-                            path.push(ext);
-                        }
-                    }
-                    'n' => {
-                        if let Some(name) = name {
-                            path.push(name);
-                        }
-                    }
-                    'r' => path.push(root),
-                    c => panic!("Unsupported placeholder '%{}'", c),
-                }
-            } else if c == '%' {
-                in_placeholder = true;
-            } else {
-                path.push(c.to_string());
-            }
-        }
-        if in_placeholder {
-            panic!("Unsupported '%' at end");
-        }
-        let path = Path::new(&path);
-        tree_sitter_stack_graphs::functions::path::normalize(&path)
-    }
-}
-
-impl std::str::FromStr for PathSpec {
-    type Err = clap::Error;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self { spec: s.into() })
-    }
-}
-
-impl From<&str> for PathSpec {
-    fn from(s: &str) -> Self {
-        Self { spec: s.into() }
     }
 }

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/util.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/util.rs
@@ -1,0 +1,149 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use anyhow::anyhow;
+use std::ffi::OsStr;
+use std::ffi::OsString;
+use std::path::Path;
+use std::path::PathBuf;
+use tree_sitter_graph::parse_error::TreeWithParseErrorVec;
+
+use crate::MAX_PARSE_ERRORS;
+
+pub(crate) fn path_exists(path: &OsStr) -> anyhow::Result<PathBuf> {
+    let path = PathBuf::from(path);
+    if !path.exists() {
+        return Err(anyhow!("path does not exist"));
+    }
+    Ok(path)
+}
+
+/// A path specification that can be formatted into a path based on a root and path
+/// contained in that root.
+pub(crate) struct PathSpec {
+    spec: String,
+}
+
+impl PathSpec {
+    pub fn format(&self, root: &Path, full_path: &Path) -> PathBuf {
+        if !full_path.starts_with(root) {
+            panic!(
+                "Path {} not contained in root {}",
+                full_path.display(),
+                root.display()
+            );
+        }
+        let relative_path = full_path.strip_prefix(root).unwrap();
+        if relative_path.is_absolute() {
+            panic!(
+                "Path {} not relative to root {}",
+                full_path.display(),
+                root.display()
+            );
+        }
+        self.format_path(
+            &self.dir_os_str(Some(root)),
+            &self.dir_os_str(relative_path.parent()),
+            relative_path.file_stem(),
+            relative_path.extension(),
+        )
+    }
+
+    /// Convert an optional directory path to an OsString representation. If the
+    /// path is missing or empty, we return `.`.
+    fn dir_os_str(&self, path: Option<&Path>) -> OsString {
+        let s = path.map_or("".into(), |p| p.as_os_str().to_os_string());
+        let s = if s.is_empty() { ".".into() } else { s };
+        s
+    }
+
+    fn format_path(
+        &self,
+        root: &OsStr,
+        dirs: &OsStr,
+        name: Option<&OsStr>,
+        ext: Option<&OsStr>,
+    ) -> PathBuf {
+        let mut path = OsString::new();
+        let mut in_placeholder = false;
+        for c in self.spec.chars() {
+            if in_placeholder {
+                in_placeholder = false;
+                match c {
+                    '%' => path.push("%"),
+                    'd' => {
+                        path.push(dirs);
+                    }
+                    'e' => {
+                        if let Some(ext) = ext {
+                            path.push(".");
+                            path.push(ext);
+                        }
+                    }
+                    'n' => {
+                        if let Some(name) = name {
+                            path.push(name);
+                        }
+                    }
+                    'r' => path.push(root),
+                    c => panic!("Unsupported placeholder '%{}'", c),
+                }
+            } else if c == '%' {
+                in_placeholder = true;
+            } else {
+                path.push(c.to_string());
+            }
+        }
+        if in_placeholder {
+            panic!("Unsupported '%' at end");
+        }
+        let path = Path::new(&path);
+        tree_sitter_stack_graphs::functions::path::normalize(&path)
+    }
+}
+
+impl std::str::FromStr for PathSpec {
+    type Err = clap::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self { spec: s.into() })
+    }
+}
+
+impl From<&str> for PathSpec {
+    fn from(s: &str) -> Self {
+        Self { spec: s.into() }
+    }
+}
+
+pub(crate) fn map_parse_errors(
+    test_path: &Path,
+    parse_errors: &TreeWithParseErrorVec,
+    source: &str,
+) -> anyhow::Error {
+    let mut error = String::new();
+    let parse_errors = parse_errors.errors();
+    for parse_error in parse_errors.iter().take(MAX_PARSE_ERRORS) {
+        let line = parse_error.node().start_position().row;
+        let column = parse_error.node().start_position().column;
+        error.push_str(&format!(
+            "  {}:{}:{}: {}\n",
+            test_path.display(),
+            line + 1,
+            column + 1,
+            parse_error.display(&source, false)
+        ));
+    }
+    if parse_errors.len() > MAX_PARSE_ERRORS {
+        let more_errors = parse_errors.len() - MAX_PARSE_ERRORS;
+        error.push_str(&format!(
+            "  {} more parse error{} omitted\n",
+            more_errors,
+            if more_errors > 1 { "s" } else { "" },
+        ));
+    }
+    anyhow!(error)
+}

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -420,6 +420,10 @@ impl StackGraphLanguage {
     pub fn builtins_mut(&mut self) -> &mut StackGraph {
         &mut self.builtins
     }
+
+    pub fn language(&self) -> tree_sitter::Language {
+        self.language
+    }
 }
 
 /// An error that can occur while loading in the TSG stack graph construction rules for a language

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -119,6 +119,21 @@ impl Loader {
         Ok(paths)
     }
 
+    /// Load a Tree-sitter language for the given file. Loading is based on the loader configuration and the given file path.
+    /// Most users should use [`Self::load_for_file`], but this method can be useful if only the underlying Tree-sitter language
+    /// is necessary, as it will not attempt to load the TSG file.
+    pub fn load_tree_sitter_language_for_file(
+        &mut self,
+        path: &Path,
+        content: Option<&str>,
+    ) -> Result<Option<tree_sitter::Language>, LoadError> {
+        if let Some(selected_language) = self.select_language_for_file(path, content)? {
+            return Ok(Some(selected_language.language));
+        }
+        Ok(None)
+    }
+
+    /// Load a stack graph language for the given file. Loading is based on the loader configuration and the given file path.
     pub fn load_for_file(
         &mut self,
         path: &Path,


### PR DESCRIPTION
Being able to view the parse tree is essential when developing TSG
files. Currently this requires setting up Tree-sitter, ensuring it is
configured correctly. This PR adds a convenient `tree-sitter-stack-graphs
parse` command, that prints a parse tree without having to do all
that. It accepts the same arguments and uses the same loading mechansim
for grammars as the `test` command.

A new `tree-sitter-stack-graphs/examples/parse` script allows for easy parsing of example files.
