### PR TITLE
Use one-based positions in user facing output

### DIFF
--- a/tree-sitter-stack-graphs/CHANGELOG.md
+++ b/tree-sitter-stack-graphs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Builtins can be explicitly supplied using the `--builtins` flag. If the given path does not have a file extension, the file extension of the language is implicitly added.
 - A new `init` command can be used to generate new tree-sitter-stack-graphs projects for NPM distributed Tree-sitter grammars.
+- The syntax tree printed by `parse` shows one-based node positions.
 
 #### Changed
 

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/parse.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/parse.rs
@@ -94,12 +94,12 @@ impl Command {
                         print!("{}: ", field_name);
                     }
                     print!(
-                        "({} [{}, {}] - [{}, {}]",
+                        "({} [{}:{} - {}:{}]",
                         node.kind(),
-                        start.row,
-                        start.column,
-                        end.row,
-                        end.column
+                        start.row + 1,
+                        start.column + 1,
+                        end.row + 1,
+                        end.column + 1
                     );
                     needs_newline = true;
                 }


### PR DESCRIPTION
Positions are always displayed to users as one-based. The parse code did not do that. This PR changes that.
