### PR TITLE
Automate NPM testing & publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     - cron: "0 0 1,15 * *"
 
 jobs:
-  test:
+  test-rust:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -54,3 +54,29 @@ jobs:
         run: cargo test --all-features
       - name: Run test suite with all optimizations
         run: cargo test --release
+
+  test-npm:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node: [16.x]
+        os: [ubuntu-latest]
+        rust: [stable]
+
+    defaults:
+      run:
+        working-directory: tree-sitter-stack-graphs/npm
+
+    steps:
+      - name: Install Node environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Install Rust environment
+        uses: hecrj/setup-rust-action@v1
+        with:
+          rust-version: ${{ matrix.rust }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build NPM package
+        run: npm ci

--- a/.github/workflows/publish-tree-sitter-stack-graphs-npm.yml
+++ b/.github/workflows/publish-tree-sitter-stack-graphs-npm.yml
@@ -1,0 +1,28 @@
+name: Publish tree-sitter-stack-graphs to NPM
+
+on:
+  push:
+    tags:
+      - tree-sitter-stack-graphs-v*'
+
+env:
+  PACKAGE_DIR: './tree-sitter-stack-graphs/npm'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Node environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+          registry-url: 'https://registry.npmjs.org'
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      # TODO Verify the package version matches the tag
+      - name: Verify package
+        run: npm publish --dry-run ${{ env.PACKAGE_DIR }}
+      - name: Publish package
+        run: npm publish ${{ env.PACKAGE_DIR }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/tree-sitter-stack-graphs/npm/README.md
+++ b/tree-sitter-stack-graphs/npm/README.md
@@ -1,0 +1,13 @@
+# tree-sitter-stack-graphs
+
+This package provides a convenient way to install the [tree-sitter-stack-graphs](https://crates.io/crates/tree-sitter-stack-graphs) CLI in an NPM project.
+
+Add it as a dev dependency to an existing project using:
+
+    npm i -D tree-sitter-stack-graphs
+
+It is also possible to invoke it directly using:
+
+    npx tree-sitter-stack-graphs
+
+See the tree-sitter-stack-graphs [documentation](https://crates.io/crates/tree-sitter-stack-graphs) for details on usage.

--- a/tree-sitter-stack-graphs/npm/package-lock.json
+++ b/tree-sitter-stack-graphs/npm/package-lock.json
@@ -1,0 +1,17 @@
+{
+  "name": "tree-sitter-stack-graphs",
+  "version": "0.3.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tree-sitter-stack-graphs",
+      "version": "0.3.1",
+      "hasInstallScript": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "tree-sitter-stack-graphs": "cli.js"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds some workflows and docs for the NPM package:
- A job to CI to test a successful package install 
- A workflow that publishes the package to the NPM Registry whenever a version tag is pushed.
- A brief README for the NPM package, so people are not presented an empty page when visiting the package on NPM.