### PR TITLE
Fix publishing workflows

### DIFF
--- a/.github/workflows/publish-lsp-positions.yml
+++ b/.github/workflows/publish-lsp-positions.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       # TODO Verify the crate version matches the tag
+      - name: Test crate
+        run: cargo test --all-features
+        working-directory: ${{ env.CRATE_DIR }}
       - name: Verify publish crate
         run: cargo publish --dry-run
         working-directory: ${{ env.CRATE_DIR }}

--- a/.github/workflows/publish-lsp-positions.yml
+++ b/.github/workflows/publish-lsp-positions.yml
@@ -19,15 +19,13 @@ jobs:
         uses: actions/checkout@v2
       # TODO Verify the crate version matches the tag
       - name: Verify publish crate
-        uses: katyo/publish-crates@v1
-        with:
-          path: ${{ env.CRATE_DIR }}
-          dry-run: true
+        run: cargo publish --dry-run
+        working-directory: ${{ env.CRATE_DIR }}
       - name: Publish crate
-        uses: katyo/publish-crates@v1
-        with:
-          path: ${{ env.CRATE_DIR }}
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish
+        working-directory: ${{ env.CRATE_DIR }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
   create-release:
     needs: publish-crate
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-stack-graphs.yml
+++ b/.github/workflows/publish-stack-graphs.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       # TODO Verify the crate version matches the tag
+      - name: Test crate
+        run: cargo test --all-features
+        working-directory: ${{ env.CRATE_DIR }}
       - name: Verify publish crate
         run: cargo publish --dry-run
         working-directory: ${{ env.CRATE_DIR }}

--- a/.github/workflows/publish-stack-graphs.yml
+++ b/.github/workflows/publish-stack-graphs.yml
@@ -19,15 +19,13 @@ jobs:
         uses: actions/checkout@v2
       # TODO Verify the crate version matches the tag
       - name: Verify publish crate
-        uses: katyo/publish-crates@v1
-        with:
-          path: ${{ env.CRATE_DIR }}
-          dry-run: true
+        run: cargo publish --dry-run
+        working-directory: ${{ env.CRATE_DIR }}
       - name: Publish crate
-        uses: katyo/publish-crates@v1
-        with:
-          path: ${{ env.CRATE_DIR }}
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish
+        working-directory: ${{ env.CRATE_DIR }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
   create-release:
     needs: publish-crate
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-tree-sitter-stack-graphs.yml
+++ b/.github/workflows/publish-tree-sitter-stack-graphs.yml
@@ -19,15 +19,13 @@ jobs:
         uses: actions/checkout@v2
       # TODO Verify the crate version matches the tag
       - name: Verify publish crate
-        uses: katyo/publish-crates@v1
-        with:
-          path: ${{ env.CRATE_DIR }}
-          dry-run: true
+        run: cargo publish --dry-run
+        working-directory: ${{ env.CRATE_DIR }}
       - name: Publish crate
-        uses: katyo/publish-crates@v1
-        with:
-          path: ${{ env.CRATE_DIR }}
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish
+        working-directory: ${{ env.CRATE_DIR }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
   publish-npm:
     needs: publish-crate
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-tree-sitter-stack-graphs.yml
+++ b/.github/workflows/publish-tree-sitter-stack-graphs.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       # TODO Verify the crate version matches the tag
+      - name: Test crate
+        run: cargo test --all-features
+        working-directory: ${{ env.CRATE_DIR }}
       - name: Verify publish crate
         run: cargo publish --dry-run
         working-directory: ${{ env.CRATE_DIR }}


### PR DESCRIPTION
As it turns out, the action used for releasing the crate has some issues.
- It does not work well with crates that have non-crates.io dependencies. In our case, we use relative path dependencies. This crashes the action run.
- The dry run doesn't do a `cargo publish --dry-run`, as I expected, but only an action dry run, skipping cargo completely.

In light of this, and the fact that it is not doing much more than invoking cargo anyway, this PR relaces the action with direct cargo invocations. It also runs the tests once more before publishing, as an extra safe guard, since there is no guarantee that the tag has gone through PR & CI.
