### PR TITLE
Add NPM package

### DIFF
--- a/tree-sitter-stack-graphs/npm/.gitignore
+++ b/tree-sitter-stack-graphs/npm/.gitignore
@@ -1,0 +1,3 @@
+/.crates.toml
+/.crates2.json
+/bin/

--- a/tree-sitter-stack-graphs/npm/cli.js
+++ b/tree-sitter-stack-graphs/npm/cli.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+const spawn = require("child_process").spawn;
+const path = require("path");
+
+const tssg = process.platform === "win32"
+    ? "tree-sitter-stack-graphs.exe"
+    : "tree-sitter-stack-graphs";
+
+spawn(
+    path.join(__dirname, "bin", tssg), process.argv.slice(2),
+    {
+        "stdio": "inherit"
+    },
+).on('close', process.exit);

--- a/tree-sitter-stack-graphs/npm/install.js
+++ b/tree-sitter-stack-graphs/npm/install.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+const child_process = require("child_process");
+const packageJSON = require("./package.json");
+
+const cargo = process.platform === "win32"
+    ? "cargo.exe"
+    : "cargo";
+
+try {
+    child_process.execSync(cargo);
+} catch (error) {
+    console.error(error.message);
+    console.error("Failed to execute Cargo. Cargo needs to be available to install this package!");
+    process.exit(1);
+}
+
+child_process.spawn(
+    cargo, [
+        "install",
+        "--quiet",
+        "--root", ".",
+        "--version", "^"+packageJSON.version,
+        "--features", "cli",
+        packageJSON.name,
+    ],
+    {
+        "stdio": "inherit"
+    },
+).on('close', process.exit);

--- a/tree-sitter-stack-graphs/npm/package.json
+++ b/tree-sitter-stack-graphs/npm/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "tree-sitter-stack-graphs",
+  "version": "0.3.1",
+  "description": "Create stack graphs using tree-sitter parsers",
+  "homepage": "https://github.com/github/stack-graphs/tree/main/tree-sitter-stack-graphs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/github/stack-graphs.git"
+  },
+  "keywords": [
+    "tree-sitter",
+    "stack-graphs"
+  ],
+  "license": "MIT OR Apache-2.0",
+  "author": "GitHub <opensource+stack-graphs@github.com>",
+  "contributors": [
+    "Douglas Creager <dcreager@dcreager.net>",
+    "Hendrik van Antwerpen <hendrikvanantwerpen@github.com>"
+  ],
+  "bin": {
+    "tree-sitter-stack-graphs": "./cli.js"
+  },
+  "scripts": {
+    "install": "node install.js"
+  }
+}


### PR DESCRIPTION
Most Tree-sitter projects are configured using NPM. This PR publishes the tree-sitter-stack-graphs CLI as an NPM package to make it easier to integrate into grammar projects.

Once published, projects should be able to declare a `devDependency` on `tree-sitter-stack-graphs` and run the CLI using `npx tree-sitter-stack-graphs`.
