### PR TITLE
Add tree-sitter-stack-graphs-typescript

### DIFF
--- a/languages/tree-sitter-stack-graphs-typescript/src/builtins.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/src/builtins.ts
@@ -1,0 +1,217 @@
+/*! *****************************************************************************
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at http://www.apache.org/licenses/LICENSE-2.0
+
+THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+MERCHANTABLITY OR NON-INFRINGEMENT.
+
+See the Apache Version 2.0 License for specific language governing permissions
+and limitations under the License.
+***************************************************************************** */
+
+interface IteratorYieldResult<TYield> {
+  done?: false;
+  value: TYield;
+}
+
+interface IteratorReturnResult<TReturn> {
+  done: true;
+  value: TReturn;
+}
+
+type IteratorResult<T, TReturn = any> = IteratorYieldResult<T> | IteratorReturnResult<TReturn>;
+
+interface Iterator<T, TReturn = any, TNext = undefined> {
+  next(...args: [] | [TNext]): IteratorResult<T, TReturn>;
+  return?(value?: TReturn): IteratorResult<T, TReturn>;
+  throw?(e?: any): IteratorResult<T, TReturn>;
+}
+
+interface Iterable<T> {
+  [Symbol.iterator](): Iterator<T>;
+}
+
+interface IterableIterator<T> extends Iterator<T> {
+  [Symbol.iterator](): IterableIterator<T>;
+}
+
+interface ArrayLike<T> {
+    readonly length: number;
+    readonly [n: number]: T;
+}
+
+interface Array<T> {
+  length: number;
+  toString(): string;
+  toLocaleString(): string;
+  pop(): T | undefined;
+  push(...items: T[]): number;
+  concat(...items: ConcatArray<T>[]): T[];
+  concat(...items: (T | ConcatArray<T>)[]): T[];
+  join(separator?: string): string;
+  reverse(): T[];
+  shift(): T | undefined;
+  slice(start?: number, end?: number): T[];
+  sort(compareFn?: (a: T, b: T) => number): this;
+  splice(start: number, deleteCount?: number): T[];
+  splice(start: number, deleteCount: number, ...items: T[]): T[];
+  unshift(...items: T[]): number;
+  indexOf(searchElement: T, fromIndex?: number): number;
+  lastIndexOf(searchElement: T, fromIndex?: number): number;
+  every<S extends T>(predicate: (value: T, index: number, array: T[]) => value is S, thisArg?: any): this is S[];
+  every(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean;
+  some(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean;
+  forEach(callbackfn: (value: T, index: number, array: T[]) => void, thisArg?: any): void;
+  map<U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): U[];
+  filter<S extends T>(predicate: (value: T, index: number, array: T[]) => value is S, thisArg?: any): S[];
+  filter(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): T[];
+  reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T): T;
+  reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue: T): T;
+  reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
+  reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T): T;
+  reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue: T): T;
+  reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
+  [n: number]: T;
+
+  find<S extends T>(predicate: (this: void, value: T, index: number, obj: T[]) => value is S, thisArg?: any): S | undefined;
+  find(predicate: (value: T, index: number, obj: T[]) => unknown, thisArg?: any): T | undefined;
+  findIndex(predicate: (value: T, index: number, obj: T[]) => unknown, thisArg?: any): number;
+  fill(value: T, start?: number, end?: number): this;
+  copyWithin(target: number, start: number, end?: number): this;
+
+  [Symbol.iterator](): IterableIterator<T>;
+  entries(): IterableIterator<[number, T]>;
+  keys(): IterableIterator<number>;
+  values(): IterableIterator<T>;
+}
+
+interface ArrayConstructor {
+  new(arrayLength?: number): any[];
+  new <T>(arrayLength: number): T[];
+  new <T>(...items: T[]): T[];
+  (arrayLength?: number): any[];
+  <T>(arrayLength: number): T[];
+  <T>(...items: T[]): T[];
+  isArray(arg: any): arg is any[];
+  readonly prototype: any[];
+}
+declare var Array: ArrayConstructor;
+
+interface Map<K, V> {
+  clear(): void;
+  delete(key: K): boolean;
+  forEach(callbackfn: (value: V, key: K, map: Map<K, V>) => void, thisArg?: any): void;
+  get(key: K): V | undefined;
+  has(key: K): boolean;
+  set(key: K, value: V): this;
+  readonly size: number;
+
+  [Symbol.iterator](): IterableIterator<[K, V]>;
+  entries(): IterableIterator<[K, V]>;
+  keys(): IterableIterator<K>;
+  values(): IterableIterator<V>;
+}
+
+interface MapConstructor {
+  new(): Map<any, any>;
+  new<K, V>(entries?: readonly (readonly [K, V])[] | null): Map<K, V>;
+  readonly prototype: Map<any, any>;
+}
+declare var Map: MapConstructor;
+
+interface ReadonlyMap<K, V> {
+  forEach(callbackfn: (value: V, key: K, map: ReadonlyMap<K, V>) => void, thisArg?: any): void;
+  get(key: K): V | undefined;
+  has(key: K): boolean;
+  readonly size: number;
+}
+
+interface WeakMap<K extends object, V> {
+  delete(key: K): boolean;
+  get(key: K): V | undefined;
+  has(key: K): boolean;
+  set(key: K, value: V): this;
+}
+
+interface WeakMapConstructor {
+  new <K extends object = object, V = any>(entries?: readonly [K, V][] | null): WeakMap<K, V>;
+  readonly prototype: WeakMap<object, any>;
+}
+declare var WeakMap: WeakMapConstructor;
+
+interface Set<T> {
+  add(value: T): this;
+  clear(): void;
+  delete(value: T): boolean;
+  forEach(callbackfn: (value: T, value2: T, set: Set<T>) => void, thisArg?: any): void;
+  has(value: T): boolean;
+  readonly size: number;
+
+  [Symbol.iterator](): IterableIterator<T>;
+  entries(): IterableIterator<[T, T]>;
+  keys(): IterableIterator<T>;
+  values(): IterableIterator<T>;
+}
+
+interface SetConstructor {
+  new <T = any>(values?: readonly T[] | null): Set<T>;
+  readonly prototype: Set<any>;
+}
+declare var Set: SetConstructor;
+
+interface ReadonlySet<T> {
+  forEach(callbackfn: (value: T, value2: T, set: ReadonlySet<T>) => void, thisArg?: any): void;
+  has(value: T): boolean;
+  readonly size: number;
+}
+
+interface WeakSet<T extends object> {
+  add(value: T): this;
+  delete(value: T): boolean;
+  has(value: T): boolean;
+}
+
+interface WeakSetConstructor {
+  new <T extends object = object>(values?: readonly T[] | null): WeakSet<T>;
+  readonly prototype: WeakSet<object>;
+}
+declare var WeakSet: WeakSetConstructor;
+
+interface PromiseLike<T> {
+  then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): PromiseLike<TResult1 | TResult2>;
+}
+
+interface Promise<T> {
+  $Promise$T: T;
+  then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;
+  catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<T | TResult>;
+}
+interface PromiseConstructor {
+  new <T>(executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void): Promise<T>;
+  all<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(values: readonly [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>, T8 | PromiseLike<T8>, T9 | PromiseLike<T9>, T10 | PromiseLike<T10>]): Promise<[T1, T2, T3, T4,
+T5, T6, T7, T8, T9, T10]>;
+  all<T1, T2, T3, T4, T5, T6, T7, T8, T9>(values: readonly [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>, T8 | PromiseLike<T8>, T9 | PromiseLike<T9>]): Promise<[T1, T2, T3, T4, T5, T6, T7, T8, T9]>;
+  all<T1, T2, T3, T4, T5, T6, T7, T8>(values: readonly [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>, T8 | PromiseLike<T8>]): Promise<[T1, T2, T3, T4, T5, T6, T7, T8]>;
+  all<T1, T2, T3, T4, T5, T6, T7>(values: readonly [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>]): Promise<[T1, T2, T3, T4, T5, T6, T7]>;
+  all<T1, T2, T3, T4, T5, T6>(values: readonly [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>]): Promise<[T1, T2, T3, T4, T5, T6]>;
+  all<T1, T2, T3, T4, T5>(values: readonly [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>]): Promise<[T1, T2, T3, T4, T5]>;
+  all<T1, T2, T3, T4>(values: readonly [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>]): Promise<[T1, T2, T3, T4]>;
+  all<T1, T2, T3>(values: readonly [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>]): Promise<[T1, T2, T3]>;
+  all<T1, T2>(values: readonly [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>]): Promise<[T1, T2]>;
+  all<T>(values: readonly (T | PromiseLike<T>)[]): Promise<T[]>;
+
+  all<T>(values: Iterable<T | PromiseLike<T>>): Promise<T[]>;
+  race<T>(values: Iterable<T>): Promise<T extends PromiseLike<infer U> ? U : T>;
+  race<T>(values: Iterable<T | PromiseLike<T>>): Promise<T>;
+  race<T>(values: readonly T[]): Promise<T extends PromiseLike<infer U> ? U : T>;
+
+  reject<T = never>(reason?: any): Promise<T>;
+  resolve(): Promise<void>;
+  resolve<T>(value: T | PromiseLike<T>): Promise<T>;
+};
+
+declare var Promise: PromiseConstructor;

--- a/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
@@ -1,16 +1,24 @@
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Stack graphs definition for TypeScript
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; ########################################################################################
+;
+; ######## ##    ## ########  ########  ######   ######  ########  #### ########  ########
+;    ##     ##  ##  ##     ## ##       ##    ## ##    ## ##     ##  ##  ##     ##    ##
+;    ##      ####   ##     ## ##       ##       ##       ##     ##  ##  ##     ##    ##
+;    ##       ##    ########  ######    ######  ##       ########   ##  ########     ##
+;    ##       ##    ##        ##             ## ##       ##   ##    ##  ##           ##
+;    ##       ##    ##        ##       ##    ## ##    ## ##    ##   ##  ##           ##
+;    ##       ##    ##        ########  ######   ######  ##     ## #### ##           ##
+;
+; ########################################################################################
 
-;; Global Variables
-;; ^^^^^^^^^^^^^^^^
+; Global Variables
+; ^^^^^^^^^^^^^^^^
 
 global FILE_PATH
 global ROOT_NODE
 global JUMP_TO_SCOPE_NODE
 
-;; Attribute Shorthands
-;; ^^^^^^^^^^^^^^^^^^^^
+; Attribute Shorthands
+; ^^^^^^^^^^^^^^^^^^^^
 
 attribute node_definition = node        => type = "pop_symbol", node_symbol = node, is_definition
 attribute node_reference = node         => type = "push_symbol", node_symbol = node, is_reference
@@ -29,7 +37,5867 @@ attribute symbol_reference = symbol     => type = "push_symbol", symbol = symbol
 
 attribute node_symbol = node            => symbol = (source-text node), source_node = node
 
-;; Stack Graph Rules
-;; ^^^^^^^^^^^^^^^^^
+; Node Name & Symbol Conventions
+; ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+;
+; @node.{expr,type,mod}_def = STRING
+;     A definition node, pop node with a name value.
+;
+; @node.{expr,type,mod}_ref = STRING
+;     A reference node, a push node with a name value.
+;
+; @node.{expr,type,mod}_{def,ref}.ns = "%T" | "%E" | "%M"
+;     Internal symbol indicating the namespace of an identifier.
+;
+; @node.{expr,type,ns}_{def,ref}.typeof = ":"
+;     Internal symbol indicating the type of an identifier.
+;
+; @node.callable = "->"
+;     Internal symbol indicating a callable.
+;
+; @node.member = "."
+;     Internal symbol indicating a named member (e.g., a field or method).
+;
+; @node.ctor = "<new>"
+;     Internal symbol indicating a constructor.
+;
+; @node.type_{abs,app} = "<>"
+;     Internal scoped symbol indicating type parameters & arguments.
+;
+; @node.indexable = "[]"
+;     Internal symbol indicating an indexable (i.e., array access).
+;
+; @node.{type,expr}_export = "%T" | "%E"
+;     Internal node for namespace guards for default and = exports.
 
-; Have fun!
+; comments can appear almost everywhere, so we simply make sure all
+; possible nodes are defined on comments
+(comment)@comment {
+  node @comment.alias_type
+  node @comment.aliased_type
+  node @comment.applied_type
+  node @comment.arg
+  node @comment.arg_index
+  node @comment.args
+  node @comment.async_type
+  node @comment.await_type
+  node @comment.callable
+  node @comment.coargs
+  node @comment.cocallable
+  node @comment.comp_index
+  node @comment.coparam
+  node @comment.coparams
+  node @comment.cotype
+  node @comment.default_export
+  node @comment.defs
+  node @comment.exports
+  node @comment.expr_def
+  node @comment.expr_def__ns
+  node @comment.expr_ref
+  node @comment.expr_ref__ns
+  node @comment.lexical_defs
+  node @comment.lexical_scope
+  node @comment.member
+  node @comment.mod_def
+  node @comment.mod_def__ns
+  node @comment.mod_ref
+  node @comment.mod_ref__ns
+  node @comment.param
+  node @comment.params
+  node @comment.return_type
+  node @comment.static_members
+  node @comment.static_type
+  node @comment.type
+  node @comment.type_def
+  node @comment.type_def__ns
+  node @comment.type_members
+  node @comment.type_ref
+  node @comment.type_ref__ns
+  node @comment.var_defs
+}
+
+
+; ######
+; #     # #####   ####   ####  #####    ##   #    #  ####
+; #     # #    # #    # #    # #    #  #  #  ##  ## #
+; ######  #    # #    # #      #    # #    # # ## #  ####
+; #       #####  #    # #  ### #####  ###### #    #      #
+; #       #   #  #    # #    # #   #  #    # #    # #    #
+; #       #    #  ####   ####  #    # #    # #    #  ####
+;
+; ########################################################
+
+;; Attributes defined on programs
+;
+; out .lexical_scope
+;     Lexical scope.
+;
+; in .defs
+;     Lexical and variable definitions.
+;
+; in .exports
+;     Exported definitions.
+;
+; out .mod_def
+;     Module definition
+
+(program)@prog {
+  node @prog.defs
+  node @prog.exports
+  node @prog.lexical_scope
+  node @prog.mod_def
+  node @prog.mod_def__ns
+}
+
+(program)@prog {
+  ; propagate lexical scope
+  edge @prog.lexical_scope -> ROOT_NODE
+
+  ; expose definitions
+  edge @prog.lexical_scope -> @prog.defs
+
+  ; module definition in ROOT_NODE scope
+  edge ROOT_NODE -> @prog.mod_def__ns
+  ;
+  attr (@prog.mod_def__ns) pop_symbol = "%M"
+  edge @prog.mod_def__ns -> @prog.mod_def
+  ;
+  let mod_name = (path-filestem FILE_PATH)
+  let mod_path = (path-normalize (path-join (path-dir FILE_PATH) mod_name))
+  attr (@prog.mod_def) symbol_definition = mod_path, source_node = @prog
+  ; expose exports via module definition
+  edge @prog.mod_def -> @prog.exports
+
+  ; if this is an index.ts, also add a definition for the directory of this file
+  scan mod_name {
+    "index" {
+      node mod_index_def
+      edge @prog.mod_def__ns -> mod_index_def
+      let mod_dir = (path-normalize (path-dir FILE_PATH))
+      attr (mod_index_def) symbol_definition = mod_dir, source_node = @prog
+      edge mod_index_def -> @prog.exports
+    }
+  }
+}
+
+(program
+  (_)@stmt
+)@prog {
+  ; propagate lexical scope
+  edge @stmt.lexical_scope -> @prog.lexical_scope
+
+  ; expose lexical and variable declarations
+  edge @prog.defs -> @stmt.lexical_defs
+  edge @prog.defs -> @stmt.var_defs
+
+  ; exports are visible via module definition
+  edge @prog.exports -> @stmt.exports
+}
+
+(program [(import_statement) (export_statement)]* @imexs)@prog {
+  if (is-empty @imexs) {
+    ; expose global definitions in ROOT_NODE
+    edge ROOT_NODE -> @prog.defs
+  }
+}
+
+
+;; hashbang
+
+(hash_bang_line)@hashbang {
+}
+
+
+;; Comments
+
+(comment)@comment {
+}
+
+
+
+;  #####
+; #     # #####   ##   ##### ###### #    # ###### #    # #####  ####
+; #         #    #  #    #   #      ##  ## #      ##   #   #   #
+;  #####    #   #    #   #   #####  # ## # #####  # #  #   #    ####
+;       #   #   ######   #   #      #    # #      #  # #   #        #
+; #     #   #   #    #   #   #      #    # #      #   ##   #   #    #
+;  #####    #   #    #   #   ###### #    # ###### #    #   #    ####
+;
+; ###################################################################
+
+;; Attributes defined on statements
+;
+; in .lexical_scope
+;     Lexical scope.
+;
+; out .lexical_defs
+;     Lexical definitions, that are block scoped
+;
+; out .var_defs
+;     Variable definitions, that are function scoped
+;
+; out .exports
+;     Exported definitions.
+;
+; out .default_export
+;    Nameless (but namespaced) exports for use in default and = exports.
+;
+; out .return_type
+;    Type of contained return statement.
+
+[
+    (abstract_class_declaration)
+    (ambient_declaration)
+    (break_statement)
+    (catch_clause)
+    (class_declaration)
+    (continue_statement)
+    (debugger_statement)
+    (do_statement)
+    (else_clause)
+    (empty_statement)
+    (enum_declaration)
+    (export_statement)
+    (expression_statement)
+    (finally_clause)
+    (for_in_statement)
+    (for_statement)
+    (function_declaration)
+    (function_signature)
+    (generator_function_declaration)
+    (hash_bang_line)
+    (if_statement)
+    (import_statement)
+    (interface_declaration)
+    (internal_module)
+    (labeled_statement)
+    (lexical_declaration)
+    (module)
+    (return_statement)
+    (statement_block)
+    (switch_body)
+    (switch_case)
+    (switch_default)
+    (switch_statement)
+    (throw_statement)
+    (try_statement)
+    (type_alias_declaration)
+    (variable_declaration)
+    (while_statement)
+    (with_statement)
+]@stmt {
+  node @stmt.default_export
+  node @stmt.exports
+  node @stmt.lexical_defs
+  node @stmt.lexical_scope
+  node @stmt.return_type
+  node @stmt.var_defs
+}
+
+
+;; Imports & Exports (The Many Faced God)
+;
+; TypeScript has many import / export forms. Below is a condensed presentation that can be used as a reference
+; for the sections below where the actual rules are defined. One has to be careful with the queries to ensure
+; that cases do not overlap, even if their syntactic forms (partially) do. This must be done by adding negative
+; matches to some queries. This overview should make it easier to spot where negative are required.
+;
+;;;; Exports
+;
+; export_statement :=
+;    (export_statement "*"                                source:(_)@from) ; export * from MODULE              ; re-export everything from MODULE
+;  | (export_statement (namespace_export (identifier)@ns) source:(_)@from) ; export * as NAMESPACE from MODULE ; re-export MODULE as NAMESPACE
+;  | (export_statement  "default" value:(_)@value)                         ; export default EXPRESSION         ; export EXPRESSION as default
+;  | (export_statement  "default" declaration:(_)@decl)                    ; export default DECLARATION        ; export DECLARATION as default
+;  | (export_statement ^"default" declaration:(_)@decl)                    ; export DECL                       ; export DECLARATION
+;  | (export_statement "type"? (export_clause)@clause  source:(_)@from)    ; export (type) CLAUSE from MODULE  ; re-export (type) identifiers from MODULE
+;  | (export_statement "type"? (export_clause)@clause !source         )    ; export (type) CLAUSE              ; export (type) identifiers
+;  | (export_statement "=" . (expression)@value)                           ; export = EXPRESSION               ; export EXPRESSION as exports object
+;  | (export_statement "as" "namespace" . (_)@ns)                          ; export as namespace NAMESPACE     ; export this module as global NAMESPACE
+;
+; export_clause :=
+;    (export_clause (export_specifier)*)                                   ; { EXPORT_SPECIFIER* }
+;
+; export_specifier :=
+;    (export_specifier name:(_)  alias:(_))                                ; NAME
+;  | (export_specifier name:(_) !alias    )                                ; NAME as ALIAS
+;
+;;;; Imports
+;
+; import_statement :=
+;    ; note that the first case overlaps with the two after it, but the behaviour is orthogonal
+;    (import_statement "type"?  (import_clause (identifier)@name                                   ) source:(_)@from)  ; import (type) NAME from MODULE           ; import default (type) from MODULE as NAME
+;  | (import_statement "type"?  (import_clause                   (namespace_import (identifier)@ns)) source:(_)@from)  ; import (type) * as NAMESPACE from MODULE ; import all (type) identifiers from MODULE in NAMESPACE
+;  | (import_statement "type"?  (import_clause                   (named_imports)@named_imports     ) source:(_)@from)  ; import (type) NAMED_IMPORTS from MODULE  ; import named (type) identifiers from MODULE
+;  | (import_statement "type"? ^(import_clause)                                                      source:(_)@from)  ; import (type) MODULE                     ; do not import any identifiers from MODULE
+;  | (import_statement "type"?  (import_require_clause (identifier)@name                             source:(_)@from)) ; import (type) NAME = require(MODULE)     ; import exports object (type) as NAME from MODULE
+;
+; named_imports :=
+;    (named_imports (import_specifier)*)                                                              ; { IMPORT_SPECIFIER* }
+;
+; import_specifier :=
+;    (import_specifier name:(_)  alias:(_))                                                           ; NAME
+;    (import_specifier name:(_) !alias    )                                                           ; NAME as ALIAS
+;
+; Note that the grammar productions for imports and exports are factored slightly
+; different. The statements above are inlined such that corresponding import and
+; export statements all live in the top-level list. Be mindful that (export_clause)
+; corresponds to (import_clause (named_imports)) and not to (import_cluase)!
+;
+; The presence of a "type" modifier does not fundamentally change the way a certain
+; export/import variant works, only which identifiers are included in the import/export.
+; Therefore, we do not handle that as different export/export variants, but deal with that
+; in the rules for the various clauses, which already determine the identifiers involved.
+
+;; Module References
+
+[
+  (export_statement                        source:(_)@from )
+  (import_statement                        source:(_)@from )
+  (import_statement (import_require_clause source:(_)@from))
+]@import_stmt {
+  node @from.mod_ref
+  node @from.mod_ref__ns
+
+  ; module reference
+  let mod_name = (path-normalize (path-join (path-dir FILE_PATH) (replace (source-text @from) "[\"\']" "")))
+  attr (@from.mod_ref) symbol_reference = mod_name, source_node = @import_stmt
+  edge @from.mod_ref -> @from.mod_ref__ns
+  ;
+  attr (@from.mod_ref__ns) push_symbol = "%M"
+  edge @from.mod_ref__ns -> ROOT_NODE
+}
+
+;; Named Clauses
+
+[
+  (export_statement "type"? (export_clause               )@clause)
+  (import_statement "type"? (import_clause (named_imports)@clause))
+] {
+  node @clause.defs
+  node @clause.exports
+  node @clause.lexical_defs
+  node @clause.lexical_scope
+}
+
+;;;; Types
+
+[
+  (export_statement "type"? (export_clause                (export_specifier name:(_)@name))@clause)
+  (import_statement "type"? (import_clause (named_imports (import_specifier name:(_)@name))@clause))
+] {
+  node @name.type_def
+  node @name.type_def__ns
+  node @name.type_ref
+  node @name.type_ref__ns
+
+  ; type reference
+  attr (@name.type_ref) node_reference = @name
+  edge @name.type_ref -> @name.type_ref__ns
+  ;
+  attr (@name.type_ref__ns) push_symbol = "%T"
+  edge @name.type_ref__ns -> @clause.lexical_scope
+}
+
+[
+  (export_statement "type"? (export_clause                (export_specifier name:(_)@name !alias))@clause)
+  (import_statement "type"? (import_clause (named_imports (import_specifier name:(_)@name !alias))@clause))
+] {
+  ; type definition
+  edge @clause.defs -> @name.type_def__ns ; FIXME defs, lexical_defs?
+  ;
+  attr (@name.type_def__ns) pop_symbol = "%T"
+  edge @name.type_def__ns -> @name.type_def
+  ;
+  attr (@name.type_def) node_definition = @name
+  edge @name.type_def -> @name.type_ref
+}
+
+[
+  (export_statement "type"? (export_clause                (export_specifier name:(_)@name alias:(_)@alias))@clause)
+  (import_statement "type"? (import_clause (named_imports (import_specifier name:(_)@name alias:(_)@alias))@clause))
+] {
+  node @alias.type_def
+  node @alias.type_def__ns
+  node @alias.type_ref
+
+  ; type definition
+  edge @clause.defs -> @alias.type_def__ns
+  ;
+  attr (@alias.type_def__ns) pop_symbol = "%T"
+  edge @alias.type_def__ns -> @alias.type_def
+  ;
+  attr (@alias.type_def) node_definition = @alias
+  edge @alias.type_def -> @name.type_ref
+}
+
+
+;;;; Expressions
+
+[
+  (export_statement "type"?@is_type (export_clause                (export_specifier name:(_)@name))@clause)
+  (import_statement "type"?@is_type (import_clause (named_imports (import_specifier name:(_)@name))@clause))
+] {
+if none @is_type {
+  node @name.expr_def
+  node @name.expr_def__ns
+  node @name.expr_ref
+  node @name.expr_ref__ns
+
+  ; expr reference
+  attr (@name.expr_ref) node_reference = @name
+  edge @name.expr_ref -> @name.expr_ref__ns
+  ;
+  attr (@name.expr_ref__ns) push_symbol = "%E"
+  edge @name.expr_ref__ns -> @clause.lexical_scope
+}
+}
+
+[
+  (export_statement "type"?@is_type (export_clause                (export_specifier name:(_)@name !alias))@clause)
+  (import_statement "type"?@is_type (import_clause (named_imports (import_specifier name:(_)@name !alias))@clause))
+] {
+if none @is_type {
+  ; expr definition
+  edge @clause.defs -> @name.expr_def__ns ; FIXME defs, lexical_defs?
+  ;
+  attr (@name.expr_def__ns) pop_symbol = "%E"
+  edge @name.expr_def__ns -> @name.expr_def
+  ;
+  attr (@name.expr_def) node_definition = @name
+  edge @name.expr_def -> @name.expr_ref
+}
+}
+
+[
+  (export_statement "type"?@is_type (export_clause                (export_specifier name:(_)@name alias:(_)@alias))@clause)
+  (import_statement "type"?@is_type (import_clause (named_imports (import_specifier name:(_)@name alias:(_)@alias))@clause))
+] {
+if none @is_type {
+  node @alias.expr_def
+  node @alias.expr_def__ns
+  node @alias.expr_ref
+
+  ; expr definition
+  edge @clause.defs -> @alias.expr_def__ns
+  ;
+  attr (@alias.expr_def__ns) pop_symbol = "%E"
+  edge @alias.expr_def__ns -> @alias.expr_def
+  ;
+  attr (@alias.expr_def) node_definition = @alias
+  edge @alias.expr_def -> @name.expr_ref
+}
+}
+
+;; Exports
+
+; export * from from MODULE
+;
+; (export_statement
+;   "*" source:(string)@name
+; )@export_stmt
+
+(export_statement
+  "*" source:(_)@name
+)@export_stmt {
+  ; export everything from source module
+  edge @export_stmt.exports -> @name.mod_ref
+}
+
+; export CLAUSE from MODULE
+; export type CLAUSE from MODULE
+;
+; (export_statement
+;   "type"? (export_clause)@clause source:(_)@name
+; )@export_stmt
+
+(export_statement
+  "type"? (export_clause)@clause source:(_)@name
+)@export_stmt {
+  ; propagate lexical scope
+  edge @clause.lexical_scope -> @name.mod_ref
+
+  ; propagate exports
+  edge @export_stmt.exports -> @clause.defs
+}
+
+; export CLAUSE
+; export type CLAUSE
+;
+; (export_statement
+;   "type"?
+;   (export_clause)@clause
+; )@export_stmt
+
+(export_statement
+  "type"?
+  (export_clause)@clause
+  !source
+)@export_stmt {
+  ; propagate lexical scope
+  edge @clause.lexical_scope -> @export_stmt.lexical_scope
+
+  ; propagate exports
+  edge @export_stmt.exports -> @clause.defs
+}
+
+; export DECL
+;
+; (export_statement
+;   ^"default"
+;   declaration:(_)@decl
+; )@export_stmt
+
+(export_statement
+  "default"?@is_default
+  declaration:(_)@decl
+)@export_stmt {
+if none @is_default {
+  ; propagate lexical scope
+  edge @decl.lexical_scope -> @export_stmt.lexical_scope
+
+  ; expose lexical definitions
+  edge @export_stmt.lexical_defs -> @decl.lexical_defs
+
+  ; expose variable definitions
+  edge @export_stmt.var_defs -> @decl.var_defs
+
+  ; export the definitions
+  edge @export_stmt.exports -> @decl.lexical_defs
+  edge @export_stmt.exports -> @decl.var_defs
+}
+}
+
+; export default DECL
+;
+; (export_statement
+;   "default"
+;   declaration:(_)@decl
+; )@export_stmt
+
+; export default EXPR
+;
+; (export_statement
+;   "default"
+;   value:(_)@expr
+; )@export_stmt
+
+; export = NAME
+;
+; (export_statement
+;   "="
+;   (expression)@expr
+; )@export_stmt
+
+; NOTE Default exports are modeled as variables named "default", because the grammar
+;      treats "default" as a regular identifier instead of a keyword. This approach
+;      ensures renaming imports such as `import { default as X } from ...` work correctly.
+;
+;      Default exports are generally expressions. However, if the export is specified as
+;      an identifier, the type with that name is also exported.
+
+(export_statement
+  ["default" "="]
+)@export_stmt {
+  node @export_stmt.default_def
+  node @export_stmt.default_expr_def
+  node @export_stmt.default_expr_def__ns_pop
+  node @export_stmt.default_expr_def__ns_push
+  node @export_stmt.default_type_def
+  node @export_stmt.default_type_def__ns_pop
+  node @export_stmt.default_type_def__ns_push
+
+  ; export as default expr
+  edge @export_stmt.exports -> @export_stmt.default_expr_def__ns_pop
+  ;
+  attr (@export_stmt.default_expr_def__ns_pop) pop_symbol = "%E"
+  edge @export_stmt.default_expr_def__ns_pop -> @export_stmt.default_expr_def
+  ;
+  ;; @export_stmt.default_expr_def pop_symbol set below for "default" and "="
+  edge @export_stmt.default_expr_def -> @export_stmt.default_expr_def__ns_push
+  ;
+  attr (@export_stmt.default_expr_def__ns_push) push_symbol = "%E"
+  edge @export_stmt.default_expr_def__ns_push -> @export_stmt.default_def
+
+  ; export as default type
+  edge @export_stmt.exports -> @export_stmt.default_type_def__ns_pop
+  ;
+  attr (@export_stmt.default_type_def__ns_pop) pop_symbol = "%T"
+  edge @export_stmt.default_type_def__ns_pop -> @export_stmt.default_type_def
+  ;
+  ;; @export_stmt.default_expr_def pop_symbol set below for "default" and "="
+  edge @export_stmt.default_type_def -> @export_stmt.default_type_def__ns_push
+  ;
+  attr (@export_stmt.default_type_def__ns_push) push_symbol = "%T"
+  edge @export_stmt.default_type_def__ns_push -> @export_stmt.default_def
+}
+
+(export_statement
+  "default"
+)@export_stmt {
+  attr (@export_stmt.default_expr_def) symbol_definition = "default", source_node = @export_stmt
+  attr (@export_stmt.default_type_def) symbol_definition = "default", source_node = @export_stmt
+}
+
+(export_statement
+  "="
+)@export_stmt {
+  attr (@export_stmt.default_expr_def) symbol_definition = "<exports>", source_node = @export_stmt
+  attr (@export_stmt.default_type_def) symbol_definition = "<exports>", source_node = @export_stmt
+}
+
+(export_statement
+  "default"
+  declaration:(_)@decl
+)@export_stmt {
+  ; propagate lexical scope
+  edge @decl.lexical_scope -> @export_stmt.lexical_scope
+
+  ; expose lexical definitions
+  edge @export_stmt.lexical_defs -> @decl.lexical_defs
+
+  ; expose variable definitions
+  edge @export_stmt.var_defs -> @decl.var_defs
+
+  ; export as default
+  edge @export_stmt.default_def -> @decl.default_export
+}
+
+[
+  (export_statement "default" value:(_)@expr)@export_stmt
+  (export_statement "=" . (_)@expr)@export_stmt
+] {
+  node @export_stmt.default_expr__ns
+  node @export_stmt.default_expr__typeof
+
+  ; propagate lexical scope
+  edge @expr.lexical_scope -> @export_stmt.lexical_scope
+
+  ; expose lexical definitions
+  edge @export_stmt.lexical_defs -> @expr.lexical_defs
+
+  ; expose variable definitions
+  edge @export_stmt.var_defs -> @expr.var_defs
+
+  ; export expression as default
+  edge @export_stmt.default_def -> @export_stmt.default_expr__ns
+  ;
+  attr (@export_stmt.default_expr__ns) pop_symbol = "%E"
+  edge @export_stmt.default_expr__ns -> @export_stmt.default_expr__typeof
+  ;
+  attr (@export_stmt.default_expr__typeof) pop_symbol = ":"
+  edge @export_stmt.default_expr__typeof -> @expr.type
+}
+
+; NOTE an identifier in a default export can also be a type reference
+[
+  (export_statement "default" value:(identifier)@name)@export_stmt
+  (export_statement "=" . (identifier)@name)@export_stmt
+] {
+  node @export_stmt.default_type__ns
+  node @name.type_ref
+  node @name.type_ref__ns
+
+  ; export type as default
+  edge @export_stmt.default_def -> @export_stmt.default_type__ns
+  ;
+  attr (@export_stmt.default_type__ns) pop_symbol = "%T"
+  edge @export_stmt.default_type__ns -> @name.type_ref
+  ;
+  attr (@name.type_ref) node_reference = @name
+  edge @name.type_ref -> @name.type_ref__ns
+  ;
+  attr (@name.type_ref__ns) push_symbol = "%T"
+  edge @name.type_ref__ns -> @export_stmt.lexical_scope
+}
+
+; export * as namespace NAME
+
+; (export_statement
+;   (namespace_export (identifier)@ns)
+;   source:(_)@from
+; )
+
+(export_statement
+  (namespace_export (identifier)@ns)
+  source:(_)@name
+)@export_stmt {
+  ; namespace definitions are specified together with (module) and (internal_module)
+
+  ; export definitions
+  edge @export_stmt.exports -> @name.expr_def__ns
+  edge @export_stmt.exports -> @name.type_def__ns
+
+  ; connect definitions to exports
+  edge @export_stmt.expr_member__ns -> @name.mod_ref
+  edge @export_stmt.type_member__ns -> @name.mod_ref
+}
+
+; export as namespace NAME
+;
+; (export_statement
+;   "as"
+;   "namespace"
+;   (identifier)@name
+; )@export_stmt
+
+(program (export_statement
+  "as" "namespace" . (_)@name
+)@export_stmt)@program {
+  ; namespace definitions are specified together with (module) and (internal_module)
+
+  ; make definitions global
+  edge ROOT_NODE -> @name.expr_def__ns
+  edge ROOT_NODE -> @name.type_def__ns
+
+  ; connect definitions to exports
+  edge @export_stmt.expr_member__ns -> @program.exports
+  edge @export_stmt.type_member__ns -> @program.exports
+}
+
+;; Imports
+
+; import MODULE
+;
+; (import_statement
+;   ^(import_clause)
+;   source:(_)@from
+; )@import_stmt
+
+(import_statement
+  "type"?
+  (import_clause)?@has_clause
+  source:(_)@from
+)@import_stmt {
+if none @has_clause {
+  ; do nothing, imported for side-effect only
+}
+}
+
+; import (type) NAMED_IMPORTS from MODULE
+
+(import_statement
+  "type"?
+  (import_clause (named_imports)@clause)
+  source:(_)@from
+)@import_stmt {
+  ; use module for lexical scope of import clause
+  edge @clause.lexical_scope -> @from.mod_ref
+
+  ; expose imported definitions
+  edge @import_stmt.lexical_defs -> @clause.defs
+}
+
+; import (type) NAME from MODULE
+; import (type) NAME = require(MODULE)
+
+[
+  (import_statement "type"? (import_clause         (identifier)) source:(_)@from)@import_stmt
+  (import_statement "type"? (import_require_clause (identifier)  source:(_)@from))@import_stmt
+] {
+  node @import_stmt.default_ref
+
+  ; connect default refererence to module
+  edge @import_stmt.default_ref -> @from.mod_ref
+}
+
+;;;; Types
+
+[
+  (import_statement "type"? (import_clause         (identifier)@name))@import_stmt
+  (import_statement "type"? (import_require_clause (identifier)@name))@import_stmt
+] {
+  node @import_stmt.type_def
+  node @import_stmt.type_def__ns
+  node @import_stmt.default_type_ref
+  node @import_stmt.default_type_ref__ns
+
+  ; type definition
+  edge @import_stmt.lexical_defs -> @import_stmt.type_def__ns
+  ;
+  attr (@import_stmt.type_def__ns) pop_symbol = "%T"
+  edge @import_stmt.type_def__ns -> @import_stmt.type_def
+  ;
+  attr (@import_stmt.type_def) node_definition = @name
+  edge @import_stmt.type_def -> @import_stmt.default_type_ref
+  ;
+  ;; @import_stmt.default_type_ref pop_symbol set below for "default" and "="
+  edge @import_stmt.default_type_ref -> @import_stmt.default_type_ref__ns
+  ;
+  attr (@import_stmt.default_type_ref__ns) push_symbol = "%T"
+  edge @import_stmt.default_type_ref__ns -> @import_stmt.default_ref
+}
+
+(import_statement "type"? (import_clause (identifier)))@import_stmt {
+  attr (@import_stmt.default_type_ref) symbol_reference = "default", source_node = @import_stmt
+}
+
+(import_statement "type"? (import_require_clause (identifier)))@import_stmt {
+  attr (@import_stmt.default_type_ref) symbol_reference = "<exports>", source_node = @import_stmt
+}
+
+;;;; Expressions
+
+[
+  (import_statement "type"?@is_type (import_clause         (identifier)@name))@import_stmt
+  (import_statement "type"?@is_type (import_require_clause (identifier)@name))@import_stmt
+] {
+if none @is_type {
+  node @import_stmt.expr_def
+  node @import_stmt.expr_def__ns
+  node @import_stmt.default_expr_ref
+  node @import_stmt.default_expr_ref__ns
+
+  ; expr definition
+  edge @import_stmt.lexical_defs -> @import_stmt.expr_def__ns
+  ;
+  attr (@import_stmt.expr_def__ns) pop_symbol = "%E"
+  edge @import_stmt.expr_def__ns -> @import_stmt.expr_def
+  ;
+  attr (@import_stmt.expr_def) node_definition = @name
+  edge @import_stmt.expr_def -> @import_stmt.default_expr_ref
+  ;
+  ;; @import_stmt.default_expr_ref pop_symbol set below for "default" and "="
+  edge @import_stmt.default_expr_ref -> @import_stmt.default_expr_ref__ns
+  ;
+  attr (@import_stmt.default_expr_ref__ns) push_symbol = "%E"
+  edge @import_stmt.default_expr_ref__ns -> @import_stmt.default_ref
+}
+}
+
+(import_statement "type"?@is_type (import_clause (identifier)))@import_stmt {
+if none @is_type {
+  attr (@import_stmt.default_expr_ref) symbol_reference = "default", source_node = @import_stmt
+}
+}
+
+(import_statement "type"?@is_type (import_require_clause (identifier)))@import_stmt {
+if none @is_type {
+  attr (@import_stmt.default_expr_ref) symbol_reference = "<exports>", source_node = @import_stmt
+}
+}
+
+; import (type) * as NAMESPACE from MODULE
+
+(import_statement
+  "type"?
+  (import_clause (namespace_import (identifier)@name))
+  source:(_)@from
+)@import_stmt {
+  ; namespace definitions are specified together with (module) and (internal_module)
+
+  ; connect definitions to import
+  edge @import_stmt.expr_member__ns -> @from.mod_ref
+  edge @import_stmt.type_member__ns -> @from.mod_ref
+}
+
+;; Import Alias
+
+; import ID = ID | NESTED_ID
+
+; (import_alias
+;   (identifier)
+;   [(identifier) (nested_identifier)]
+; ) {}
+
+
+
+;; Debugger
+
+; debugger;
+; debugger
+
+(debugger_statement)@debugger_stmt {
+}
+
+
+
+;; Expression
+
+; 1;
+
+(expression_statement (_)@expr)@expr_stmt {
+  ; propagate lexical scope
+  edge @expr.lexical_scope -> @expr_stmt.lexical_scope
+}
+
+
+
+;; Declaration
+
+;; Variable Declarations
+
+; var foo;
+; var x = 1;
+; var x, y = {}, z;
+; let baz = bar;
+; const quux = baz;
+
+(variable_declaration (variable_declarator)@declor)@decl {
+  ; propagate lexical scope
+  edge @declor.lexical_scope -> @decl.lexical_scope
+
+  ; local definitions
+  edge @decl.var_defs -> @declor.defs
+
+  ; default export
+  edge @decl.default_export -> @declor.default_export
+}
+
+(lexical_declaration  (variable_declarator)@declor)@decl {
+  ; propagate lexical scope
+  edge @declor.lexical_scope -> @decl.lexical_scope
+
+  ; local definitions
+  edge @decl.lexical_defs -> @declor.defs
+
+  ; default export
+  edge @decl.default_export -> @declor.default_export
+}
+
+
+;; Variable Declarator
+
+(variable_declarator)@decl {
+  node @decl.default_export
+  node @decl.defs
+  node @decl.lexical_scope
+}
+
+(variable_declarator
+  name:(_)@pat
+)@decl {
+  node @decl.expr_export
+  node @decl.type_export
+
+  ; propagate lexical scope
+  edge @pat.lexical_scope -> @decl.lexical_scope
+
+  ; local definitions from pattern
+  edge @decl.defs -> @pat.defs
+
+  ; default export
+  edge @decl.default_export -> @decl.expr_export
+  ;
+  attr (@decl.expr_export) pop_symbol = "%E"
+}
+
+(variable_declarator
+  name:(_)@pat
+  type:(_)@type
+)@decl {
+  ; propagate lexical scope
+  edge @type.lexical_scope -> @decl.lexical_scope
+
+  ; match pattern cotype to type annotation
+  edge @pat.cotype -> @type.type
+
+  ; default export
+  edge @decl.expr_export -> @type.type
+}
+
+(variable_declarator
+  name:(_)@pat
+  !type
+  value:(_)@value
+)@decl {
+  ; match pattern cotype to value type
+  edge @pat.cotype -> @value.type
+
+  ; default export
+  edge @decl.expr_export -> @value.type
+}
+
+(variable_declarator
+  value:(_)@value
+)@decl {
+  ; propagate lexical scope
+  edge @value.lexical_scope -> @decl.lexical_scope
+}
+
+(variable_declarator
+  type:(_)@type
+  value:(_)@value
+)@decl {
+  ; match value cotype to type annotation
+  edge @value.cotype -> @type.type
+}
+
+
+
+;; Function Declarations
+
+; function foo(x) {
+;   return x;
+; }
+
+; (function_declaration
+;   name:(_)@name
+;   type_parameters:(_)@type_params ; opt
+;   parameters:(_)@call_sig
+;   body:(_)@body
+;   return_type:(_)@return_type ; opt
+; )@fun_decl
+
+; (generator_function_declaration
+;   name:(_)@name
+;   type_parameters:(_)@type_params ; opt
+;   parameters:(_)@call_sig
+;   body:(_)@body
+; )@fun_decl
+
+; (function_signature
+;   name:(_)@name
+;   type_parameters:(_)@type_params ; opt
+;   parameters:(_)@params
+;   return_type:(_)@return_type ; opt
+; )@fun_decl
+
+[
+  (function_declaration           name:(_)@name)
+  (generator_function_declaration name:(_)@name)
+  (function_signature             name:(_)@name)
+]@fun_decl {
+  node @fun_decl.callable
+  node @fun_decl.callable__params
+  node @fun_decl.callable__return
+  node @fun_decl.expr_export
+  node @name.expr_def
+  node @name.expr_def__ns
+  node @name.expr_def__typeof
+
+  ; function definition
+  edge @fun_decl.var_defs -> @name.expr_def__ns
+  ;
+  attr (@name.expr_def__ns) pop_symbol = "%E"
+  edge @name.expr_def__ns -> @name.expr_def
+  ;
+  attr (@name.expr_def) node_definition = @name
+
+  ; function type
+  edge @name.expr_def -> @name.expr_def__typeof
+  ;
+  attr (@name.expr_def__typeof) pop_symbol = ":"
+  edge @name.expr_def__typeof -> @fun_decl.callable
+  ;
+  attr (@fun_decl.callable) pop_symbol = "->"
+  edge @fun_decl.callable -> @fun_decl.generic_type
+  ;
+  edge @fun_decl.generic_inner_type -> @fun_decl.callable__params
+  edge @fun_decl.generic_inner_type -> @fun_decl.callable__return
+  ;
+  attr (@fun_decl.callable__return) pop_symbol = "<return>"
+
+  ; default export
+  edge @fun_decl.default_export -> @fun_decl.expr_export
+  ;
+  attr (@fun_decl.expr_export) pop_symbol = "%E"
+  edge @fun_decl.expr_export -> @fun_decl.callable
+}
+
+; type parameters are handled in generics rules
+
+[
+  (function_declaration           parameters:(_)@params)
+  (generator_function_declaration parameters:(_)@params)
+  (function_signature             parameters:(_)@params)
+]@fun_decl {
+  ; propagate lexical scope
+  edge @params.lexical_scope -> @fun_decl.generic_inner_lexical_scope
+
+  ; expose parameter definitions
+  edge @fun_decl.generic_inner_lexical_scope -> @params.defs
+  attr (@fun_decl.generic_inner_lexical_scope -> @params.defs) precedence = 1
+
+  ; expose parameters to type
+  edge @fun_decl.callable__params -> @params.params
+}
+
+[
+  (function_declaration           return_type:(_)@return_type)
+  (generator_function_declaration return_type:(_)@return_type)
+  (function_signature             return_type:(_)@return_type)
+]@fun_decl {
+  ; propagate lexical scope
+  edge @return_type.lexical_scope -> @fun_decl.generic_inner_lexical_scope
+
+  ; function type returns return type
+  edge @fun_decl.callable__return -> @return_type.type
+}
+
+[
+  (function_declaration           "async"?@is_async !return_type body:(_)@body)
+  (generator_function_declaration "async"?@is_async !return_type body:(_)@body)
+]@fun_decl {
+if none @is_async {
+  ; function returns body return type
+  edge @fun_decl.callable__return -> @body.return_type
+}
+}
+
+[
+  (function_declaration           body:(_)@body)
+  (generator_function_declaration body:(_)@body)
+]@fun_decl {
+  ; propagate lexical scope
+  edge @body.lexical_scope -> @fun_decl.generic_inner_lexical_scope
+
+  ; function scopes lexical and variable definitions
+  edge @fun_decl.generic_inner_lexical_scope -> @body.lexical_defs
+  attr (@fun_decl.generic_inner_lexical_scope -> @body.lexical_defs) precedence = 1
+  edge @fun_decl.generic_inner_lexical_scope -> @body.var_defs
+  attr (@fun_decl.generic_inner_lexical_scope -> @body.var_defs) precedence = 1
+}
+
+[
+  (function_declaration           "async" !return_type body:(_)@body)
+  (generator_function_declaration "async" !return_type body:(_)@body)
+]@fun_decl {
+  ; function returns body return type
+  edge @fun_decl.callable__return -> @fun_decl.async_type
+  ;
+  edge @fun_decl.await_type -> @body.return_type
+}
+
+
+
+;; (Abstract) Class & Interface Declaration
+
+; class Foo { }
+; class Bar extends Foo {
+;   baz() {}
+; }
+
+; (abstract_class_declaration
+;   decorator:(_) ; rep
+;   name:(_) ; opt
+;   type_parameters:(_) ; opt
+;   (class_heritage) ; opt
+;   body:(_)
+; ) {}
+
+; (class_declaration
+;   decorator:(_) ; rep
+;   name:(_) ; opt
+;   type_parameters:(_) ; opt
+;   (class_heritage) ; opt
+;   body:(_)
+; ) {}
+
+; (interface_declaration
+;   name:(_)@name
+;   type_parameters:(_) ; opt
+;   (extends_clause) ; opt
+;   body:(_)@body
+; )@decl
+
+; decorators
+[
+  (abstract_class_declaration decorator:(_)@dec)
+  (class_declaration          decorator:(_)@dec)
+]@class_decl {
+  ; connect lexical scope
+  edge @dec.lexical_scope -> @class_decl.lexical_scope
+}
+
+; definitions
+[
+  (abstract_class_declaration name:(_)@name)
+  (class_declaration          name:(_)@name)
+  (interface_declaration      name:(_)@name)
+]@class_decl {
+  node @class_decl.type_export
+  node @name.type_def
+  node @name.type_def__ns
+
+  ; type definition
+  edge @class_decl.lexical_defs -> @name.type_def__ns
+  ;
+  attr (@name.type_def__ns) pop_symbol = "%T"
+  edge @name.type_def__ns -> @name.type_def
+  ;
+  attr (@name.type_def) node_definition = @name
+  edge @name.type_def -> @class_decl.generic_type
+
+  ; default type export
+  edge @class_decl.default_export -> @class_decl.type_export
+  ;
+  attr (@class_decl.type_export) pop_symbol = "%T"
+  edge @class_decl.type_export -> @class_decl.generic_type
+}
+[
+  (abstract_class_declaration name:(_)@name)
+  (class_declaration          name:(_)@name)
+; NOTE not for interface_declaration as body is already a type with an endpoint of needed
+]@class_decl {
+  ; mark type scope as endpoint
+  attr (@class_decl.generic_inner_type) is_endpoint
+}
+[
+  (abstract_class_declaration name:(_)@name)
+  (class_declaration          name:(_)@name)
+]@class_decl {
+  node @class_decl.expr_export
+
+  ; class expr definition
+  edge @class_decl.lexical_defs -> @name.expr_def__ns
+  ;
+  attr (@name.expr_def__ns) pop_symbol = "%E"
+  edge @name.expr_def__ns -> @name.expr_def
+  ;
+  attr (@name.expr_def) node_definition = @name
+
+  ; type of expression is .static_type
+  edge @name.expr_def -> @name.expr_def__typeof
+  ;
+  attr (@name.expr_def__typeof) pop_symbol = ":"
+  edge @name.expr_def__typeof -> @class_decl.static_type
+
+  ; default expression export
+  edge @class_decl.default_export -> @class_decl.expr_export
+  ;
+  attr (@class_decl.expr_export) pop_symbol = "%E"
+  edge @class_decl.expr_export -> @class_decl.static_type
+
+  ; mark type scope as endpoint
+  attr (@class_decl.static_type) is_endpoint
+}
+
+; type parameters are handled in generics rules below
+
+; inheritance
+[
+  (abstract_class_declaration (class_heritage)@heritage)
+  (class_declaration          (class_heritage)@heritage)
+]@class_decl {
+  ; propagate lexical scope
+  edge @heritage.lexical_scope -> @class_decl.generic_inner_lexical_scope
+
+  ; class type inherits from heritage type
+  edge @class_decl.generic_inner_type -> @heritage.type_members
+
+  ; class object inherits from super class object
+  edge @class_decl.static_type -> @heritage.static_members
+}
+[
+  (interface_declaration (extends_type_clause)@extends)
+]@class_decl {
+  ; propagate lexical scope
+  edge @extends.lexical_scope -> @class_decl.generic_inner_lexical_scope
+
+  ; interface type inherits from extends type
+  edge @class_decl.generic_inner_type -> @extends.type_members
+}
+
+; this
+[
+  (abstract_class_declaration)
+  (class_declaration         )
+  (interface_declaration     )
+]@class_decl {
+  node @class_decl.this__expr_def
+  node @class_decl.this__expr_def__ns
+  node @class_decl.this__expr_def__typeof
+  node @class_decl.this__type_def
+  node @class_decl.this__type_def__ns
+  node @class_decl.static_type
+
+  ; this expr definition
+  edge @class_decl.generic_inner_lexical_scope -> @class_decl.this__expr_def__ns
+  ;
+  attr (@class_decl.this__expr_def__ns) pop_symbol = "%E"
+  edge @class_decl.this__expr_def__ns -> @class_decl.this__expr_def
+  ;
+  attr (@class_decl.this__expr_def) pop_symbol = "this"
+  edge @class_decl.this__expr_def -> @class_decl.this__expr_def__typeof
+  ;
+  attr (@class_decl.this__expr_def__typeof) pop_symbol = ":"
+  edge @class_decl.this__expr_def__typeof -> @class_decl.generic_inner_type
+
+  ; this type definition
+  ; FIXME this is more dynamic in reality
+  edge @class_decl.generic_inner_lexical_scope -> @class_decl.this__type_def__ns
+  ;
+  attr (@class_decl.this__type_def__ns) pop_symbol = "%T"
+  edge @class_decl.this__type_def__ns -> @class_decl.this__type_def
+  ;
+  attr (@class_decl.this__type_def) pop_symbol = "this"
+  edge @class_decl.this__type_def -> @class_decl.generic_inner_type
+}
+
+; default constructor
+; FIXME only if no other constructor is defined
+[
+  (abstract_class_declaration)
+  (class_declaration         )
+]@class_decl {
+  node @class_decl.ctor_def
+
+  ; default nullary constructor
+  edge @class_decl.static_type -> @class_decl.ctor_def
+  ;
+  attr (@class_decl.ctor_def) pop_symbol = "<new>"
+  ; FIXME constructor inherits type parameters of surrounding class
+  edge @class_decl.ctor_def -> @class_decl.generic_type
+}
+
+; body
+[
+  (abstract_class_declaration body:(_)@body)
+  (class_declaration          body:(_)@body)
+]@class_decl {
+  ; propagate lexical scope
+  ; FIXME the static members have access to type variables like this
+  edge @body.lexical_scope -> @class_decl.generic_inner_lexical_scope
+
+  ; class type consists of body members
+  edge @class_decl.generic_inner_type -> @body.type_members
+
+  ; class object consists of static members
+  edge @class_decl.static_type -> @body.static_members
+}
+[
+  (interface_declaration      body:(_)@body)
+]@class_decl {
+  ; propagate lexical scope
+  edge @body.lexical_scope -> @class_decl.generic_inner_lexical_scope
+
+  ; interface type equals body type
+  edge @class_decl.generic_inner_type -> @body.type
+}
+
+
+
+;; Class Body
+
+; (class_body
+;   [(decorator)
+;    (method_definition)
+;    (abstract_method_signature)
+;    (index_signature)
+;    (method_signature)
+;    (public_field_definition)]
+; )
+
+(class_body)@class_body {
+  node @class_body.lexical_scope
+  node @class_body.type_members
+  node @class_body.static_members
+}
+
+(class_body
+  (_)@mem
+)@class_body {
+  ; propagate lexical scope
+  edge @mem.lexical_scope -> @class_body.lexical_scope
+
+  ; body members are member definitions
+  edge @class_body.type_members -> @mem.type_members
+
+  ; body static members are static member definitions
+  edge @class_body.static_members -> @mem.static_members
+}
+
+
+
+;; Statement Block
+
+(statement_block
+  (_)@stmt
+)@block {
+  ; propagate lexical scope
+  edge @stmt.lexical_scope -> @block.lexical_scope
+
+  ; lexical definitions are scoped by the block
+  edge @block.lexical_scope -> @stmt.lexical_defs
+  attr (@block.lexical_scope -> @stmt.lexical_defs) precedence = 1
+
+  ; variable definitions escape the block
+  edge @block.var_defs -> @stmt.var_defs
+
+  ; exports escape the block (for use in namespaces and ambient modules)
+  edge @block.exports -> @stmt.exports
+
+  ; expose return type
+  edge @block.return_type -> @stmt.return_type
+}
+
+
+
+;; If
+
+; if (x)
+;   log(y);
+
+; if (a.b) {
+;   log(c);
+;   d;
+; }
+
+; if (x)
+;   y;
+; else if (a)
+;   b;
+
+; if (a) {
+;   c;
+; } else {
+;   e;
+; }
+
+(if_statement
+  condition:(_)@condition
+)@if_stmt {
+  ; propagate lexical scope
+  edge @condition.lexical_scope -> @if_stmt.lexical_scope
+
+  ; lexical definitions
+  edge @if_stmt.lexical_defs -> @condition.lexical_defs
+
+  ; variable definitions
+  edge @if_stmt.var_defs -> @condition.var_defs
+
+  ; expose return type
+  edge @if_stmt.return_type -> @condition.return_type
+}
+(if_statement
+  consequence:(_)@consequence
+)@if_stmt {
+  ; propagate lexical scope
+  edge @consequence.lexical_scope -> @if_stmt.lexical_scope
+
+  ; lexical definitions
+  edge @if_stmt.lexical_defs -> @consequence.lexical_defs
+
+  ; variable definitions
+  edge @if_stmt.var_defs -> @consequence.var_defs
+
+  ; expose return type
+  edge @if_stmt.return_type -> @consequence.return_type
+}
+(if_statement
+  alternative:(_)@alternative
+)@if_stmt {
+  ; propagate lexical scope
+  edge @alternative.lexical_scope -> @if_stmt.lexical_scope
+
+  ; lexical definitions
+  edge @if_stmt.lexical_defs -> @alternative.lexical_defs
+
+  ; variable definitions
+  edge @if_stmt.var_defs -> @alternative.var_defs
+
+  ; expose return type
+  edge @if_stmt.return_type -> @alternative.return_type
+}
+
+(else_clause (_)@inner)@else_clause {
+  ; propagate lexical scope
+  edge @inner.lexical_scope -> @else_clause.lexical_scope
+
+  ; lexical definitions
+  edge @else_clause.lexical_defs -> @inner.lexical_defs
+
+  ; variable definitions
+  edge @else_clause.var_defs -> @inner.var_defs
+
+  ; expose return type
+  edge @else_clause.return_type -> @inner.return_type
+}
+
+
+
+;; Switch
+
+; switch (x) {
+;   case 1:
+;   case 2:
+;     something();
+;     break;
+;   case "three":
+;     somethingElse();
+;     break;
+;   default:
+;     return 4;
+; }
+
+(switch_statement
+  value:(_)@value
+  body:(_)@body
+)@switch_stmt {
+  ; propagate lexical scope
+  edge @body.lexical_scope -> @switch_stmt.lexical_scope
+
+  ; variable definitions
+  edge @switch_stmt.var_defs -> @body.var_defs
+
+  ; expose return type
+  edge @switch_stmt.return_type -> @body.return_type
+}
+
+(switch_body
+  (_)@choice
+)@switch_body {
+  ; propagate lexical scope
+  edge @choice.lexical_scope -> @switch_body.lexical_scope
+
+  ; lexical definitions are scoped in the body
+  edge @switch_body.lexical_scope -> @choice.lexical_defs
+  attr (@switch_body.lexical_scope -> @choice.lexical_defs) precedence = 1
+
+  ; variable definitions escape
+  edge @switch_body.var_defs -> @choice.var_defs
+
+  ; expose return type
+  edge @switch_body.return_type -> @choice.return_type
+}
+
+(switch_case
+  value:(_)@value
+  body: (_)@stmt
+)@switch_case {
+  ; propagate lexical scope
+  edge @stmt.lexical_scope -> @switch_case.lexical_scope
+
+  ; lexical definitions
+  edge @switch_case.lexical_defs -> @stmt.lexical_defs
+
+  ; variable definitions
+  edge @switch_case.var_defs -> @stmt.var_defs
+
+  ; expose return type
+  edge @switch_case.return_type -> @stmt.return_type
+}
+
+(switch_default
+  body: (_)@stmt
+)@switch_default {
+  ; propagate lexical scope
+  edge @stmt.lexical_scope -> @switch_default.lexical_scope
+
+  ; lexical definitions
+  edge @switch_default.lexical_defs -> @stmt.lexical_defs
+
+  ; variable definitions
+  edge @switch_default.var_defs -> @stmt.var_defs
+
+  ; expose return type
+  edge @switch_default.return_type -> @stmt.return_type
+}
+
+
+
+;; For
+
+; for (var a, b; c; d)
+;   e;
+
+; for (i = 0, init(); i < 10; i++)
+;   log(y);
+
+; for (;;) {
+;   z;
+;   continue;
+; }
+
+; (for_statement
+;   initializer:(_)@initializer
+;   condition:(_)@condition
+;   increment:(_)@increment ; opt
+;   body:(_)@body
+; )@for_stmt
+
+(for_statement
+  initializer:(_)@initializer
+  condition:(_)@condition
+  body:(_)@body
+)@for_stmt {
+  ; propagate lexical scope
+  edge @initializer.lexical_scope -> @for_stmt.lexical_scope
+  edge @condition.lexical_scope -> @for_stmt.lexical_scope
+  edge @body.lexical_scope -> @for_stmt.lexical_scope
+
+  ; initializer lexical definition is scoped in loop
+  edge @for_stmt.lexical_scope -> @initializer.lexical_defs
+  attr (@for_stmt.lexical_scope -> @initializer.lexical_defs) precedence = 1
+
+  ; initializer variable definition escapes the loop
+  edge @for_stmt.var_defs -> @initializer.var_defs
+
+  ; body lexical definitions are scoped in loop
+  edge @for_stmt.lexical_scope -> @body.lexical_defs
+  attr (@for_stmt.lexical_scope -> @body.lexical_defs) precedence = 1
+
+  ; body variable definitions escape the loop
+  edge @for_stmt.var_defs -> @body.var_defs
+
+  ; expose return type
+  edge @for_stmt.return_type -> @body.return_type
+}
+
+(for_statement
+  increment:(_)@increment
+)@for_stmt {
+  ; propagate lexical scope
+  edge @increment.lexical_scope -> @for_stmt.lexical_scope
+}
+
+
+
+;; For In / For Of
+
+; for (item in items)
+;   item();
+; for (var item in items || {})
+;   item();
+; for (const {thing} in things)
+;   thing();
+; for (x in a, b, c)
+;   foo();
+; for (x[i] in a) {}
+; for (x.y in a) {}
+; for ([a, b] in c) {}
+; for ((a) in b) {}
+
+; for (a of b) {}
+
+(for_in_statement
+  left:(_)@left
+  right:(_)@right
+  body:(_)@body
+)@for_in_stmt {
+  ; propagate lexical scope
+  edge @left.lexical_scope -> @for_in_stmt.lexical_scope
+  edge @right.lexical_scope -> @for_in_stmt.lexical_scope
+  edge @body.lexical_scope -> @for_in_stmt.lexical_scope
+
+  ; expose return type
+  edge @for_in_stmt.return_type -> @body.return_type
+}
+
+(for_in_statement
+  "var"
+  left:(_)@pat
+)@for_in_stmt {
+  ; variable definition escapes
+  edge @for_in_stmt.var_defs -> @pat.defs
+}
+
+(for_in_statement
+  ["let" "const"]
+  left:(_)@pat
+)@for_in_stmt {
+  ; lexical declaration are locally scoped
+  edge @for_in_stmt.lexical_scope -> @pat.defs
+}
+
+(for_in_statement
+  left:(_)@pat
+  "of"
+  right:(_)@expr
+)@for_in_stmt {
+  node @for_in_stmt.indexable
+
+  ; connect pattern cotype to index of expression
+  edge @pat.cotype -> @for_in_stmt.indexable
+  ;
+  attr (@for_in_stmt.indexable) push_symbol = "[]"
+  edge @for_in_stmt.indexable -> @expr.type
+}
+
+
+
+;; While
+
+; while (a)
+;   b();
+
+; while (a) {
+
+; }
+
+(while_statement
+  condition:(_)@condition
+  body:(_)@body
+)@while_stmt {
+  ; propagate lexical scope
+  edge @condition.lexical_scope -> @while_stmt.lexical_scope
+  edge @body.lexical_scope -> @while_stmt.lexical_scope
+
+  ; lexical definitions escape
+  edge @while_stmt.lexical_defs -> @body.lexical_defs
+
+  ; variable definitions escape
+  edge @while_stmt.var_defs -> @body.var_defs
+
+  ; expose return type
+  edge @while_stmt.return_type -> @body.return_type
+}
+
+
+
+;; Do
+
+; do {
+;   a;
+; } while (b)
+
+; do a; while (b)
+
+; do {} while (b)
+
+(do_statement
+  body:(_)@body
+  condition:(_)@condition
+)@do_stmt {
+  ; propagate lexical scope
+  edge @condition.lexical_scope -> @do_stmt.lexical_scope
+  edge @body.lexical_scope -> @do_stmt.lexical_scope
+
+  ; lexical definitions escape
+  edge @do_stmt.lexical_defs -> @body.lexical_defs
+
+  ; variable definitions escape
+  edge @do_stmt.var_defs -> @body.var_defs
+
+  ; expose return type
+  edge @do_stmt.return_type -> @body.return_type
+}
+
+
+
+;; Try
+
+; try { a; } catch (b) { c; }
+; try { d; } finally { e; }
+; try { f; } catch { g; } finally { h; }
+; try { throw [a, b] } catch ([c, d]) { }
+
+(try_statement
+  body:(_)@body
+)@try_stmt {
+  ; propagate lexical scope
+  edge @body.lexical_scope -> @try_stmt.lexical_scope
+
+  ; lexical definitions escape
+  edge @try_stmt.lexical_defs -> @body.lexical_defs
+
+  ; variable definitions escape
+  edge @try_stmt.var_defs -> @body.var_defs
+
+  ; expose return type
+  edge @try_stmt.return_type -> @body.return_type
+}
+
+(try_statement
+  handler:(_)@handler
+)@try_stmt {
+  ; propagate lexical scope
+  edge @handler.lexical_scope -> @try_stmt.lexical_scope
+
+  ; lexical definitions escape
+  edge @try_stmt.lexical_defs -> @handler.lexical_defs
+
+  ; variable definitions escape
+  edge @try_stmt.var_defs -> @handler.var_defs
+
+  ; expose return type
+  edge @try_stmt.return_type -> @handler.return_type
+}
+
+(try_statement
+  finalizer:(_)@finalizer
+)@try_stmt {
+  ; propagate lexical scope
+  edge @finalizer.lexical_scope -> @try_stmt.lexical_scope
+
+  ; lexical definitions escape
+  edge @try_stmt.lexical_defs -> @finalizer.lexical_defs
+
+  ; variable definitions escape
+  edge @try_stmt.var_defs -> @finalizer.var_defs
+
+  ; expose return type
+  edge @try_stmt.return_type -> @finalizer.return_type
+}
+
+; (catch_clause
+;   parameter:(_)@param ; opt
+;   type:(_)@type       ; opt, and only if parameter is present
+;   body:(_)@body
+; )@catch_clause
+
+(catch_clause type:(_)@type)@catch_clause {
+  ; propagate lexical scope
+  edge @type.lexical_scope -> @catch_clause.lexical_scope
+}
+
+(catch_clause body:(_)@body)@catch_clause {
+  ; propagate lexical scope
+  edge @body.lexical_scope -> @catch_clause.lexical_scope
+
+  ; lexical definitions escape
+  edge @catch_clause.lexical_defs -> @body.lexical_defs
+
+  ; variable definitions escape
+  edge @catch_clause.var_defs -> @body.var_defs
+
+  ; expose return type
+  edge @catch_clause.return_type -> @body.return_type
+}
+
+(finally_clause body:(_)@body)@finally_clause {
+  ; propagate lexical scope
+  edge @body.lexical_scope -> @finally_clause.lexical_scope
+
+  ; lexical definitions escape
+  edge @finally_clause.lexical_defs -> @body.lexical_defs
+
+  ; variable definitions escape
+  edge @finally_clause.var_defs -> @body.var_defs
+
+  ; expose return type
+  edge @finally_clause.return_type -> @body.return_type
+}
+
+
+
+;; With
+
+; with (x) { i; }
+; with (x) { }
+
+(with_statement
+  object:(_)@object
+  body:(_)@body
+)@with_stmt {
+  node @with_stmt.member
+  node @with_stmt.expr_ref__ns
+
+  ; propagate lexical scope
+  edge @object.lexical_scope -> @with_stmt.lexical_scope
+  edge @body.lexical_scope -> @with_stmt.lexical_scope
+
+  ; lexical definitions escape
+  edge @with_stmt.lexical_defs -> @body.lexical_defs
+
+  ; variable definitions escape
+  edge @with_stmt.var_defs -> @body.var_defs
+
+  ; expose return type
+  edge @with_stmt.return_type -> @body.return_type
+
+  ; expression references as member references in object
+  edge @body.lexical_scope -> @with_stmt.expr_ref__ns
+  ;
+  attr (@with_stmt.expr_ref__ns) pop_symbol = "%E"
+  edge @with_stmt.expr_ref__ns -> @with_stmt.member
+  ;
+  attr (@with_stmt.member) push_symbol = "."
+  edge @with_stmt.member -> @object.type
+}
+
+
+
+;; Break
+
+; break;
+
+(break_statement)@break_stmt {
+}
+
+
+
+;; Continue
+
+; continue;
+
+(continue_statement)@continue_stmt {
+}
+
+
+
+;; Return
+
+; return;
+
+(return_statement
+  (_)@returned_expr
+)@return_stmt {
+  ; propagate lexical scope
+  edge @returned_expr.lexical_scope -> @return_stmt.lexical_scope
+
+  ; expose return type
+  edge @return_stmt.return_type -> @returned_expr.type
+}
+
+
+
+;; Throw
+
+; throw new Error("error");
+; throw x = 1, x;
+
+(throw_statement (_)@thrown_expr)@throw_stmt {
+  ; propagate lexical scope
+  edge @thrown_expr.lexical_scope -> @throw_stmt.lexical_scope
+}
+
+
+
+;; Empty
+
+; if (true) { ; };;;
+; if (true) {} else {}
+
+(empty_statement)@empty_stmt {
+}
+
+
+
+;; Labeled
+
+; label:
+; while (true) { }
+
+(statement_identifier)@stmt_identifier {
+  ; FIXME remove when we bump tree-sitter-typescript version
+  node @stmt_identifier.lexical_scope
+  node @stmt_identifier.lexical_defs
+  node @stmt_identifier.var_defs
+  node @stmt_identifier.return_type
+}
+
+; FIXME match body: when we bump tree-sitter-typescript version
+(labeled_statement (_)@inner)@labeled_stmt {
+  ; propagate lexical scope
+  edge @inner.lexical_scope -> @labeled_stmt.lexical_scope
+
+  ; lexical definitions escape
+  edge @labeled_stmt.lexical_defs -> @inner.lexical_defs
+
+  ; variable definitions escape
+  edge @labeled_stmt.var_defs -> @inner.var_defs
+
+  ; expose return type
+  edge @labeled_stmt.return_type -> @inner.return_type
+}
+
+
+
+;; Ambient Declaration
+
+(ambient_declaration
+  (declaration)@decl
+)@amb_decl {
+  ; propagate lexical scope
+  edge @decl.lexical_scope -> @amb_decl.lexical_scope
+
+  ; lexical definitions are for ROOT_NODE
+  edge @amb_decl.lexical_defs -> @decl.lexical_defs
+
+  ; variable definitions are for ROOT_NODE
+  edge @amb_decl.var_defs -> @decl.var_defs
+}
+
+(ambient_declaration
+  "global"
+  (statement_block)@stmt_blk
+)@amb_decl {
+  ; propagate lexical scope
+  edge @stmt_blk.lexical_scope -> @amb_decl.lexical_scope
+
+  ; lexical definitions are for ROOT_NODE
+  edge ROOT_NODE -> @stmt_blk.lexical_defs
+
+  ; variable definitions are for ROOT_NODE
+  edge ROOT_NODE -> @stmt_blk.var_defs
+}
+
+; FIXME what is this? tsc doesn't recognize this syntax
+(ambient_declaration
+  "module"
+  (property_identifier)@prop
+  (_)@type
+)@amb_decl {
+  ; propagate lexical scope
+  edge @type.lexical_scope -> @amb_decl.lexical_scope
+}
+
+
+
+;; (Internal) Module
+
+; (module
+;   name:[(string) (identifier) (nested_identifier)]
+;   body:(_) ; opt
+; ) {}
+
+; (internal_module
+;   name:[(string) (identifier) (nested_identifier)]
+;   body:(_) ; opt
+; ) {}
+
+; NOTE namespaces are modeled as a type and an expression definition, exposing
+;      type and expression members
+
+[
+  ; X
+  (module                                       name:(identifier)@name  @mod)
+  (internal_module                              name:(identifier)@name  @mod)
+  (export_statement "as" "namespace" .               (identifier)@name) @mod
+  (export_statement (namespace_export                (identifier)@name))@mod
+  (import_statement (import_clause (namespace_import (identifier)@name)))@mod
+  (ambient_declaration (module                      name:(string)@name      @mod))
+  ; X._
+  (module                                name:(nested_identifier . (identifier)@name @mod))
+  (internal_module                       name:(nested_identifier . (identifier)@name @mod))
+  ; X._._
+  (module                                name:(nested_identifier . (nested_identifier . (identifier)@name @mod)))
+  (internal_module                       name:(nested_identifier . (nested_identifier . (identifier)@name @mod)))
+  ; X._._._
+  (module                                name:(nested_identifier . (nested_identifier . (nested_identifier . (identifier)@name @mod))))
+  (internal_module                       name:(nested_identifier . (nested_identifier . (nested_identifier . (identifier)@name @mod))))
+  ; X._._._._
+  (module                                name:(nested_identifier . (nested_identifier . (nested_identifier . (nested_identifier . (identifier)@name @mod)))))
+  (internal_module                       name:(nested_identifier . (nested_identifier . (nested_identifier . (nested_identifier . (identifier)@name @mod)))))
+]@mod_decl {
+  node @name.expr_def
+  node @name.expr_def__ns
+  node @name.expr_def__typeof
+  node @mod.expr_member
+  node @mod.expr_member__ns
+  node @name.type_def
+  node @name.type_def__ns
+  node @mod.type_member
+  node @mod.type_member__ns
+
+  ; expose expression definition
+  edge @mod_decl.lexical_defs -> @name.expr_def__ns
+
+  ; expression definition
+  attr (@name.expr_def__ns) pop_symbol = "%E"
+  edge @name.expr_def__ns -> @name.expr_def
+  ;
+  attr (@name.expr_def) node_definition = @name
+
+  ; namespaces mimic objects with members to access exported expressions
+  edge @name.expr_def -> @name.expr_def__typeof
+  ;
+  attr (@name.expr_def__typeof) pop_symbol = ":"
+  edge @name.expr_def__typeof -> @mod.expr_member
+  ;
+  attr (@mod.expr_member) pop_symbol = "."
+  edge @mod.expr_member -> @mod.expr_member__ns
+  ;
+  attr (@mod.expr_member__ns) push_symbol = "%E"
+
+  ; expose type definition
+  edge @mod_decl.lexical_defs -> @name.type_def__ns
+
+  ; type definition
+  attr (@name.type_def__ns) pop_symbol = "%T"
+  edge @name.type_def__ns -> @name.type_def
+  ;
+  attr (@name.type_def) node_definition = @name
+
+  ; namespaces mimic types with member types to access exported expressions
+  edge @name.type_def -> @mod.type_member
+  ;
+  attr (@mod.type_member) pop_symbol = "."
+  edge @mod.type_member -> @mod.type_member__ns
+  ;
+  attr (@mod.type_member__ns) push_symbol = "%T"
+}
+
+[
+  ; _.X
+  (module                                name:(nested_identifier . (_)@basemod . (identifier)@name)@mod)
+  (internal_module                       name:(nested_identifier . (_)@basemod . (identifier)@name)@mod)
+  ; _._.X
+  (module                                name:(nested_identifier . (nested_identifier . (_)@basemod . (identifier)@name)@mod))
+  (internal_module                       name:(nested_identifier . (nested_identifier . (_)@basemod . (identifier)@name)@mod))
+  ; _._._.X
+  (module                                name:(nested_identifier . (nested_identifier . (nested_identifier . (_)@basemod . (identifier)@name)@mod)))
+  (internal_module                       name:(nested_identifier . (nested_identifier . (nested_identifier . (_)@basemod . (identifier)@name)@mod)))
+  ; _._._._.X
+  (module                                name:(nested_identifier . (nested_identifier . (nested_identifier . (nested_identifier . (_)@basemod . (identifier)@name)@mod))))
+  (internal_module                       name:(nested_identifier . (nested_identifier . (nested_identifier . (nested_identifier . (_)@basemod . (identifier)@name)@mod))))
+] {
+  node @name.expr_def
+  node @name.expr_def__ns
+  node @name.expr_def__typeof
+  node @mod.expr_member
+  node @mod.expr_member__ns
+  node @name.type_def
+  node @name.type_def__ns
+  node @mod.type_member
+  node @mod.type_member__ns
+
+  ; expose expression definition
+  edge @basemod.expr_member__ns -> @name.expr_def__ns
+
+  ; expression definition
+  attr (@name.expr_def__ns) pop_symbol = "%E"
+  edge @name.expr_def__ns -> @name.expr_def
+  ;
+  attr (@name.expr_def) node_definition = @name
+
+  ; namespaces mimic objects with members to access exported expressions
+  edge @name.expr_def -> @name.expr_def__typeof
+  ;
+  attr (@name.expr_def__typeof) pop_symbol = ":"
+  edge @name.expr_def__typeof -> @mod.expr_member
+  ;
+  attr (@mod.expr_member) pop_symbol = "."
+  edge @mod.expr_member -> @mod.expr_member__ns
+  ;
+  attr (@mod.expr_member__ns) push_symbol = "%E"
+
+  ; expose type definition
+  edge @basemod.type_member__ns -> @name.type_def__ns
+
+  ; type definition
+  attr (@name.type_def__ns) pop_symbol = "%T"
+  edge @name.type_def__ns -> @name.type_def
+  ;
+  attr (@name.type_def) node_definition = @name
+
+  ; namespaces mimic types with member types to access exported expressions
+  edge @name.type_def -> @mod.type_member
+  ;
+  attr (@mod.type_member) pop_symbol = "."
+  edge @mod.type_member -> @mod.type_member__ns
+  ;
+  attr (@mod.type_member__ns) push_symbol = "%T"
+}
+
+[
+  (module                                name:(_)@mod body:(_)@body)
+  (internal_module                       name:(_)@mod body:(_)@body)
+]@mod_decl {
+  ; propagate lexical scope
+  edge @body.lexical_scope -> @mod_decl.lexical_scope
+
+  ; connect object to exports
+  edge @mod.expr_member__ns -> @body.exports
+
+  ; connect type to exports
+  edge @mod.type_member__ns -> @body.exports
+}
+
+; NOTE internal_module is also an expression in the grammar, not only a statement.
+;      Not entirely sure why... tsc doesn't seem to accept namespaces in arbitrary
+;      expression positions. Therefore we forward relevant nodes here.
+
+(expression_statement (internal_module)@mod_decl)@stmt {
+  ; connect lexical definitions
+  edge @stmt.lexical_defs -> @mod_decl.lexical_defs
+}
+
+
+
+;; Ambient Module
+
+(ambient_declaration
+  (module name:(string)@name body:(_)@body)
+)@amb_decl {
+  node @name.mod_def
+  node @name.mod_def__ns
+
+  ; propagate lexical scope
+  edge @body.lexical_scope -> @amb_decl.lexical_scope
+
+  ; global definition
+  edge ROOT_NODE -> @name.mod_def__ns
+  ;
+  attr (@name.mod_def__ns) pop_symbol = "%M"
+  edge @name.mod_def__ns -> @name.mod_def
+  ;
+  attr (@name.mod_def) symbol_definition = (replace (source-text @name) "[\"\']" ""), source_node = @name
+
+  ; exports are reachable via module definition
+  edge @name.mod_def -> @body.exports
+}
+
+
+
+;; Enum Declaration
+
+; (enum_declaration
+;   name:(_)
+;   body:(_)
+; ) {}
+
+(enum_declaration
+  name:(_)@name
+  body:(_)@body
+)@enum_decl {
+  node @enum_decl.static_type
+  node @enum_decl.expr_export
+  node @enum_decl.expr_export__ns
+  node @enum_decl.type
+  node @name.expr_def
+  node @name.expr_def__ns
+  node @name.expr_def__typeof
+  node @name.type_def
+  node @name.type_def__ns
+
+  ; propagate lexical scope
+  edge @body.lexical_scope -> @enum_decl.lexical_scope
+
+  ; enum expression declaration
+  edge @enum_decl.lexical_defs -> @name.expr_def__ns
+  ;
+  attr (@name.expr_def__ns) pop_symbol = "%E"
+  edge @name.expr_def__ns -> @name.expr_def
+  ;
+  attr (@name.expr_def) node_definition = @name
+
+  ; type of enum expression is members
+  edge @name.expr_def -> @name.expr_def__typeof
+  ;
+  attr (@name.expr_def__typeof) pop_symbol = ":"
+  edge @name.expr_def__typeof -> @enum_decl.static_type
+  ;
+  edge @enum_decl.static_type -> @body.static_members
+
+  ; default expression export
+  edge @enum_decl.default_export -> @enum_decl.expr_export
+  ;
+  attr (@enum_decl.expr_export) pop_symbol = "%E"
+  edge @enum_decl.expr_export -> @body.static_members
+
+  ; enum type declaration
+  edge @enum_decl.lexical_defs -> @name.type_def__ns
+  ;
+  attr (@name.type_def__ns) pop_symbol = "%T"
+  edge @name.type_def__ns -> @name.type_def
+  ;
+  attr (@name.type_def) node_definition = @name
+  edge @name.type_def -> @enum_decl.type
+  ;
+  edge @enum_decl.type -> @body.type_members
+
+  ; NOTE enum_declaration cannot appear directly in `export default'
+  ;      statements, so we do not set .default_export
+
+  ; this is the enum type
+  edge @body.this -> @enum_decl.type
+
+  ; mark type scope as endpoint
+  attr (@enum_decl.type) is_endpoint
+  attr (@enum_decl.static_type) is_endpoint
+}
+
+; (enum_body
+;   (_) ; _property_name | enum_assignment ; opt, sepBy1
+; ) {}
+
+(enum_body)@body {
+  node @body.lexical_scope
+  node @body.static_members
+  node @body.this
+  node @body.type_members
+}
+
+(enum_body
+  [
+    name:(_)@name
+    (enum_assignment name:(_)@name)
+  ]@constant
+)@body {
+  node @constant.member
+  node @name.expr_def
+  node @name.expr_def__typeof
+
+  ; property definition
+  edge @body.static_members -> @constant.member
+  ;
+  attr (@constant.member) pop_symbol = "."
+  edge @constant.member -> @name.expr_def
+  ;
+  attr (@name.expr_def) symbol_definition = (replace (source-text @name) "[\"\']" ""), source_node = @name
+
+  ; type of the constant
+  edge @name.expr_def -> @name.expr_def__typeof
+  ;
+  attr (@name.expr_def__typeof) pop_symbol = ":"
+  edge @name.expr_def__typeof -> @body.this
+}
+
+; (enum_assignment
+;   (_)@property_name
+;   value:(_)
+; ) {}
+
+(enum_body
+  (enum_assignment value:(_)@value)
+)@body {
+  ; propagate lexical scope
+  edge @value.lexical_scope -> @body.lexical_scope
+}
+
+
+
+;; Type Alias Declaration
+
+; (type_alias_declaration
+;   name:(_)@name
+;   type_parameters:(_)@type_params ; opt
+;   value:(_)@value
+; )@decl
+
+(type_alias_declaration
+  name:(_)@name
+  value:(_)@value
+)@decl {
+  node @name.type_def
+  node @name.type_def__ns
+
+  ; propagate lexical scope
+  edge @value.lexical_scope -> @decl.generic_inner_lexical_scope
+
+  ; type definition
+  edge @decl.lexical_defs -> @name.type_def__ns
+  ;
+  attr (@name.type_def__ns) pop_symbol = "%T"
+  edge @name.type_def__ns -> @name.type_def
+  ;
+  attr (@name.type_def) node_definition = @name
+  edge @name.type_def -> @decl.generic_type
+  ;
+  ; type parameters are handled by generics rules below
+  ;
+  edge @decl.generic_inner_type -> @decl.alias_type
+  ;
+  ; alias guards are handled by alias rules below
+  ;
+  edge @decl.aliased_type -> @value.type
+
+  ; NOTE type_alias_declaration cannot appear directly in `export default'
+  ;      statements, so we do not set .default_export
+}
+
+
+
+; #######
+; #       #    # #####  #####  ######  ####   ####  #  ####  #    #  ####
+; #        #  #  #    # #    # #      #      #      # #    # ##   # #
+; #####     ##   #    # #    # #####   ####   ####  # #    # # #  #  ####
+; #         ##   #####  #####  #           #      # # #    # #  # #      #
+; #        #  #  #      #   #  #      #    # #    # # #    # #   ## #    #
+; ####### #    # #      #    # ######  ####   ####  #  ####  #    #  ####
+;
+; ########################################################################
+
+;; Attributes defined on expressions
+;
+; in .lexical_scope
+;     Scope to resolve type names.
+;
+; out .type
+;     Scope representing the type of the expression.
+
+[
+  (array)
+  (arrow_function)
+  (as_expression)
+  (assignment_expression)
+  (augmented_assignment_expression)
+  (await_expression)
+  (binary_expression)
+  (call_expression)
+  (class)
+  (false)
+  (function)
+  (generator_function)
+  (import)
+  (member_expression)
+  (meta_property)
+  (new_expression)
+  (non_null_expression)
+  (null)
+  (number)
+  (object)
+  (parenthesized_expression)
+  (regex)
+  (sequence_expression)
+  (spread_element)
+  (string)
+  (subscript_expression)
+  (super)
+  (template_string)
+  (ternary_expression)
+  (this)
+  (true)
+  (type_assertion)
+  (unary_expression)
+  (undefined)
+  (update_expression)
+  (yield_expression)
+]@expr {
+  node @expr.cotype
+  node @expr.lexical_defs
+  node @expr.lexical_scope
+  node @expr.return_type
+  node @expr.type
+  node @expr.var_defs
+}
+
+[
+  (abstract_class_declaration name:(_)@name)
+  (class_declaration          name:(_)@name)
+  (property_signature         name:(_)@name)
+  (public_field_definition    name:(_)@name)
+  (method_signature           name:(_)@name)
+  (abstract_method_signature  name:(_)@name)
+  (method_definition          name:(_)@name)
+] {
+  node @name.expr_def
+  node @name.expr_def__ns
+  node @name.expr_def__typeof
+}
+
+;; Parenthesized
+
+; (parenthesized_expression
+;   (expression)@expr
+;   (type_annotation)@type ; opt
+; )@parens_expr
+; (parenthesized_expression
+;   (sequence_expression)@seq_expr
+; )@parens_expr
+
+(parenthesized_expression
+  [(expression) (sequence_expression)]@expr
+)@parens_expr {
+  ; propagate lexical scope
+  edge @expr.lexical_scope -> @parens_expr.lexical_scope
+}
+
+(parenthesized_expression
+  [(expression) (sequence_expression)]@expr
+  !type
+)@parens_expr {
+  ; type is type of the inner expression
+  edge @parens_expr.type -> @expr.type
+}
+
+(parenthesized_expression
+  type:(_)@type ; opt
+)@parens_expr {
+  ; propagate lexical scope
+  edge @type.lexical_scope -> @parens_expr.lexical_scope
+
+  ; type is type of the annotation
+  edge @parens_expr.type -> @type.type
+}
+
+
+
+;; Strings
+
+; "A double quoted string.";
+; 'A single quoted string.';
+
+(string)@string {
+}
+
+
+;; Template Strings
+
+; `A template string ${ "with another string" } inside of it.`;
+
+; (template_string)@template_string
+; (template_string (template_substitution (_)@inner_expr))@template_string
+
+(template_string
+  (template_substitution (_)@inner_expr)
+)@template_string {
+  ; propagate lexical scope
+  edge @inner_expr.lexical_scope -> @template_string.lexical_scope
+}
+
+
+
+;; Numbers
+
+; 12345;
+
+(number)@number {
+}
+
+
+;; Variables
+
+; x;
+
+[
+  (primary_expression/identifier)@name
+  ; FIXME expansion of _lhs_expression/identifier and _augmented_assignment_lhs
+  (for_in_statement ["var" "let" "const"]?@is_def left:(identifier)@name)
+  (assignment_expression left:(identifier)@name)
+  (augmented_assignment_expression left:(identifier)@name)
+  ; FIXME type_query has its own restricted expression production
+  ;       we need to do this for every (identifier) inside a type query
+  ;       this cannot be expressed, so we manually unroll three levels here
+  (type_query (identifier)@name)
+  (type_query (member_expression object:(identifier)@name))
+  (type_query (member_expression object:(member_expression object:(identifier)@name)))
+  (type_query (member_expression object:(member_expression object:(member_expression object:(identifier)@name))))
+  (type_query (subscript_expression object:(identifier)@name))
+  (type_query (subscript_expression object:(member_expression object:(identifier)@name)))
+  (type_query (subscript_expression object:(member_expression object:(member_expression object:(identifier)@name))))
+  (type_query (call_expression function:(identifier)@name))
+  (type_query (call_expression function:(member_expression object:(identifier)@name)))
+  (type_query (call_expression function:(member_expression object:(member_expression object:(identifier)@name))))
+  (type_query (call_expression function:(member_expression object:(member_expression object:(member_expression object:(identifier)@name)))))
+  (type_query (call_expression function:(subscript_expression object:(identifier)@name)))
+  (type_query (call_expression function:(subscript_expression object:(member_expression object:(identifier)@name))))
+  (type_query (call_expression function:(subscript_expression object:(member_expression object:(member_expression object:(identifier)@name)))))
+  ; FIXME decorator has its own restricted expression production
+  ;       we need to do this for every (identifier) inside a decorator
+  ;       this cannot be expressed, so we manually unroll three levels here
+  (decorator (identifier)@name)
+  (decorator (member_expression object:(identifier)@name))
+  (decorator (member_expression object:(member_expression object:(identifier)@name)))
+  (decorator (member_expression object:(member_expression object:(member_expression object:(identifier)@name))))
+  (decorator (call_expression function:(identifier)@name))
+  (decorator (call_expression function:(member_expression object:(identifier)@name)))
+  (decorator (call_expression function:(member_expression object:(member_expression object:(identifier)@name))))
+  (decorator (call_expression function:(member_expression object:(member_expression object:(member_expression object:(identifier)@name)))))
+] {
+if none @is_def {
+  node @name.cotype
+  node @name.lexical_defs
+  node @name.lexical_scope
+  node @name.type
+  node @name.var_defs
+}
+}
+
+[
+  (primary_expression/identifier)@name
+  (decorator (identifier)@name)
+  ; FIXME expansion of _lhs_expression/identifier and _augmented_assignment_lhs
+  ;       we need to do this for every (identifier) inside a type query
+  ;       this cannot be expressed, so we manually unroll three levels here
+  (for_in_statement ["var" "let" "const"]?@is_def left:(identifier)@name)
+  (assignment_expression left:(identifier)@name)
+  (augmented_assignment_expression left:(identifier)@name)
+  ; FIXME type_query has its own restricted expression production
+  (type_query (identifier)@name)
+  (type_query (member_expression object:(identifier)@name))
+  (type_query (member_expression object:(member_expression object:(identifier)@name)))
+  (type_query (member_expression object:(member_expression object:(member_expression object:(identifier)@name))))
+  (type_query (subscript_expression object:(identifier)@name))
+  (type_query (subscript_expression object:(member_expression object:(identifier)@name)))
+  (type_query (subscript_expression object:(member_expression object:(member_expression object:(identifier)@name))))
+  (type_query (call_expression function:(identifier)@name))
+  (type_query (call_expression function:(member_expression object:(identifier)@name)))
+  (type_query (call_expression function:(member_expression object:(member_expression object:(identifier)@name))))
+  (type_query (call_expression function:(member_expression object:(member_expression object:(member_expression object:(identifier)@name)))))
+  (type_query (call_expression function:(subscript_expression object:(identifier)@name)))
+  (type_query (call_expression function:(subscript_expression object:(member_expression object:(identifier)@name))))
+  (type_query (call_expression function:(subscript_expression object:(member_expression object:(member_expression object:(identifier)@name)))))
+  ; FIXME decorator has its own restricted expression production
+  ;       we need to do this for every (identifier) inside a decorator
+  ;       this cannot be expressed, so we manually unroll three levels here
+  (decorator                           (identifier)@name)
+  (decorator (member_expression object:(identifier)@name))
+  (decorator (member_expression object:(member_expression object:(identifier)@name)))
+  (decorator (member_expression object:(member_expression object:(member_expression object:(identifier)@name))))
+  (decorator (call_expression function:(identifier)@name))
+  (decorator (call_expression function:(member_expression object:(identifier)@name)))
+  (decorator (call_expression function:(member_expression object:(member_expression object:(identifier)@name))))
+  (decorator (call_expression function:(member_expression object:(member_expression object:(member_expression object:(identifier)@name)))))
+] {
+if none @is_def {
+  node @name.expr_ref
+  node @name.expr_ref__ns
+  node @name.expr_ref__typeof
+
+  ; expression reference
+  attr (@name.expr_ref) node_reference = @name
+  edge @name.expr_ref -> @name.expr_ref__ns
+  ;
+  attr (@name.expr_ref__ns) push_symbol = "%E"
+  edge @name.expr_ref__ns -> @name.lexical_scope
+
+  ; type is type of the reference
+  edge @name.type -> @name.expr_ref__typeof
+  ;
+  attr (@name.expr_ref__typeof) push_symbol = ":"
+  edge @name.expr_ref__typeof -> @name.expr_ref
+}
+}
+
+
+
+;; Meta property
+
+; new.target
+
+(meta_property)@new_target {
+}
+
+
+
+;; Booleans and other special values
+
+;; true;
+
+(true)@true {
+}
+
+;; false;
+
+(false)@false {
+}
+
+
+
+;; this;
+
+(this)@this {
+  node @this.expr_ref
+  node @this.expr_ref__ns
+  node @this.expr_ref__typeof
+
+  ; expression reference
+  attr (@this.expr_ref) symbol_reference = "this", source_node = @this
+  edge @this.expr_ref -> @this.expr_ref__ns
+  ;
+  attr (@this.expr_ref__ns) push_symbol = "%E"
+  edge @this.expr_ref__ns -> @this.lexical_scope
+
+  ; type is type of the reference
+  edge @this.type -> @this.expr_ref__typeof
+  ;
+  attr (@this.expr_ref__typeof) push_symbol = ":"
+  edge @this.expr_ref__typeof -> @this.expr_ref
+}
+
+
+
+;; super
+
+(super)@super {
+}
+
+
+
+; null;
+(null)@null {
+}
+
+
+
+; undefined;
+(undefined)@undefined {
+}
+
+
+
+;; Regular Expressions
+
+; /foo/;
+; /bar/g;
+
+; i dont think the specifics of the patterns or flags matter
+; (regex (regex_pattern))
+; (regex (regex_pattern) (regex_flags))
+
+(regex)@regex {
+}
+
+
+
+;; Spread Element
+
+(spread_element (_)@expr)@spread_elem {
+  ; propagate lexical scope
+  edge @expr.lexical_scope -> @spread_elem.lexical_scope
+}
+
+
+
+;; Objects
+
+; {
+;   foo: "bar",
+;   "baz": 1,
+;   quux(x) { x; }
+; };
+;
+; { foo, bar };
+
+; (object
+;   (pair (property_identifier) (string))
+;   (pair (string) (number))
+;   (method_definition
+;     (property_identifier)
+;     (formal_parameters)
+;     (statement_block)))
+;
+; (object
+;   (shorthand_property_identifier)
+;   (shorthand_property_identifier))
+
+; (object (pair (_) (_)@rhs))@object
+; (object (spread_element)@element)@object
+
+(object)@object_expr {
+  attr (@object_expr.type) is_endpoint
+}
+
+(object (_)@entry)@object_expr {
+  ; propagate lexical scope
+  edge @entry.lexical_scope -> @object_expr.lexical_scope
+
+  ; type of object are its members
+  edge @object_expr.type -> @entry.type_members
+}
+
+(object (shorthand_property_identifier)@name) {
+  node @name.lexical_scope
+  node @name.member
+  node @name.type_members
+  node @name.expr_def
+  node @name.expr_def__typeof
+  node @name.expr_ref
+  node @name.expr_ref__ns
+  node @name.expr_ref__typeof
+
+  ; property definition
+  edge @name.type_members -> @name.member
+  ;
+  attr (@name.member) pop_symbol = "."
+  edge @name.member -> @name.expr_def
+  ;
+  attr (@name.expr_def) symbol_definition = (replace (source-text @name) "[\"\']" ""), source_node = @name
+
+  ; type of the property is type of the reference
+  edge @name.expr_def -> @name.expr_def__typeof
+  ;
+  attr (@name.expr_def__typeof) pop_symbol = ":"
+  edge @name.expr_def__typeof -> @name.expr_ref__typeof
+
+  ; expression reference
+  attr (@name.expr_ref) node_reference = @name
+  edge @name.expr_ref -> @name.expr_ref__ns
+  ;
+  attr (@name.expr_ref__ns) push_symbol = "%E"
+  edge @name.expr_ref__ns -> @name.lexical_scope
+
+  ; type of the reference is type of the declaration
+  attr (@name.expr_ref__typeof) push_symbol = ":"
+  edge @name.expr_ref__typeof -> @name.expr_ref
+}
+
+(pair
+  key:(_)@name
+  value:(_)@expr
+)@pair {
+  node @pair.lexical_scope
+  node @pair.member
+  node @pair.type_members
+  node @name.expr_def
+  node @name.expr_def__ns
+  node @name.expr_def__typeof
+
+  ; propagate lexical scope
+  edge @expr.lexical_scope -> @pair.lexical_scope
+
+  ; property definition
+  edge @pair.type_members -> @pair.member
+  ;
+  attr (@pair.member) pop_symbol = "."
+  edge @pair.member -> @name.expr_def
+  ;
+  attr (@name.expr_def) symbol_definition = (replace (source-text @name) "[\"\']" ""), source_node = @name
+
+  ; type of the property is type of the expression
+  edge @name.expr_def -> @name.expr_def__typeof
+  ;
+  attr (@name.expr_def__typeof) pop_symbol = ":"
+  edge @name.expr_def__typeof -> @expr.type
+}
+
+(spread_element)@spread_elem {
+  node @spread_elem.member
+  node @spread_elem.type_members
+}
+
+
+;; Arrays
+
+; [1,2,3];
+
+; (array (number) (number) (number))
+; (array (_expression)@element)@array
+
+(array)@array_expr {
+  node @array_expr.indexable
+
+  ; array is indexable
+  edge @array_expr.type -> @array_expr.indexable
+  ;
+  attr (@array_expr.indexable) pop_symbol = "[]"
+}
+
+(array (_)@element)@array_expr {
+  ; propagate lexical scope
+  edge @element.lexical_scope -> @array_expr.lexical_scope
+
+  ; type is the union of element types
+  edge @array_expr.indexable -> @element.type
+}
+
+
+
+;; Formal Parameters
+
+(formal_parameters)@formal_params {
+  node @formal_params.coparams
+  node @formal_params.defs
+  node @formal_params.lexical_scope
+  node @formal_params.params
+}
+
+(formal_parameters
+  (_)@param
+)@formal_params
+{
+  ; propagate lexical scope
+  edge @param.lexical_scope -> @formal_params.lexical_scope
+
+  ; collect param definitions
+  edge @formal_params.defs -> @param.defs
+
+  ; collect parameters for type
+  edge @formal_params.params -> @param.param
+
+  ; coparams for parameter type inference
+  edge @param.coparam -> @formal_params.coparams
+}
+
+
+
+;; Required & Optional Parameter
+
+; (required_parameter
+;   [(pattern) (this)]
+;   (type_annotation) ; opt
+;   value:(_) ; opt
+; )
+;
+; (optional_parameter
+;   [(pattern) (this)]
+;   (type_annotation) ; opt
+;   value:(_) ; opt
+; )
+
+[
+  (required_parameter)
+  (optional_parameter)
+]@param {
+  node @param.coparam
+  node @param.defs
+  node @param.lexical_scope
+  node @param.param
+}
+
+[
+  (required_parameter pattern:(_)@pattern)
+  (optional_parameter pattern:(_)@pattern)
+]@param {
+  ; propagate lexical scope
+  edge @pattern.lexical_scope -> @param.lexical_scope
+
+  ; expose parameter for type
+  attr (@param.param) pop_symbol = (named-child-index @param)
+
+  ; co-parameter for type inference
+  attr (@param.coparam) push_symbol = (named-child-index @param)
+
+  ; expose definitions
+  edge @param.defs -> @pattern.defs
+}
+
+[
+  (required_parameter pattern:(_)@pattern type:(_)@type)
+  (optional_parameter pattern:(_)@pattern type:(_)@type)
+]@param {
+  ; propagate lexical scope
+  edge @type.lexical_scope -> @param.lexical_scope
+
+  ; connect parameter to type annotation
+  edge @param.param -> @type.type
+
+  ; connect pattern to type annotation
+  edge @pattern.cotype -> @type.type
+}
+
+[
+  (required_parameter pattern:(_)@pattern !type)
+  (optional_parameter pattern:(_)@pattern !type)
+]@param {
+  ; connect parameter to coparameter
+  edge @param.param -> @param.coparam
+
+  ; connect pattern to coparameter
+  edge @pattern.cotype -> @param.coparam
+}
+
+[
+  (required_parameter value:(_)@value)
+  (optional_parameter value:(_)@value)
+]@param {
+  ; propagate lexical scope
+  edge @value.lexical_scope -> @param.lexical_scope
+}
+
+
+
+;; Arrow / Generator / Function Literals
+
+; function (x) {};
+
+; (function
+;   (formal_parameters (identifier))
+;   (statement_block))
+
+; this captures the parameters
+; (function
+;   parameters: (_)@params)
+
+; this captures the body
+; (function
+;   body:(_)@body)@function
+
+; functions with names
+; (function
+;   name:(_)@name
+;   parameters:(_)@call_sig)@fun {
+; }
+
+; x => x;
+; (x) => x;
+; () => {};
+
+; (arrow_function
+;   [ parameter:(identifier)@param parameters:(_)@params ]
+;   body:[(expression) (statement_block)]@body
+; )
+
+; function *() {};
+
+; (generator_function
+;   (formal_parameters)
+;   (statement_block))
+
+; this captures the parameters
+; (generator_function
+;   parameters:(_)@params)
+
+; this captures the body
+; (generator_function
+;   body:(_)@body)@function
+
+; generator functions with names
+; (generator_function
+;   name:(_)@name
+;   parameters:(_)@call_sig)@fun {
+; }
+
+[
+  (function)
+  (arrow_function)
+  (generator_function)
+]@fun {
+  node @fun.callable
+  node @fun.callable__params
+  node @fun.callable__return
+  node @fun.cocallable
+  node @fun.cocallable__params
+
+  ; type is callable
+  edge @fun.type -> @fun.callable
+  ;
+  attr (@fun.callable) pop_symbol = "->"
+  edge @fun.callable -> @fun.callable__params
+  edge @fun.callable -> @fun.callable__return
+  ;
+  attr (@fun.callable__return) pop_symbol = "<return>"
+
+  ; cotype should also be callable
+  edge @fun.cocallable__params -> @fun.cocallable
+  ;
+  attr (@fun.cocallable) push_symbol = "->"
+  edge @fun.cocallable -> @fun.cotype
+}
+
+[
+  (function           parameters:(_)@call_sig)
+  (arrow_function     parameters:(_)@call_sig)
+  (generator_function parameters:(_)@call_sig)
+]@fun {
+  ; propagate lexical scope
+  edge @call_sig.lexical_scope -> @fun.lexical_scope
+
+  ; parameters are visible in body
+  edge @fun.lexical_scope -> @call_sig.defs
+  attr (@fun.lexical_scope -> @call_sig.defs) precedence = 1
+
+  ; connect parameters
+  edge @fun.callable__params -> @call_sig.params
+
+  ; parameter types inferred via cotype
+  edge @call_sig.coparams -> @fun.cocallable__params
+}
+
+(arrow_function parameter:(_)@name)@fun {
+  node @name.expr_def
+  node @name.expr_def__ns
+  node @name.expr_def__typeof
+  node @name.param
+  node @name.coparam
+
+  ; expression definition
+  attr (@name.expr_def__ns) pop_symbol = "%E"
+  edge @name.expr_def__ns -> @name.expr_def
+  ;
+  attr (@name.expr_def) node_definition = @name
+
+  ; parameter definition is visible in body
+  edge @fun.lexical_scope -> @name.expr_def__ns
+
+  ; parameter type is inferred via coparam
+  edge @fun.callable__params -> @name.param
+  ;
+  attr (@name.param) pop_symbol = 0
+  edge @name.param -> @name.coparam
+
+  ; parameter type inferred via cotype
+  edge @name.expr_def -> @name.expr_def__typeof
+  ;
+  attr (@name.expr_def__typeof) pop_symbol = ":"
+  edge @name.expr_def__typeof -> @name.coparam
+  ;
+  attr (@name.coparam) push_symbol = 0
+  edge @name.coparam -> @fun.cocallable__params
+}
+
+[
+  (function           body:(_)@body)
+  (arrow_function     body:(_)@body)
+  (generator_function body:(_)@body)
+]@fun {
+  ; propagate lexical scope
+  edge @body.lexical_scope -> @fun.lexical_scope
+}
+
+;;;; specified return type
+
+[
+  (function return_type:(_)@return_type)
+  (arrow_function return_type:(_)@return_type)
+]@fun {
+  ; propagate lexical scope
+  edge @return_type.lexical_scope -> @fun.lexical_scope
+
+  ; callable type is return type
+  edge @fun.callable__return -> @return_type.type
+}
+
+;;;; inferred return type
+
+[
+  (function       "async"?@is_async !return_type body:(_)@body)
+  (arrow_function "async"?@is_async !return_type body:(statement_block)@body)
+]@fun {
+if none @is_async {
+  ; callable is type of return statement
+  edge @fun.callable__return -> @body.return_type
+}
+}
+
+(arrow_function "async"?@is_async body:(expression)@expr)@fun {
+if none @is_async {
+  ; callable return type is type of body
+  edge @fun.callable__return -> @expr.type
+}
+}
+
+;;;; inferred async return type
+
+[
+  (function       "async" !return_type body:(_)@body)
+  (arrow_function "async"              body:(statement_block)@body)
+]@fun_decl {
+  ; function returns body return type
+  edge @fun_decl.callable__return -> @fun_decl.async_type
+  ;
+  edge @fun_decl.await_type -> @body.return_type
+}
+
+(arrow_function "async" body:(expression)@expr)@fun_decl {
+  ; function returns body return type
+  edge @fun_decl.callable__return -> @fun_decl.async_type
+  ;
+  edge @fun_decl.await_type -> @expr.type
+}
+
+
+
+;; Function Calls
+
+; foo(1,2,3);
+
+; (call_expression
+;   (identifier)
+;   (arguments
+;     (number)
+;     (number)
+;     (number)))
+
+; (call_expression
+;   function:(_)
+;   type_arguments:(_) ; opt
+;   arguments:(_)
+; )
+
+; this gets the function
+; (call_expression
+;   function: (_)@function)@call
+
+; this gets the expression arguments
+; (call_expression
+;   arguments: (_expression)@argument)@call
+
+; this gets the spread arguments
+; (call_expression
+;   arguments: (spread_element)@spread)@call
+
+(call_expression
+  function:(_)@fun
+)@call_expr {
+  node @call_expr.callable
+  node @call_expr.callable__params
+  node @call_expr.callable__return
+
+  ; propagate lexical scope
+  edge @fun.lexical_scope -> @call_expr.lexical_scope
+
+  ; type of call is type applied callable
+  edge @call_expr.type ->  @call_expr.callable__return
+  ;
+  attr (@call_expr.callable__return) push_symbol = "<return>"
+  edge @call_expr.callable__return -> @call_expr.applied_type
+  ;
+  edge @call_expr.generic_type -> @call_expr.callable
+  ;
+  attr (@call_expr.callable) push_symbol = "->"
+  edge @call_expr.callable -> @fun.type
+}
+
+; type application is handled by the generics rules below
+
+(call_expression
+  function:(_)@fun arguments: (_)@args
+)@call_expr {
+  ; propagate lexical scope
+  edge @args.lexical_scope -> @call_expr.lexical_scope
+}
+
+(call_expression
+  function:(_)@fun arguments: (arguments)@args
+)@call_expr {
+  ; connect cotype to function params
+  edge @args.coargs -> @call_expr.callable__params ;; FIXME
+  ;
+  edge @call_expr.callable__params -> @call_expr.applied_type
+}
+
+
+
+;; Arguments
+
+(arguments)@args {
+  node @args.lexical_scope
+  node @args.coargs
+}
+
+(arguments (_)@arg)@args {
+  node @arg.coarg
+
+  ; propagate lexical scope
+  edge @arg.lexical_scope -> @args.lexical_scope
+
+  ; connect cotype
+  edge @arg.cotype -> @arg.coarg
+  ;
+  attr (@arg.coarg) push_symbol = (named-child-index @arg)
+  edge @arg.coarg -> @args.coargs
+}
+
+
+
+;; Property Access
+
+; foo.bar;
+; foo["bar"];
+
+; (member_expression (identifier) (property_identifier))
+; (subscript_expression (identifier) (string))
+
+(member_expression
+  object: (_)@object
+  property: (_)@prop
+)@member_expr {
+  node @member_expr.member
+  node @prop.expr_ref
+  node @prop.expr_ref__typeof
+
+  ; propagate lexical scope
+  edge @object.lexical_scope -> @member_expr.lexical_scope
+
+  ; reference to property
+  attr (@prop.expr_ref) node_reference = @prop
+  edge @prop.expr_ref -> @member_expr.member
+  ;
+  attr (@member_expr.member) push_symbol = "."
+  edge @member_expr.member -> @object.type
+
+  ; type is type of property
+  edge @member_expr.type -> @prop.expr_ref__typeof
+  ;
+  attr (@prop.expr_ref__typeof) push_symbol = ":"
+  edge @prop.expr_ref__typeof -> @prop.expr_ref
+}
+
+
+(subscript_expression
+  object: (_)@object
+  index: (_)@index
+)@subscript_expr {
+  ; propagate lexical scope
+  edge @object.lexical_scope -> @subscript_expr.lexical_scope
+  edge @index.lexical_scope -> @subscript_expr.lexical_scope
+}
+
+(subscript_expression
+  object: (_)@object
+  index: (string)@index
+)@subscript_expr {
+  node @index.expr_ref
+  node @index.expr_ref__typeof
+  node @subscript_expr.member
+
+  ; reference to index
+  attr (@index.expr_ref) symbol_reference = (replace (source-text @index) "[\"\']" ""), source_node = @index
+  edge @index.expr_ref -> @subscript_expr.member
+  ;
+  attr (@subscript_expr.member) push_symbol = "."
+  edge @subscript_expr.member -> @object.type
+
+  ; type is type of index
+  edge @subscript_expr.type -> @index.expr_ref__typeof
+  ;
+  attr (@index.expr_ref__typeof) push_symbol = ":"
+  edge @index.expr_ref__typeof -> @index.expr_ref
+}
+
+(subscript_expression
+  object: (_)@object
+  index: (_)@index ; FIXME typeof index == number
+)@subscript_expr {
+  node @subscript_expr.indexable
+
+  ; type is type of index
+  edge @subscript_expr.type -> @subscript_expr.indexable
+
+  attr (@subscript_expr.indexable) push_symbol = "[]"
+  edge @subscript_expr.indexable -> @object.type
+}
+
+(subscript_expression
+  object: (_)@object
+  index: (number)@index
+)@subscript_expr {
+  node @subscript_expr.comp_index
+
+  ; type is specific index component, in case this is a tuple
+  edge @subscript_expr.type -> @subscript_expr.comp_index
+  ;
+  attr (@subscript_expr.comp_index) push_node = @index
+  edge @subscript_expr.comp_index -> @subscript_expr.indexable
+}
+
+
+
+;; Constructor Calls
+
+; new Foo;
+; new Bar(1,2);
+
+; (new_expression (identifier))
+; (new_expression
+;   (identifier)
+;   (arguments (number) (number)))
+
+; (new_expression
+;   constructor:(_)
+;   type_arguments:(_) ; opt
+;   arguments:(_)      ; opt
+; )
+
+(new_expression constructor:(_)@ctor)@new_expr {
+  node @new_expr.ctor_ref
+
+  ; propagate lexical scope
+  edge @ctor.lexical_scope -> @new_expr.lexical_scope
+
+  ; type of new is the return type of the constructor
+  edge @new_expr.type -> @new_expr.applied_type
+  ;
+  ; type application between reference and constructor type
+  ;
+  edge @new_expr.generic_type -> @new_expr.ctor_ref
+  ;
+  attr (@new_expr.ctor_ref) push_symbol = "<new>"
+  edge @new_expr.ctor_ref -> @ctor.type
+}
+
+; type application is handled by the generics rules below
+
+(new_expression
+  arguments:(_)@args
+)@new_expr {
+  ; propagate lexical scope
+  edge @args.lexical_scope -> @new_expr.lexical_scope
+}
+
+
+
+;; Awaits
+
+; await foo();
+
+; (await_expression
+;   (call_expression (identifier) (arguments)))
+
+(await_expression
+  (_)@awaited_expr
+)@await_expr {
+  ; propagate lexical scope
+  edge @awaited_expr.lexical_scope -> @await_expr.lexical_scope
+
+  ; type is the result type of the await
+  edge @await_expr.type -> @await_expr.await_type
+
+  ; await the type of the expression
+  edge @await_expr.async_type -> @awaited_expr.type
+}
+
+
+
+;; Math Operators
+
+; x++;
+; x--;
+; x + y;
+; x - y;
+; x * y;
+; x / y;
+; x % y;
+; x ** y;
+; +x;
+; -x;
+
+; lots of duplication here
+; (update_expression (identifier))
+; (update_expression (identifier))
+; (binary_expression (identifier) (identifier))
+; (binary_expression (identifier) (identifier))
+; (binary_expression (identifier) (identifier))
+; (binary_expression (identifier) (identifier))
+; (binary_expression (identifier) (identifier))
+; (binary_expression (identifier) (identifier))
+; (unary_expression (identifier))
+; (unary_expression (identifier))
+
+(update_expression argument: (_)@argument)@update_expr {
+  ; propagate lexical scope
+  edge @argument.lexical_scope -> @update_expr.lexical_scope
+}
+
+(binary_expression left: (_)@left right: (_)@right)@binary_expr {
+  ; propagate lexical scope
+  edge @left.lexical_scope -> @binary_expr.lexical_scope
+  edge @right.lexical_scope -> @binary_expr.lexical_scope
+}
+
+(unary_expression argument: (_)@argument)@unary_expr {
+  ; propagate lexical scope
+  edge @argument.lexical_scope -> @unary_expr.lexical_scope
+}
+
+
+
+;; Boolean Operators
+
+; x && y;
+; x || y;
+; !x;
+
+; redundant
+; (binary_expression (identifier) (identifier))
+; (binary_expression (identifier) (identifier))
+; (unary_expression (identifier))
+
+
+;; Null Coalescing Operator
+
+; x ?? y;
+
+; redundant
+; (binary_expression (identifier) (identifier))
+
+
+;; Bitwise Operators
+
+; x >> y;
+; x >>> y;
+; x << y;
+; x & y;
+; x | y;
+; x ^ y;
+; ~x;
+
+; redundant
+; (binary_expression (identifier) (identifier))
+; (binary_expression (identifier) (identifier))
+; (binary_expression (identifier) (identifier))
+; (binary_expression (identifier) (identifier))
+; (binary_expression (identifier) (identifier))
+; (binary_expression (identifier) (identifier))
+; (unary_expression (identifier))
+
+
+
+;; Comparator Operators
+
+; x < y;
+; x <= y;
+; x > y;
+; x >= y;
+; x == y;
+; x === y;
+; x != y;
+; x !== y;
+
+; redundant
+; (binary_expression (identifier) (identifier))
+; (binary_expression (identifier) (identifier))
+; (binary_expression (identifier) (identifier))
+; (binary_expression (identifier) (identifier))
+; (binary_expression (identifier) (identifier))
+; (binary_expression (identifier) (identifier))
+; (binary_expression (identifier) (identifier))
+; (binary_expression (identifier) (identifier))
+
+
+
+;; Assignment Expressions;
+
+; x = 0;
+; x.y = 0;
+; x["y"] = 0;
+
+; (assignment_expression (identifier) (number))
+; (assignment_expression
+;   (member_expression (identifier) (property_identifier))
+;   (number))
+; (assignment_expression
+;   (subscript_expression (identifier) (string))
+;   (number))
+
+(assignment_expression
+  left: (_)@left
+  right: (_)@right
+)@assignment_expr {
+  ; propagate lexical scope
+  edge @left.lexical_scope -> @assignment_expr.lexical_scope
+  edge @right.lexical_scope -> @assignment_expr.lexical_scope
+
+  ; type is type of lhs
+  edge @assignment_expr.type -> @left.type
+}
+
+; _destructuring_pattern is used as an expression in assignment_expression
+(assignment_expression
+  left: [(object_pattern) (array_pattern)] @destruct_pat
+  right: (_)@left
+) {
+  node @destruct_pat.type
+
+  ; type is pattern cotype
+  edge @destruct_pat.type -> @destruct_pat.cotype
+
+  ; connect cotype to type
+  edge @destruct_pat.cotype -> @left.cotype
+}
+
+
+;; Augmented Assignment Expressions
+
+; x += y;
+; x.y -= z;
+
+; (augmented_assignment_expression
+;   (identifier)
+;   (identifier))
+; (augmented_assignment_expression
+;   (member_expression (identifier) (identifier))
+;   (identifier))
+
+(augmented_assignment_expression
+  left: (_)@left
+  right: (_)@right
+)@augmented_assignment_expr {
+  ; propagate lexical scope
+  edge @left.lexical_scope -> @augmented_assignment_expr.lexical_scope
+  edge @right.lexical_scope -> @augmented_assignment_expr.lexical_scope
+
+  ; type is type of lhs
+  edge @augmented_assignment_expr.type -> @left.type
+}
+
+
+
+;; Comma Operator
+
+; 1, 2;
+
+; (sequence_expression (number) (number))
+
+(sequence_expression
+  left: (_)@left
+  right: (_)@right
+)@sequence_expr {
+  ; propagate lexical scope
+  edge @left.lexical_scope -> @sequence_expr.lexical_scope
+  edge @right.lexical_scope -> @sequence_expr.lexical_scope
+
+  ; FIXME @sequence_expr.type is type of last, but cannot express because of nesting
+}
+
+
+;; Ternary Expression
+
+; x ? y : z;
+
+; (ternary_expression
+;   (identifier)
+;   (identifier)
+;   (identifier))
+
+(ternary_expression
+  condition: (_)@condition
+  consequence: (_)@consequence
+  alternative: (_)@alternative
+)@ternary_expr {
+  ; propagate lexical scope
+  edge @condition.lexical_scope -> @ternary_expr.lexical_scope
+  edge @consequence.lexical_scope -> @ternary_expr.lexical_scope
+  edge @alternative.lexical_scope -> @ternary_expr.lexical_scope
+
+  ; type is union of branch types
+  edge @ternary_expr.type -> @consequence.type
+  edge @ternary_expr.type -> @alternative.type
+}
+
+
+
+;; Type Operators
+
+; typeof x;
+; x instanceof String;
+
+; redundant
+; (unary_expression (identifier))
+; (binary_expression (identifier) (identifier))
+
+
+
+;; Delete Expression
+
+; delete foo.bar;
+
+; redundant
+; (unary_expression
+;   (member_expression (identifier) (property_identifier)))
+
+
+
+;; Void Operator
+
+; void foo;
+
+; redundant
+; (unary_expression (identifier))
+
+
+
+;; Yield Expression
+(yield_expression (_)@yielded_expr)@yield_expr {
+  ; propagate lexical scope
+  edge @yielded_expr.lexical_scope -> @yield_expr.lexical_scope
+}
+
+
+
+;; Class Expressions
+
+; (class
+;   decorator:(_) ; rep
+;   name:(_) ; opt
+;   type_parameters:(_) ; opt
+;   (class_heritage) ; opt
+;   body:(_)
+; ) {}
+
+; (class { });
+; (class Foo { });
+; (class Bar extends Foo {
+;   baz() {}
+; });
+
+; (class)@class
+; (class name:(_)@name)@class
+; (class (_) (_)@superclass (_))@class
+
+; type parameters are handled in generics rules below
+
+(class (class_heritage)@heritage)@class_expr {
+  ; propagate lexical scope
+  edge @heritage.lexical_scope -> @class_expr.lexical_scope
+
+  ; class type inherits from heritage type
+  edge @class_expr.generic_inner_type -> @heritage.type_members
+
+  ; type of class expression inherits heritage static members
+  edge @class_expr.type -> @heritage.static_members
+
+  ; mark type scope as endpoint
+  attr (@class_expr.type) is_endpoint
+  attr (@class_expr.generic_inner_type) is_endpoint
+}
+
+; this
+(class)@class_expr {
+  node @class_expr.this__expr_def
+  node @class_expr.this__expr_def__ns
+  node @class_expr.this__expr_def__typeof
+  node @class_expr.this__type_def
+  node @class_expr.this__type_def__ns
+  node @class_expr.this__type_def__typeof
+
+  ; this expr definition
+  edge @class_expr.generic_inner_lexical_scope -> @class_expr.this__expr_def__ns
+  ;
+  attr (@class_expr.this__expr_def__ns) pop_symbol = "%E"
+  edge @class_expr.this__expr_def__ns -> @class_expr.this__expr_def
+  ;
+  attr (@class_expr.this__expr_def) pop_symbol = "this"
+  edge @class_expr.this__expr_def -> @class_expr.this__expr_def__typeof
+  ;
+  attr (@class_expr.this__expr_def__typeof) pop_symbol = ":"
+  edge @class_expr.this__expr_def__typeof -> @class_expr.generic_inner_type
+
+  ; this type definition
+  ; FIXME this is more dynamic in reality
+  edge @class_expr.generic_inner_lexical_scope -> @class_expr.this__type_def__ns
+  ;
+  attr (@class_expr.this__type_def__ns) pop_symbol = "%T"
+  edge @class_expr.this__type_def__ns -> @class_expr.this__type_def
+  ;
+  attr (@class_expr.this__type_def) pop_symbol = "this"
+  edge @class_expr.this__type_def -> @class_expr.generic_inner_type
+}
+
+; default constructor
+; FIXME only if no other constructor is defined
+(class)@class_expr {
+  node @class_expr.ctor_def
+
+  ; default nullary constructor
+  edge @class_expr.type -> @class_expr.ctor_def
+  ;
+  attr (@class_expr.ctor_def) pop_symbol = "<new>"
+  ; FIXME constructor inherits type parameters of surrounding class
+  edge @class_expr.ctor_def -> @class_expr.generic_type
+}
+
+; body
+(class body:(_)@body)@class_expr {
+  ; propagate lexical scope
+  edge @body.lexical_scope -> @class_expr.lexical_scope
+
+  ; class type consists of body members
+  edge @class_expr.generic_inner_type -> @body.type_members
+
+  ; type of class expression consists of static members
+  edge @class_expr.type -> @body.static_members
+}
+
+
+
+;; Non-null Expression
+
+(non_null_expression
+  (_)@expr
+)@non_null_expr {
+  ; propagate lexical scope
+  edge @expr.lexical_scope -> @non_null_expr.lexical_scope
+}
+
+
+
+;; Type Assertion
+
+; (type_assertion
+;   (type_arguments)
+;   (expression)
+; )
+
+(type_assertion
+  (type_arguments)@type_arguments
+  (expression)@expr
+)@type_assert {
+  ; propagate lexical scope
+  edge @expr.lexical_scope -> @type_assert.lexical_scope
+}
+
+
+
+;; As Expression
+
+; (as_expression
+;   (expression)
+;   (template_string)
+; )
+; (as_expression
+;   (expression)
+;   (_)@type
+; )
+
+(as_expression
+  (_)@expr
+  (_)@type
+)@as_expr {
+  ; propagate lexical scope
+  edge @expr.lexical_scope -> @as_expr.lexical_scope
+  edge @type.lexical_scope -> @as_expr.lexical_scope
+
+  ; type is type of annotation
+  edge @as_expr.type -> @type.type
+}
+
+
+
+; ######
+; #     #   ##   ##### ##### ###### #####  #    #  ####
+; #     #  #  #    #     #   #      #    # ##   # #
+; ######  #    #   #     #   #####  #    # # #  #  ####
+; #       ######   #     #   #      #####  #  # #      #
+; #       #    #   #     #   #      #   #  #   ## #    #
+; #       #    #   #     #   ###### #    # #    #  ####
+
+;; Attributes defined on patterns
+;
+; in .lexical_scope
+;
+; out .defs
+;
+; in .cotype
+;
+
+[
+  (array_pattern)
+  (assignment_pattern)
+  (object_assignment_pattern)
+  (object_pattern)
+  (pair_pattern)
+  (rest_pattern)
+  (shorthand_property_identifier_pattern)
+]@pat {
+  node @pat.cotype
+  node @pat.defs
+  node @pat.lexical_scope
+}
+; these also appear in pattern positions, but already gets some nodes from other rules
+[
+  (this)
+  (member_expression)
+  (subscript_expression)
+]@pat {
+  node @pat.defs
+}
+
+[ ; NOTE these are the ones not also variables
+  (for_in_statement ["var" "let" "const"] left:(identifier)@name)
+  (variable_declarator name:(identifier)@name)
+  (pattern/identifier)@name
+  (rest_pattern (_)@name)
+]@pat {
+  node @name.cotype
+  node @name.lexical_scope
+}
+
+[
+  (for_in_statement ["var" "let" "const"] left:(identifier)@name)
+  (variable_declarator name:(identifier)@name)
+  (pattern/identifier)@name
+  (rest_pattern (_)@name)
+]@pat {
+  node @name.defs
+  node @name.expr_def
+  node @name.expr_def__ns
+  node @name.expr_def__typeof
+
+  ; pattern defs are this def
+  edge @name.defs -> @name.expr_def__ns
+
+  attr (@name.expr_def__ns) pop_symbol = "%E"
+  edge @name.expr_def__ns -> @name.expr_def
+
+  ; local definition
+  attr (@name.expr_def) node_definition = @name
+  edge @name.expr_def -> @name.expr_def__typeof
+
+  ; definition type
+  attr (@name.expr_def__typeof) pop_symbol = ":"
+  edge @name.expr_def__typeof -> @name.cotype
+}
+
+
+
+(object_pattern (_)@entry)@obj_pat {
+  edge @entry.lexical_scope -> @obj_pat.lexical_scope
+
+  edge @obj_pat.defs -> @entry.defs
+
+  edge @entry.cotype -> @obj_pat.cotype
+}
+
+
+
+; capture object field
+(shorthand_property_identifier_pattern)@prop_pat {
+  node @prop_pat.expr_def
+  node @prop_pat.expr_def__ns
+  node @prop_pat.expr_def__typeof
+  node @prop_pat.expr_ref
+  node @prop_pat.expr_ref__ns
+  node @prop_pat.expr_ref__typeof
+  node @prop_pat.member
+
+  ; link definitions
+  edge @prop_pat.defs -> @prop_pat.expr_def__ns
+
+  ; definition namespace
+  attr (@prop_pat.expr_def__ns) pop_symbol = "%E"
+  edge @prop_pat.expr_def__ns -> @prop_pat.expr_def
+
+  ; definition name
+  attr (@prop_pat.expr_def) node_definition = @prop_pat
+  edge @prop_pat.expr_def -> @prop_pat.expr_def__typeof
+
+  ; type of definition
+  attr (@prop_pat.expr_def__typeof) pop_symbol = ":"
+  edge @prop_pat.expr_def__typeof -> @prop_pat.expr_ref__typeof
+
+  ; type of reference
+  attr (@prop_pat.expr_ref__typeof) push_symbol = ":"
+  edge @prop_pat.expr_ref__typeof -> @prop_pat.expr_ref
+
+  ; reference name
+  attr (@prop_pat.expr_ref) node_reference = @prop_pat
+  edge @prop_pat.expr_ref -> @prop_pat.member
+
+  ; member projection
+  attr (@prop_pat.member) push_symbol = "."
+  edge @prop_pat.member -> @prop_pat.cotype
+}
+
+
+
+; capture object field with specific pattern
+(pair_pattern
+  key:(_)@key ; can be v or "v"!
+  value:(_)@value_pat
+)@pair_pat {
+  node @key.expr_ref
+  node @key.expr_ref__ns
+  node @key.expr_ref__typeof
+  node @pair_pat.member
+
+  edge @value_pat.lexical_scope -> @pair_pat.lexical_scope
+
+  edge @pair_pat.defs -> @value_pat.defs
+
+  ; value cotype through projection
+  edge @value_pat.cotype -> @key.expr_ref__typeof
+
+  ; type of reference
+  attr (@key.expr_ref__typeof) push_symbol = ":"
+  edge @key.expr_ref__typeof -> @key.expr_ref
+
+  ; reference name
+  attr (@key.expr_ref) symbol_reference = (replace (source-text @key) "[\"\']" "")
+  edge @key.expr_ref -> @pair_pat.member
+
+  ; member projection
+  attr (@pair_pat.member) push_symbol = "."
+  edge @pair_pat.member -> @pair_pat.cotype
+}
+
+
+
+; capture object field with default value
+(object_assignment_pattern
+  left:(_)@pat
+  right:(_)@expr
+)@obj_assgn_pat {
+  ; propagate lexical scope
+  edge @pat.lexical_scope -> @obj_assgn_pat.lexical_scope
+  edge @expr.lexical_scope -> @obj_assgn_pat.lexical_scope
+
+  ; propagate cotype
+  edge @pat.cotype -> @obj_assgn_pat.cotype
+
+  ; propagate defs
+  edge @obj_assgn_pat.defs -> @pat.defs
+
+  ; use default assignment type for cotype
+  edge @pat.cotype -> @expr.type
+}
+
+
+
+(array_pattern)@array_pat {
+  node @array_pat.indexable
+
+  ; propagate cotype
+  attr (@array_pat.indexable) push_symbol = "[]"
+  edge @array_pat.indexable -> @array_pat.cotype
+}
+
+(array_pattern
+  (_)@pat
+)@array_pat {
+  node @pat.comp_index
+
+  ; propagate lexical scope
+  edge @pat.lexical_scope -> @array_pat.lexical_scope
+
+  ; propagate cotype components
+  edge @pat.cotype -> @pat.comp_index
+  ;
+  attr (@pat.comp_index) push_symbol = (named-child-index @pat)
+  edge @pat.comp_index -> @array_pat.indexable
+
+  ; propagate defs
+  edge @array_pat.defs -> @pat.defs ;; FIXME
+}
+
+
+
+(assignment_pattern
+  left:(_)@pat
+  right:(_)@expr
+)@assignment_pat {
+  ; propagate lexical scope
+  edge @pat.lexical_scope -> @assignment_pat.lexical_scope
+  edge @expr.lexical_scope -> @assignment_pat.lexical_scope
+
+  ; propagate cotype
+  edge @pat.cotype -> @assignment_pat.cotype
+
+  ; propagate defs
+  edge @assignment_pat.defs -> @pat.defs
+
+  ; use default assignment type for cotype
+  edge @pat.cotype -> @expr.type
+}
+
+
+
+(rest_pattern (_)@inner)@rest_pat {
+  ; propagate lexical scope
+  edge @inner.lexical_scope -> @rest_pat.lexical_scope
+
+  ; propagate cotype
+  ; FIXME what is the cotype?
+
+  ; propagate defs
+  edge @rest_pat.defs -> @inner.defs
+}
+
+
+
+; #     #
+; ##   ## ###### #    # #####  ###### #####   ####
+; # # # # #      ##  ## #    # #      #    # #
+; #  #  # #####  # ## # #####  #####  #    #  ####
+; #     # #      #    # #    # #      #####       #
+; #     # #      #    # #    # #      #   #  #    #
+; #     # ###### #    # #####  ###### #    #  ####
+
+;; Attributes defined on members
+;
+; in .lexical_scope
+;     Scope to resolve type names.
+;     Set by enclosing node.
+;
+; out .type_members
+;     Scope representing the declared type members.
+;
+; out .static_members
+;     Scope representing the declared static members.
+
+[
+  (abstract_method_signature)
+  (call_signature)
+  (construct_signature)
+  (decorator) ; not strictly a member, but appears in same positions
+  (index_signature)
+  (method_definition)
+  (method_signature)
+  (property_signature)
+  (public_field_definition)
+]@mem {
+  node @mem.lexical_scope
+  node @mem.type_members
+  node @mem.static_members
+}
+
+
+
+;; Decorator
+
+(decorator (_)@expr)@dec {
+  edge @expr.lexical_scope -> @dec.lexical_scope
+}
+
+
+
+;; Construct Signature
+
+; (construct_signature
+;   (type_parameters) ; opt
+;   (formal_parameters)
+;   (type_annotation) ; opt
+; ) {}
+
+(construct_signature)@ctor_sig {
+  node @ctor_sig.ctor_def
+
+  ; constructor member
+  edge @ctor_sig.type_members -> @ctor_sig.ctor_def
+  ;
+  attr (@ctor_sig.ctor_def) pop_symbol = "<new>"
+  edge @ctor_sig.ctor_def -> @ctor_sig.generic_type
+}
+
+; type parameters are be handled by the generics rules
+
+(construct_signature
+  parameters:(_)@params
+)@construct_sig {
+  ; propagate lexical scope
+  edge @params.lexical_scope -> @construct_sig.generic_inner_lexical_scope
+}
+
+(construct_signature
+  type:(_)@type ; opt
+)@construct_sig {
+  ; propagate lexical scope
+  edge @type.lexical_scope -> @construct_sig.generic_inner_lexical_scope
+
+  ; propagate lexical scope
+  edge @construct_sig.generic_inner_type -> @type.type
+}
+
+
+
+;; Index Signature
+
+; (index_signature
+;   name:(_)@index_name
+;   index_type:(_)@index_type
+;   type:(_)@type
+; )@index_sig
+
+(index_signature
+  index_type:(_)@index_type
+  type:(_)@type
+)@index_sig {
+  node @index_sig.indexable
+
+  ; propagate lexical scope
+  edge @index_type.lexical_scope -> @index_sig.lexical_scope
+  edge @type.lexical_scope -> @index_sig.lexical_scope
+
+  ; member definition
+  edge @index_sig.type_members -> @index_sig.indexable
+  ;
+  attr (@index_sig.indexable) pop_symbol = "[]"
+  edge @index_sig.indexable -> @type.type
+}
+
+
+
+;; Call Signature
+
+; (call_signature
+;   type_parameters:(_) ; opt
+;   parameters:(_)
+;   return_type:[(type_annotation) (asserts) (type_predicate_annotation)] ; opt
+; ) {}
+
+(call_signature)@call_sig {
+  node @call_sig.callable
+  node @call_sig.callable__return
+
+  ; call definition
+  edge @call_sig.type_members -> @call_sig.callable
+  ;
+  attr (@call_sig.callable) pop_symbol = "->"
+  edge @call_sig.callable -> @call_sig.callable__return
+  ;
+  attr (@call_sig.callable__return) pop_symbol = "<return>"
+  edge @call_sig.callable__return -> @call_sig.generic_type
+}
+
+; type parameters are handled by generics rules below
+
+(call_signature
+  parameters:(_)@parameters
+)@call_sig {
+  ; propagate lexical scope
+  edge @parameters.lexical_scope -> @call_sig.generic_inner_lexical_scope
+}
+
+(call_signature
+  return_type:(_)@return_type
+)@call_sig {
+  ; propagate lexical scope
+  edge @return_type.lexical_scope -> @call_sig.generic_inner_lexical_scope
+
+  ; inner type is return type
+  edge @call_sig.generic_inner_type -> @return_type.type
+}
+
+
+
+;; Property Signature
+
+; (property_signature
+;   name:(_)@name
+;   type:(_)@type ; opt
+; )@sig
+
+(property_signature
+  name:(_)@name
+)@sig {
+  node @sig.member
+
+  ; member definition
+  edge @sig.type_members -> @sig.member
+  ;
+  attr (@sig.member) pop_symbol = "."
+  edge @sig.member -> @name.expr_def
+  ;
+  attr (@name.expr_def) node_definition = @name
+}
+
+(property_signature
+  name:(_)@name
+  type:(_)@type ; opt
+)@sig {
+  ; propagate lexical scope
+  edge @type.lexical_scope -> @sig.lexical_scope
+
+  ; type of property is type of annotation
+  edge @name.expr_def -> @name.expr_def__typeof
+  ;
+  attr (@name.expr_def__typeof) pop_symbol = ":"
+  edge @name.expr_def__typeof -> @type.type
+}
+
+
+
+;; Public Field Definition
+
+; (public_field_definition
+;   name:(_)@name
+;   type:(_)@type ; opt
+;   value:(_)@value ; opt
+; )@def
+
+(public_field_definition
+  name:(_)@name
+)@def {
+  node @def.member
+
+  ; member definition
+  edge @def.type_members -> @def.member
+  ;
+  attr (@def.member) pop_symbol = "."
+  edge @def.member -> @name.expr_def
+  ;
+  attr (@name.expr_def) node_definition = @name
+}
+
+(public_field_definition
+  name:(_)@name
+  type:(_)@type ; opt
+)@def {
+  ; propagate lexical scope
+  edge @type.lexical_scope -> @def.lexical_scope
+
+  ; type of field is type of annotation
+  edge @name.expr_def -> @name.expr_def__typeof
+  ;
+  attr (@name.expr_def__typeof) pop_symbol = ":"
+  edge @name.expr_def__typeof -> @type.type
+}
+
+(public_field_definition
+  name:(_)@name
+  !type ; opt
+  value:(_)@value ; opt
+)@def {
+  ; type of field is type of value
+  edge @name.expr_def -> @name.expr_def__typeof
+  ;
+  attr (@name.expr_def__typeof) pop_symbol = ":"
+  edge @name.expr_def__typeof -> @value.type
+}
+
+(public_field_definition
+  value:(_)@value ; opt
+)@def {
+  ; propagate lexical scope
+  edge @value.lexical_scope -> @def.lexical_scope
+}
+
+
+
+;; (Abstract) Method Signature & Definition
+
+; (method_signature
+;   ; 'get' | 'set' | '*' ; opt
+;   name:(_)
+;   type_parameters:(_) ; opt
+;   parameters:(_)
+;   return_type:[(type_annotation) (asserts) (type_predicate_annotation)]
+; )
+;
+; (abstract_method_signature
+;   ; 'get' | 'set' | '*' ; opt
+;   name:(_)
+;   type_parameters:(_) ; opt
+;   parameters:(_)
+;   return_type:[(type_annotation) (asserts) (type_predicate_annotation)]
+; ) { }
+
+; (method_definition
+;   ; 'get' | 'set' | '*' ; opt
+;   name:(_)
+;   type_parameters:(_) ; opt
+;   parameters:(_)
+;   return_type:[(type_annotation) (asserts) (type_predicate_annotation)]
+;   body:(_)
+; )
+
+;;;; regular members (not 'get' and 'set', not constructors)
+
+[
+  (method_signature          ["get" "set"]?@is_acc name:(_)@name) ; FIXME name:^("constructor")
+  (abstract_method_signature ["get" "set"]?@is_acc name:(_)@name) ; FIXME name:^("constructor")
+  (method_definition         ["get" "set"]?@is_acc name:(_)@name) ; FIXME name:^("constructor")
+]@mem {
+if none @is_acc {
+  node @mem.member
+  node @mem.callable
+  node @mem.callable__params
+  node @mem.callable__return
+
+  ; member definition
+  edge @mem.type_members -> @mem.member
+  ;
+  attr (@mem.member) pop_symbol = "."
+  edge @mem.member -> @name.expr_def
+  ;
+  attr (@name.expr_def) node_definition = @name
+
+  ; type of method is callable generic type
+  edge @name.expr_def -> @name.expr_def__typeof
+  ;
+  attr (@name.expr_def__typeof) pop_symbol = ":"
+  edge @name.expr_def__typeof -> @mem.callable
+  ;
+  attr (@mem.callable) pop_symbol = "->"
+  edge @mem.callable -> @mem.generic_type
+  ;
+  edge @mem.generic_inner_type -> @mem.callable__params
+  edge @mem.generic_inner_type -> @mem.callable__return
+  ;
+  attr (@mem.callable__return) pop_symbol = "<return>"
+}
+}
+
+; type parameters are handled by generics rules below
+
+[
+  (method_signature          ["get" "set"]?@is_acc parameters:(_)@params)
+  (abstract_method_signature ["get" "set"]?@is_acc parameters:(_)@params)
+  (method_definition         ["get" "set"]?@is_acc parameters:(_)@params)
+]@mem {
+if none @is_acc {
+  ; propagate lexical scope
+  edge @params.lexical_scope -> @mem.generic_inner_lexical_scope
+
+  ; parameters are visible in body
+  edge @mem.generic_inner_lexical_scope -> @params.defs
+  attr (@mem.generic_inner_lexical_scope -> @params.defs) precedence = 1
+
+  ; connect paarams to type
+  edge @mem.callable__params -> @params.params
+}
+}
+
+[
+  (method_signature          ["get" "set"]?@is_acc return_type:(_)@return_type)
+  (abstract_method_signature ["get" "set"]?@is_acc return_type:(_)@return_type)
+  (method_definition         ["get" "set"]?@is_acc return_type:(_)@return_type)
+]@mem {
+if none @is_acc {
+  ; propagate lexical scope
+  edge @return_type.lexical_scope -> @mem.generic_inner_lexical_scope
+
+  ; inner type is return type
+  edge @mem.callable__return -> @return_type.type
+}
+}
+
+[
+  (method_definition ["get" "set" "async"]?@is_acc !return_type body:(_)@body)
+]@mem {
+if none @is_acc {
+  ; inner type is type of return statement
+  edge @mem.callable__return -> @body.return_type
+}
+}
+
+[
+  (method_definition "async" !return_type body:(_)@body)
+]@mem {
+  ; inner type is type of return statement
+  edge @mem.callable__return -> @mem.async_type
+  ;
+  edge @mem.await_type -> @body.return_type
+}
+
+;;;; 'get' and 'set' methods
+
+[
+  (method_signature          ["get" "set"] name:(_)@name)
+  (abstract_method_signature ["get" "set"] name:(_)@name)
+  (method_definition         ["get" "set"] name:(_)@name)
+]@mem {
+  node @mem.member
+
+  ; member definition
+  edge @mem.type_members -> @mem.member
+  ;
+  attr (@mem.member) pop_symbol = "."
+  edge @mem.member -> @name.expr_def
+  ;
+  attr (@name.expr_def) node_definition = @name
+}
+
+[
+  ; NOTE type_parameters and parameters are assumed to be empty
+  (method_signature          "get" name:(_)@name return_type:(_)@return_type)
+  (abstract_method_signature "get" name:(_)@name return_type:(_)@return_type)
+  (method_definition         "get" name:(_)@name return_type:(_)@return_type)
+]@mem {
+  ; propagate lexical scope
+  edge @return_type.lexical_scope -> @mem.lexical_scope
+
+  ; type of field is return type
+  edge @name.expr_def -> @name.expr_def__typeof
+  ;
+  attr (@name.expr_def__typeof) pop_symbol = ":"
+  edge @name.expr_def__typeof -> @return_type.type
+}
+
+[
+  ; NOTE type_parameters and return_type are assumed to be empty
+  (method_signature          "set" name:(_)@name parameters:(formal_parameters (required_parameter (type_annotation)@param_type)))
+  (abstract_method_signature "set" name:(_)@name parameters:(formal_parameters (required_parameter (type_annotation)@param_type)))
+  (method_definition         "set" name:(_)@name parameters:(formal_parameters (required_parameter (type_annotation)@param_type)))
+]@mem {
+  ; propagate lexical scope
+  edge @param_type.lexical_scope -> @mem.lexical_scope
+
+  ; type of field is parameter type
+  edge @name.expr_def -> @name.expr_def__typeof
+  ;
+  attr (@name.expr_def__typeof) pop_symbol = ":"
+  edge @name.expr_def__typeof -> @param_type.type
+}
+
+;;;; method body
+
+[
+  (method_definition body:(_)@body)
+]@mem {
+  ; propagate lexical scope
+  edge @body.lexical_scope -> @mem.generic_inner_lexical_scope
+}
+
+
+
+;;;; FIXME constructor methods
+
+
+
+;; Class Heritage
+
+; (class_heritage
+;   (extends_clause)@extends       ; opt
+;   (implements_clause)@implements ; opt
+; )@class_heritage
+
+[
+  (class_heritage)
+  (extends_clause)
+  (extends_type_clause)
+  (implements_clause)
+]@heritage {
+  node @heritage.lexical_scope
+  node @heritage.type_members
+  node @heritage.static_members
+}
+
+(class_heritage
+  (_)@extends_or_implements ; opt
+)@class_heritage {
+  ; propagate lexical scope
+  edge @extends_or_implements.lexical_scope -> @class_heritage.lexical_scope
+
+  ; type members inherited from extends & implements clauses
+  edge @class_heritage.type_members -> @extends_or_implements.type_members
+
+  ; static members inherited from extends & implements clauses
+  edge @class_heritage.static_members -> @extends_or_implements.static_members
+}
+
+
+
+;; Implements Clause
+
+; (implements_clause
+;   (_)@type ; commaSep1
+; )@implements
+
+(implements_clause)@implements {
+  edge @implements.type_members -> @implements.alias_type
+}
+
+(implements_clause
+  (_)@type ; commaSep1
+)@implements {
+  ; propagate lexical scope
+  edge @type.lexical_scope -> @implements.lexical_scope
+
+  ; type members from type of interface
+  edge @implements.aliased_type -> @type.type
+}
+
+
+
+;; Extends Clause
+
+; (extends_clause
+;   (expression)@expr ; commaSep1
+;   type_arguments:(_)@type_args ; commaSep1, opt
+; )@extends
+
+(extends_clause
+  (expression)@expr ; commaSep1
+; type_arguments
+)@extends {
+  node @extends.ctor_ref
+
+  ; propagate lexical scope
+  edge @expr.lexical_scope -> @extends.lexical_scope
+
+  ; static members from the super type
+  edge @extends.static_members -> @extends.alias_type
+  ;
+  edge @extends.aliased_type -> @expr.type
+
+  ; type members from the constructor return type
+  edge @extends.type_members -> @extends.ctor_ref
+  ;
+  attr (@extends.ctor_ref) push_symbol = "<new>"
+  edge @extends.ctor_ref -> @expr.type
+}
+
+(extends_clause
+  type_arguments:(_)@type_args
+)@extends {
+  ; propagate lexical scope
+  edge @type_args.lexical_scope -> @extends.lexical_scope
+
+  ; FIXME constructor type arguments are currently ignored
+}
+
+
+
+;; Extends Type Clause
+
+; (extends_type_clause
+;   [(type_identifier) (nested_type_identifier) (generic_type)]@type ; commaSep1
+; )@extends
+
+(extends_type_clause)@extends {
+  edge @extends.type_members -> @extends.alias_type
+}
+
+(extends_type_clause
+  (_)@type ; commaSep1
+)@extends {
+  ; propagate lexical scope
+  edge @type.lexical_scope -> @extends.lexical_scope
+
+  ; type members from the super interface
+  edge @extends.aliased_type -> @type.type
+}
+
+
+
+; #######
+;    #    #   # #####  ######  ####
+;    #     # #  #    # #      #
+;    #      #   #    # #####   ####
+;    #      #   #####  #           #
+;    #      #   #      #      #    #
+;    #      #   #      ######  ####
+;
+; ##################################
+
+;; Attributes defined on syntactic types
+;
+; in .lexical_scope
+;     Scope to resolve type names.
+;     Set by enclosing node.
+;
+; out .type
+;     Scope representing the type of the syntactic type.
+
+[
+  (array_type)
+  (asserts)
+  (conditional_type)
+  (constraint)
+  (constructor_type)
+  (default_type)
+  (existential_type)
+  (flow_maybe_type)
+  (function_type)
+  (generic_type)
+  (index_type_query)
+  (infer_type)
+  (intersection_type)
+  (literal_type)
+  (lookup_type)
+  (mapped_type_clause)
+  (nested_type_identifier)
+  (object_type)
+  (omitting_type_annotation)
+  (opting_type_annotation)
+  (optional_type)
+  (parenthesized_type)
+  (predefined_type)
+  (readonly_type)
+  (rest_type)
+  (template_literal_type)
+  (template_type)
+  (this_type)
+  (tuple_type)
+  (type_annotation)
+  (type_arguments)
+  (type_identifier)
+  (type_parameter)
+  (type_parameters)
+  (type_predicate)
+  (type_predicate_annotation)
+  (type_query)
+  (union_type)
+]@type {
+  node @type.lexical_scope
+  node @type.type
+}
+
+
+;; Accessibility Modifier
+
+; (accessibility_modifier) {}
+
+
+
+;; Omitting Type Annotation
+
+; (omitting_type_annotation
+;   (_)@type
+; )@type_annotation
+
+(omitting_type_annotation
+  (_)@type
+)@type_annotation {
+  ; propagate lexical scope
+  edge @type.lexical_scope -> @type_annotation.lexical_scope
+
+  ; type is type of inner
+  edge @type_annotation.type -> @type.type
+}
+
+
+
+;; Opting Type Annotation
+
+; (opting_type_annotation
+;   (_)@type
+; )@type_annotation
+
+(opting_type_annotation
+  (_)@type
+)@type_annotation {
+  ; propagate lexical scope
+  edge @type.lexical_scope -> @type_annotation.lexical_scope
+
+  ; type is type of inner
+  edge @type_annotation.type -> @type.type
+}
+
+
+
+;; Type Annotation
+
+; (type_annotation
+;   (_)@type
+; )@type_annotation
+
+(type_annotation
+  (_)@type
+)@type_annotation {
+  ; propagate lexical scope
+  edge @type.lexical_scope -> @type_annotation.lexical_scope
+
+  ; type is type of inner
+  edge @type_annotation.type -> @type.type
+}
+
+
+
+;; Assertion
+
+; (asserts
+;   [(type_predicate) (identifier) (this)]
+; ) {}
+
+(asserts
+  (_)@type
+)@asserts {
+  ; propagate lexical scope
+  edge @type.lexical_scope -> @asserts.lexical_scope
+
+  ; type is type of inner
+  edge @asserts.type -> @type.type
+}
+
+
+
+;; Optional Type
+
+(optional_type
+  (_)@type
+)@opt_type {
+  ; propagate lexical scope
+  edge @type.lexical_scope -> @opt_type.lexical_scope
+
+  ; type is type of inner
+  edge @opt_type.type -> @type.type
+}
+
+
+
+;; Rest Type
+
+(rest_type
+  (_)@type
+)@rest_type {
+  ; propagate lexical scope
+  edge @type.lexical_scope -> @rest_type.lexical_scope
+
+  ; FIXME is this an array type?
+  edge @rest_type.type -> @type.type
+}
+
+
+
+;; Constructor Type
+
+; (constructor_type
+;   (type_parameters) ; opt
+;   (formal_parameters)
+;   (_)@type
+; ) {}
+
+(constructor_type)@ctor_type {
+  node @ctor_type.ctor_def
+
+  ; type is ctor member
+  edge @ctor_type.type -> @ctor_type.ctor_def
+  ;
+  attr (@ctor_type.ctor_def) pop_symbol = "<new>"
+  edge @ctor_type.ctor_def -> @ctor_type.generic_type
+}
+
+; type parameters are handled by generics rules below
+
+(constructor_type
+  parameters:(_)@params
+  type:(_)@type
+)@ctor_type {
+  ; propagate lexical scope
+  edge @params.lexical_scope -> @ctor_type.generic_inner_lexical_scope
+  edge @type.lexical_scope -> @ctor_type.generic_inner_lexical_scope
+
+  ; type is the return type
+  edge @ctor_type.generic_inner_type -> @type.type
+}
+
+
+
+;; Infer Type
+
+; (infer_type
+;   (type_identifier)
+; ) {}
+
+(infer_type
+  (_)@type
+)@infer_type {
+  ; propagate lexical scope
+  edge @type.lexical_scope -> @infer_type.lexical_scope
+
+  ; type is the inner type
+  edge @infer_type.type -> @type.type
+}
+
+
+
+;; Conditional Type
+
+; T1 extends T2 ? T3 : T4
+
+(conditional_type
+  left:(_)@left
+  right:(_)@right
+  consequence:(_)@consequence
+  alternative:(_)@alternative
+)@cond_type {
+  ; propagate lexical scope
+  edge @left.lexical_scope -> @cond_type.lexical_scope
+  edge @right.lexical_scope -> @cond_type.lexical_scope
+  edge @consequence.lexical_scope -> @cond_type.lexical_scope
+  edge @alternative.lexical_scope -> @cond_type.lexical_scope
+
+  ; type is the union of the possible result types (over-approximation)
+  edge @cond_type.type -> @consequence.type
+  edge @cond_type.type -> @alternative.type
+}
+
+
+
+;; Generic Type
+
+; (generic_type
+;   [(type_identifier) (nested_type_identifier)]
+;   (type_arguments)
+; ) {}
+
+(generic_type
+  name: (_)@type
+)@generic_type {
+  ; propagate lexical scope
+  edge @type.lexical_scope -> @generic_type.lexical_scope
+
+  ; type is applied generic type
+  edge @generic_type.type -> @generic_type.applied_type
+  ;
+  ; type application is handled by the generics rules below
+  ;
+  edge @generic_type.generic_type -> @type.type
+}
+
+
+
+;; Type Predicate
+
+; NAME is TYPE
+
+; (type_predicate
+;   [(identifier) (this)]
+;   (_)@type
+; ) {}
+
+(type_predicate
+  (_)@name
+  (_)@type
+)@type_pred {
+  ; propagate lexical scope
+  edge @type.lexical_scope -> @type_pred.lexical_scope
+
+  ; FIXME name is a expression reference
+}
+
+
+;; Type Predicate Annotation
+
+; (type_predicate_annotation
+;   (type_predicate)@type_pred
+; )@type_pred_anno {}
+
+(type_predicate_annotation
+  (type_predicate)@type_pred
+)@type_pred_anno {
+  ; propagate lexical scope
+  edge @type_pred.lexical_scope -> @type_pred_anno.lexical_scope
+}
+
+
+
+;; Type Query
+
+; typeof E
+
+; (type_query
+;   (_)@expr
+; ) {}
+
+(type_query
+  (_)@expr
+)@type_query {
+  ; propagate lexical scope
+  edge @expr.lexical_scope -> @type_query.lexical_scope
+
+  ; type is type of expression
+  edge @type_query.type -> @expr.type
+}
+
+
+
+;; Index Type Query
+
+; keyof T
+
+(index_type_query
+  (_)@type
+)@index_type_query {
+  ; propagate lexical scope
+  edge @type.lexical_scope -> @index_type_query.lexical_scope
+}
+
+
+
+;; Lookup Type
+
+; T1[T2]
+
+(lookup_type
+  (_)@primary_type
+  (_)@type
+)@lookup_type {
+  ; propagate lexical scope
+  edge @primary_type.lexical_scope -> @lookup_type.lexical_scope
+  edge @type.lexical_scope -> @lookup_type.lexical_scope
+}
+
+
+
+;; Mapped Type Clause
+
+; [T1 in T2]
+
+; (mapped_type_clause
+;   (type_identifier)
+;   (_)@type
+; ) {}
+
+(mapped_type_clause
+  type:(_)@type
+)@mapped_type_clause {
+  ; propagate lexical scope
+  edge @type.lexical_scope -> @mapped_type_clause.lexical_scope
+
+  ; FIXME is this correct?
+  edge @mapped_type_clause.type -> @type.type
+}
+
+
+
+;; Literal Type
+
+; (literal_type
+;   [(unary_expression operator:(_) argument:(number))
+;    (number)
+;    (string)
+;    (true)
+;    (false)]
+; ) {}
+
+
+
+;; Existential Type
+
+(existential_type) {}
+
+
+
+;; Maybe Type
+
+(flow_maybe_type
+  (_)@primary_type
+)@flow_type {
+  ; propagate lexical scope
+  edge @primary_type.lexical_scope -> @flow_type.lexical_scope
+
+  ; type is type of inner
+  edge @flow_type.type -> @primary_type.type
+}
+
+
+
+;; Parenthesized Type
+
+(parenthesized_type
+  (_)@type
+)@parens_type {
+  ; propagate lexical scope
+  edge @type.lexical_scope -> @parens_type.lexical_scope
+
+  ; type is type of inner
+  edge @parens_type.type -> @type.type
+}
+
+
+
+;; Predefined Type
+
+; (predefined_type) {}
+
+
+
+;; Type Arguments
+
+(type_arguments)@type_args {
+  node @type_args.type_args
+}
+
+(type_arguments
+  (_)@type ; commaSep1
+)@type_args {
+  node @type.arg_index
+
+  ; propagate lexical scope
+  edge @type.lexical_scope -> @type_args.lexical_scope
+
+  ; type args are positional indexed types of sub terms
+  edge @type_args.type_args -> @type.arg_index
+  ;
+  attr (@type.arg_index) pop_symbol = (named-child-index @type)
+  edge @type.arg_index -> @type.type
+}
+
+
+
+;; Array Type
+
+; (array_type
+;   (_)@element_type
+; )@type
+
+(array_type
+  (_)@element_type
+)@type {
+  node @type.indexable
+
+  ; propagate lexical scope
+  edge @element_type.lexical_scope -> @type.lexical_scope
+
+  ; type is indexable element type
+  edge @type.type -> @type.indexable
+  ;
+  attr (@type.indexable) pop_symbol = "[]"
+  edge @type.indexable -> @element_type.type
+}
+
+
+
+;; Tuple Type
+
+; (tuple_type
+;   (_)@component_type ; commaSep
+; )@type
+
+(tuple_type)@type {
+  node @type.indexable
+
+  ; type is indexable
+  edge @type.type -> @type.indexable
+  ;
+  attr (@type.indexable) pop_symbol = "[]"
+}
+
+(tuple_type
+  (_)@comp_type ; commaSep
+)@type {
+  node @comp_type.comp_index
+
+  ; propagate lexical scope
+  edge @comp_type.lexical_scope -> @type.lexical_scope
+
+  ; component indexed using position
+  edge @type.indexable -> @comp_type.comp_index
+  ;
+  attr (@comp_type.comp_index) pop_symbol = (named-child-index @comp_type)
+  edge @comp_type.comp_index -> @comp_type.type
+}
+
+; (tuple_parameter
+;   [(identifier) (rest_pattern)]
+;   (type_annotation)
+; ) {}
+
+; (optional_tuple_parameter
+;   (identifier)
+;   (type_annotation)
+; ) {}
+
+; tuple components can be parameters, but require extra properties
+(tuple_type [
+  (required_parameter)
+  (optional_parameter)
+]@_tuple_param) {
+  node @_tuple_param.type
+}
+(tuple_type [
+  (required_parameter type:(_)@type)
+  (optional_parameter type:(_)@type)
+]@_tuple_param) {
+  ; component type is type annotation
+  edge @_tuple_param.type -> @type.type
+}
+
+
+
+;; Readonly Type
+
+; (readonly_type
+;   (_)@inner_type
+; )@type
+
+(readonly_type
+  (_)@inner_type
+)@type {
+  ; propagate lexical scope
+  edge @inner_type.lexical_scope -> @type.lexical_scope
+
+  ; type is type of inner
+  edge @type.type -> @inner_type.type
+}
+
+
+
+;; Union Type
+
+; (union_type
+;   (_)@left_type ; opt
+;   (_)@right_type
+; )@type
+
+(union_type
+  (_)@inner_type
+)@type {
+  ; propagate lexical scope
+  edge @inner_type.lexical_scope -> @type.lexical_scope
+
+  ; type is union of types of inner
+  edge @type.type -> @inner_type.type
+}
+
+
+
+;; Intersection Type
+
+; (intersection_type
+;   (_)@left_type ; opt
+;   (_)@right_type
+; )@type
+
+(intersection_type
+  (_)@inner_type
+)@type {
+  ; propagate lexical scope
+  edge @inner_type.lexical_scope -> @type.lexical_scope
+
+  ; type is union of types of inner (over-approximation)
+  edge @type.type -> @inner_type.type
+}
+
+
+
+;; Function Type
+
+; (function_type
+;   (type_parameters) ; opt
+;   (formal_parameters)
+;   [(_)@type (type_predicate)]
+; ) {}
+
+(function_type)@fun_type {
+  node @fun_type.callable
+  node @fun_type.callable__params
+  node @fun_type.callable__return
+
+  ; type is callable generic type
+  edge @fun_type.type -> @fun_type.callable
+  ;
+  attr (@fun_type.callable) pop_symbol = "->"
+  edge @fun_type.callable -> @fun_type.generic_type
+  ;
+  edge @fun_type.generic_inner_type -> @fun_type.callable__params
+  edge @fun_type.generic_inner_type -> @fun_type.callable__return
+  ;
+  attr (@fun_type.callable__return) pop_symbol = "<return>"
+}
+
+; type parameters are handled by generics rules below
+
+(function_type parameters:(_)@params)@fun_type {
+  ; propagate lexical scope
+  edge @params.lexical_scope -> @fun_type.generic_inner_lexical_scope
+
+  ; connect params to type
+  edge @fun_type.callable__params -> @params.params
+}
+
+(function_type return_type:(_)@return_type)@fun_type {
+  ; propagate lexical scope
+  edge @return_type.lexical_scope -> @fun_type.generic_inner_lexical_scope
+
+  ; inner type is return type
+  edge @fun_type.callable__return -> @return_type.type
+}
+
+
+
+;; Type Identifier
+
+; (type_identifier)@name
+
+; FIXME shoulds not apply if
+;       - part of nested_type_identifier
+(type_identifier)@name {
+  node @name.type_ref
+  node @name.type_ref__ns
+
+  ; type reference
+  attr (@name.type_ref) node_reference = @name
+  edge @name.type_ref -> @name.type_ref__ns
+  ;
+  attr (@name.type_ref__ns) push_symbol = "%T"
+  edge @name.type_ref__ns -> @name.lexical_scope
+
+  ; type is the declaration
+  edge @name.type -> @name.type_ref
+}
+
+
+
+;; Nested Type Identifier
+
+; (nested_type_identifier
+;   module:[(identifier) (nested_identifier)]
+;   name:(_)
+; ) {}
+
+[
+  ; X
+  (nested_type_identifier module:(identifier)@name @mod)
+  ; X._
+  (nested_type_identifier module:(nested_identifier . (identifier)@name @mod))
+  ; X._._
+  (nested_type_identifier module:(nested_identifier . (nested_identifier . (identifier)@name @mod)))
+  ; X._._._
+  (nested_type_identifier module:(nested_identifier . (nested_identifier . (nested_identifier . (identifier)@name @mod))))
+  ; X._._._._
+  (nested_type_identifier module:(nested_identifier . (nested_identifier . (nested_identifier . (nested_identifier . (identifier)@name @mod)))))
+]@nested_type_id {
+  node @name.type_ref
+  node @name.type_ref__ns
+  node @mod.type
+
+  ; type reference to namespace name
+  edge @mod.type -> @name.type_ref
+  ;
+  attr (@name.type_ref) node_reference = @name
+  edge @name.type_ref -> @name.type_ref__ns
+  ;
+  attr (@name.type_ref__ns) push_symbol = "%T"
+  edge @name.type_ref__ns -> @nested_type_id.lexical_scope
+}
+
+[
+  ; _.X
+  (nested_type_identifier module:(nested_identifier . (_)@basemod . (identifier)@name .)@mod)
+  ; _._.X
+  (nested_type_identifier module:(nested_identifier . (nested_identifier . (_)@basemod . (identifier)@name .)@mod))
+  ; _._._.X
+  (nested_type_identifier module:(nested_identifier . (nested_identifier . (nested_identifier . (_)@basemod . (identifier)@name .)@mod)))
+  ; _._._._.X
+  (nested_type_identifier module:(nested_identifier . (nested_identifier . (nested_identifier . (nested_identifier . (_)@basemod . (identifier)@name .)@mod))))
+] {
+  node @name.type_ref
+  node @name.type_ref__ns
+  node @mod.member
+  node @mod.type
+
+  ; type reference to namespace name
+  edge @mod.type -> @name.type_ref
+  ;
+  attr (@name.type_ref) node_reference = @name
+  edge @name.type_ref -> @mod.member
+  ;
+  attr (@mod.member) push_symbol = "."
+  edge @mod.member -> @basemod.type
+}
+
+(nested_type_identifier
+  module:(_)@mod
+  name:(_)@name
+)@nested_type_id {
+  node @name.nested_type_ref ; FIXME non-standard name because the general (type_identifier) rule is also applied to @name
+  node @nested_type_id.member
+
+  ; type reference into namespace type
+  edge @nested_type_id.type -> @name.nested_type_ref
+  ;
+  attr (@name.nested_type_ref) node_reference = @name
+  edge @name.nested_type_ref -> @nested_type_id.member
+  ;
+  attr (@nested_type_id.member) push_symbol = "."
+  edge @nested_type_id.member -> @mod.type
+}
+
+
+
+;; Object Type
+
+; (object_type
+;   [(export_statement)
+;    (property_signature)
+;    (call_signature)
+;    (construct_signature)
+;    (index_signature)
+;    (method_signature)]@inner
+; )@type
+
+(object_type)@type {
+  ; mark type scope as endpoint
+  attr (@type.type) is_endpoint
+}
+
+(object_type
+  (_)@inner
+)@type {
+  ; propagate lexical scope
+  edge @inner.lexical_scope -> @type.lexical_scope
+
+  ; type consist of members
+  edge @type.type -> @inner.type_members
+}
+
+
+
+;; Type Parameters
+
+; (type_parameters
+;   (type_parameter) ; commaSep1
+; ) {}
+
+(type_parameters)@type_params {
+  node @type_params.defs
+}
+
+(type_parameters
+  (_)@param
+)@type_params {
+  ; propagate lexical scope
+  edge @param.lexical_scope -> @type_params.lexical_scope
+
+  ; type definitions are visible to each other
+  edge @param.lexical_scope -> @type_params.defs
+
+  ; expose type definitions
+  edge @type_params.defs -> @param.defs
+}
+
+; (type_parameter
+;   name:(type_identifier)
+;   constraint:(constraint) ; opt
+;   value:(default_type) ; opt
+; ) {}
+
+(type_parameter
+  name:(_)@name
+)@type_param {
+  node @name.type_def
+  node @name.type_def__ns
+  node @type_param.arg_index
+  node @type_param.defs
+
+  ; type definition
+  edge @type_param.defs -> @name.type_def__ns
+  ;
+  attr (@name.type_def__ns) pop_symbol = "%T"
+  edge @name.type_def__ns -> @name.type_def
+  ;
+  attr (@name.type_def) node_definition = @name
+
+  ; jump from parameter to positional type argument
+  edge @name.type_def -> @type_param.arg_index
+  ;
+  attr (@type_param.arg_index) push_symbol = (named-child-index @type_param)
+  edge @type_param.arg_index -> JUMP_TO_SCOPE_NODE
+}
+
+(type_parameter
+  name:(_)@name
+  value:(_)@type ; opt
+)@type_param {
+  ; propagate lexical scope
+  edge @type.lexical_scope -> @type_param.lexical_scope
+
+  ; type of definition is default type
+  edge @name.type_def -> @type_param.alias_type
+  ;
+  ; alias guards are set up by rules below
+  ;
+  edge @type_param.aliased_type -> @type.type
+}
+
+
+
+;; Default Type
+
+(default_type
+  (_)@type
+)@def_type {
+  ; propagate lexical scope
+  edge @type.lexical_scope -> @def_type.lexical_scope
+
+  ; type is type of inner
+  edge @def_type.type -> @type.type
+}
+
+
+
+;; Type Constraint
+
+(constraint
+  (_)@type
+)@type_c {
+  ; propagate lexical scope
+  edge @type.lexical_scope -> @type_c.lexical_scope
+
+  ; type is type of inner
+  edge @type_c.type -> @type.type
+}
+
+
+
+;; This Type
+
+(this_type)@this {
+  node @this.expr_ref
+  node @this.expr_ref__ns
+
+  ; expression reference
+  attr (@this.expr_ref) symbol_reference = "this", source_node = @this
+  edge @this.expr_ref -> @this.expr_ref__ns
+  ;
+  attr (@this.expr_ref__ns) push_symbol = "%T"
+  edge @this.expr_ref__ns -> @this.lexical_scope
+
+  ; type is the definition
+  edge @this.type -> @this.expr_ref
+}
+
+
+
+;; Template literal type
+
+; (template_literal_type)
+
+(template_literal_type (_)@inner)@type {
+  ; propagate lexical scope
+  edge @inner.lexical_scope -> @type.lexical_scope
+
+  ; type is type of inner
+  edge @type.type -> @inner.type
+}
+
+
+
+;; Template type
+
+; (template_type)
+
+(template_type (_)@inner)@type {
+  ; propagate lexical scope
+  edge @inner.lexical_scope -> @type.lexical_scope
+
+  ; type is type of inner
+  edge @type.type -> @inner.type
+}
+
+
+
+;  #####
+; #     # ###### #    # ###### #####  #  ####   ####
+; #       #      ##   # #      #    # # #    # #
+; #  #### #####  # #  # #####  #    # # #       ####
+; #     # #      #  # # #      #####  # #           #
+; #     # #      #   ## #      #   #  # #    # #    #
+;  #####  ###### #    # ###### #    # #  ####   ####
+
+;; Attributes defined on generic declarations
+;
+; in .lexical_scope
+;     Scope to resolve types in.
+;
+; out .generic_inner_lexical_scope
+;     Scope for types including the type parameters.
+;
+; out .generic_type
+;     Scope representing the (possibly) generic type.
+;
+; in .generic_inner_type
+;     Scope representing the type being abstracted over.
+
+[
+  (abstract_class_declaration)
+  (abstract_method_signature)
+  (call_signature)
+  (class)
+  (class_declaration)
+  (construct_signature)
+  (constructor_type)
+  (function_declaration)
+  (function_signature)
+  (function_type)
+  (generator_function_declaration)
+  (interface_declaration)
+  (method_definition)
+  (method_signature)
+  (type_alias_declaration)
+]@gen_decl {
+  node @gen_decl.generic_inner_lexical_scope
+  node @gen_decl.generic_inner_type
+  node @gen_decl.generic_type
+}
+
+[
+  (abstract_class_declaration     !type_parameters)
+  (abstract_method_signature      !type_parameters)
+  (call_signature                 !type_parameters)
+  (class                          !type_parameters)
+  (class_declaration              !type_parameters)
+  (construct_signature            !type_parameters)
+  (constructor_type               !type_parameters)
+  (function_declaration           !type_parameters)
+  (function_signature             !type_parameters)
+  (function_type                  !type_parameters)
+  (generator_function_declaration !type_parameters)
+  (interface_declaration          !type_parameters)
+  (method_definition              !type_parameters)
+  (method_signature               !type_parameters)
+  (type_alias_declaration         !type_parameters)
+]@gen_decl {
+  ; propagate lexical scope
+  edge @gen_decl.generic_inner_lexical_scope -> @gen_decl.lexical_scope
+
+  ; type is inner type, without abstraction
+  edge @gen_decl.generic_type -> @gen_decl.generic_inner_type
+}
+[
+  (abstract_class_declaration     type_parameters:(_)@type_params)
+  (abstract_method_signature      type_parameters:(_)@type_params)
+  (call_signature                 type_parameters:(_)@type_params)
+  (class                          type_parameters:(_)@type_params)
+  (class_declaration              type_parameters:(_)@type_params)
+  (construct_signature            type_parameters:(_)@type_params)
+  (constructor_type               type_parameters:(_)@type_params)
+  (function_declaration           type_parameters:(_)@type_params)
+  (function_signature             type_parameters:(_)@type_params)
+  (function_type                  type_parameters:(_)@type_params)
+  (generator_function_declaration type_parameters:(_)@type_params)
+  (interface_declaration          type_parameters:(_)@type_params)
+  (method_definition              type_parameters:(_)@type_params)
+  (method_signature               type_parameters:(_)@type_params)
+  (type_alias_declaration         type_parameters:(_)@type_params)
+]@gen_decl {
+  node @gen_decl.drop_type_args
+  node @gen_decl.drop_type_abs
+  node @gen_decl.type_abs
+
+  ; propagate lexical scope for parameters
+  edge @type_params.lexical_scope -> @gen_decl.lexical_scope
+
+  ; propagate lexical inner scope, dropping type arguments
+  edge @gen_decl.generic_inner_lexical_scope -> @gen_decl.drop_type_args
+  ;
+  attr (@gen_decl.drop_type_args) type = "drop_scopes"
+  edge @gen_decl.drop_type_args -> @gen_decl.lexical_scope
+
+  ; inner lexical scope includes type definitions
+  edge @gen_decl.generic_inner_lexical_scope -> @type_params.defs
+  attr (@gen_decl.generic_inner_lexical_scope -> @type_params.defs) precedence = 1
+
+  ; generic type is abstraction over inner type
+  edge @gen_decl.generic_type -> @gen_decl.type_abs
+  ;
+  attr (@gen_decl.type_abs) pop_scoped_symbol = "<>"
+  edge @gen_decl.type_abs -> @gen_decl.generic_inner_type
+
+  ; FIXME   This edge enables resolving to a member while dropping the type
+  ;       application from the scope stack. This is necessary to be able to
+  ;       resolve to a member inside a generic type without consuming its type.
+  ;       Consuming the type results in either DROP or JUMP. Resolving just to
+  ;       the field does not consume the scope on the scope stack, and is not
+  ;       considered a complete path.
+  ;         I think this is an example where a semantics that allows a non-
+  ;       empty scope stack, but not symbol stack, makes more sense than re-
+  ;       quiring the complete consumption of it. One of the effects of the strict
+  ;       semantics is that an intermediate path may not resolve on its own, but does
+  ;       resolve in the context of another path.
+  ;         An example can be found in the test `types/generic-interface.ts`, where
+  ;       in the expression `x.f.v`, the reference `.f` does not resolve on its own,
+  ;       while the reference `.v`, which depend on being able to resolve `.f` does
+  ;       resolve fine.
+  edge @gen_decl.type_abs -> @gen_decl.drop_type_abs
+  ;
+  attr (@gen_decl.drop_type_abs) type = "drop_scopes"
+  edge @gen_decl.drop_type_abs -> @gen_decl.generic_inner_type
+}
+
+;; Attributes defined on generic applications
+;
+; in .lexical_scope
+;     Scope to resolve types in.
+;
+; out .applied_type
+;     Application of the generic type.
+;
+; in .generic_type
+;     Generic type to be applied.
+
+[
+  (call_expression)
+  (new_expression)
+  (generic_type)
+]@gen_expr {
+  node @gen_expr.applied_type
+  node @gen_expr.generic_type
+}
+
+[
+  (call_expression !type_arguments)
+  (new_expression  !type_arguments)
+]@gen_expr {
+  ; direct edge for non-generic functions
+  edge @gen_expr.applied_type -> @gen_expr.generic_type
+}
+
+[
+  (call_expression !type_arguments)
+  (new_expression  !type_arguments)
+]@gen_expr {
+  node @gen_expr.type_app
+  node @gen_expr.inferred_type_args
+
+  ; push inferred type arguments
+  edge @gen_expr.applied_type -> @gen_expr.type_app
+  ;
+  attr (@gen_expr.type_app) push_scoped_symbol = "<>", scope = @gen_expr.inferred_type_args
+  edge @gen_expr.type_app -> @gen_expr.generic_type
+
+  ; FIXME infer type arguments
+}
+
+[
+  (call_expression type_arguments:(_)@type_args)
+  (new_expression  type_arguments:(_)@type_args)
+  (generic_type    type_arguments:(_)@type_args)
+]@gen_expr {
+  node @gen_expr.type_app
+
+  ; propagate lexical scope
+  edge @type_args.lexical_scope -> @gen_expr.lexical_scope
+
+  ; push given type arguments
+  edge @gen_expr.applied_type -> @gen_expr.type_app
+  ;
+  attr (@gen_expr.type_app) push_scoped_symbol = "<>", scope = @type_args.type_args
+  edge @gen_expr.type_app -> @gen_expr.generic_type
+}
+
+
+
+;    #
+;   # #   #      #   ##    ####  ######  ####
+;  #   #  #      #  #  #  #      #      #
+; #     # #      # #    #  ####  #####   ####
+; ####### #      # ######      # #           #
+; #     # #      # #    # #    # #      #    #
+; #     # ###### # #    #  ####  ######  ####
+
+; Attributes defined on type aliases
+;
+; out .alias_type
+;     Type with alias guards in place.
+;
+; in .aliased_type
+;     Type to be aliased.
+
+[
+  (extends_clause)
+  (extends_type_clause)
+  (implements_clause)
+  (type_alias_declaration)
+  (type_parameter)
+]@alias {
+  node @alias.alias_type
+  node @alias.alias_type__callable_pop
+  node @alias.alias_type__callable_push
+  node @alias.alias_type__ctor_pop
+  node @alias.alias_type__ctor_push
+  node @alias.alias_type__indexable_pop
+  node @alias.alias_type__indexable_push
+  node @alias.alias_type__member_pop
+  node @alias.alias_type__member_push
+  node @alias.aliased_type
+
+  ; alias members
+  edge @alias.alias_type -> @alias.alias_type__member_pop
+  ;
+  attr (@alias.alias_type__member_pop) pop_symbol = "."
+  edge @alias.alias_type__member_pop -> @alias.alias_type__member_push
+  ;
+  attr (@alias.alias_type__member_push) push_symbol = "."
+  edge @alias.alias_type__member_push -> @alias.aliased_type
+
+  ; alias callable
+  edge @alias.alias_type -> @alias.alias_type__callable_pop
+  ;
+  attr (@alias.alias_type__callable_pop) pop_symbol = "->"
+  edge @alias.alias_type__callable_pop -> @alias.alias_type__callable_push
+  ;
+  attr (@alias.alias_type__callable_push) push_symbol = "->"
+  edge @alias.alias_type__callable_push -> @alias.aliased_type
+
+  ; alias indexable
+  edge @alias.alias_type -> @alias.alias_type__indexable_pop
+  ;
+  attr (@alias.alias_type__indexable_pop) pop_symbol = "[]"
+  edge @alias.alias_type__indexable_pop -> @alias.alias_type__indexable_push
+  ;
+  attr (@alias.alias_type__indexable_push) push_symbol = "[]"
+  edge @alias.alias_type__indexable_push -> @alias.aliased_type
+
+  ; alias constructors
+  edge @alias.alias_type -> @alias.alias_type__ctor_pop
+  ;
+  attr (@alias.alias_type__ctor_pop) pop_symbol = "<new>"
+  edge @alias.alias_type__ctor_pop -> @alias.alias_type__ctor_push
+  ;
+  attr (@alias.alias_type__ctor_push) push_symbol = "<new>"
+  edge @alias.alias_type__ctor_push -> @alias.aliased_type
+}
+
+; Attributes defined on expr aliases
+;
+; out .alias_expr
+;     Type with alias guards in place.
+;
+; in .aliased_expr
+;     Type to be aliased.
+
+; [
+; ]@alias {
+;   ; type of expression
+;   edge @alias.alias_expr -> @alias.alias_expr__typeof
+;   ;
+;   attr (@alias.alias_expr__typeof) pop_symbol = ":"
+
+;   ; alias members
+;   edge @alias.alias_expr__typeof -> @alias.alias_expr__member_pop
+;   ;
+;   attr (@alias.alias_expr__member_pop) pop_symbol = "."
+;   edge @alias.alias_expr__member_pop -> @alias.alias_expr__member_push
+;   ;
+;   attr (@alias.alias_expr__member_push) push_symbol = "."
+;   edge @alias.alias_expr__member_push -> @alias.aliased_expr__typeof
+
+;   ; alias callable
+;   edge @alias.alias_expr__typeof -> @alias.alias_expr__callable_pop
+;   ;
+;   attr (@alias.alias_expr__callable_pop) pop_symbol = "->"
+;   edge @alias.alias_expr__callable_pop -> @alias.alias_expr__callable_push
+;   ;
+;   attr (@alias.alias_expr__callable_push) push_symbol = "->"
+;   edge @alias.alias_expr__callable_push -> @alias.aliased_expr__typeof
+
+;   ; alias indexable
+;   edge @alias.alias_expr__typeof -> @alias.alias_expr__indexable_pop
+;   ;
+;   attr (@alias.alias_expr__indexable_pop) pop_symbol = "[]"
+;   edge @alias.alias_expr__indexable_pop -> @alias.alias_expr__indexable_push
+;   ;
+;   attr (@alias.alias_expr__indexable_push) push_symbol = "[]"
+;   edge @alias.alias_expr__indexable_push -> @alias.aliased_expr__typeof
+
+;   ; alias constructors
+;   edge @alias.alias_expr__typeof -> @alias.alias_expr__ctor_pop
+;   ;
+;   attr (@alias.alias_expr__ctor_pop) pop_symbol = "<new>"
+;   edge @alias.alias_expr__ctor_pop -> @alias.alias_expr__ctor_push
+;   ;
+;   attr (@alias.alias_expr__ctor_push) push_symbol = "<new>"
+;   edge @alias.alias_expr__ctor_push -> @alias.aliased_expr__typeof
+
+;   ; type of target
+;   attr (@alias.aliased_expr__typeof) push_symbol = ":"
+;   edge @alias.aliased_expr__typeof -> @alias.aliased_expr
+; }
+
+
+
+;
+;    #                                        #       #
+;   # #    ####  #   # #    #  ####          #       # #   #    #   ##   # #####
+;  #   #  #       # #  ##   # #    #        #       #   #  #    #  #  #  #   #
+; #     #  ####    #   # #  # #            #       #     # #    # #    # #   #
+; #######      #   #   #  # # #           #        ####### # ## # ###### #   #
+; #     # #    #   #   #   ## #    #     #         #     # ##  ## #    # #   #
+; #     #  ####    #   #    #  ####     #          #     # #    # #    # #   #
+;
+
+; Attributes defined on await:
+;
+; in .async_type
+;   The async type being awaiting.
+;
+; out .await_type
+;   The type of the result of awaiting.
+
+[
+  (await_expression)
+]@await {
+  node @await.async_type
+  node @await.await_type
+  node @await.await_type__member
+  node @await.await_type__ref
+  node @await.await_type__typeof
+
+  ; type is the internal $Promise$T member of the promise type
+  edge @await.await_type -> @await.await_type__typeof
+  ;
+  attr (@await.await_type__typeof) push_symbol = ":"
+  edge @await.await_type__typeof -> @await.await_type__ref
+  ;
+  attr (@await.await_type__ref) push_symbol = "$Promise$T"
+  edge @await.await_type__ref -> @await.await_type__member
+  ;
+  attr (@await.await_type__member) push_symbol = "."
+  edge @await.await_type__member -> @await.async_type
+}
+
+; Attributes defined on async:
+;
+; out .async_type
+;   The async type being returned.
+;
+; out .await_type
+;   The type of the result of awaiting.
+
+[
+  (arrow_function                 "async")
+  (function                       "async")
+  (function_declaration           "async")
+  (generator_function             "async")
+  (generator_function_declaration "async")
+  (method_definition              "async")
+]@async {
+  node @async.async_type
+  node @async.async_type__type_app
+  node @async.async_type__type_arg
+  node @async.async_type__type_args
+  node @async.async_type__promise_ref
+  node @async.async_type__promise_ref__ns
+  node @async.await_type
+  node @async.await_type__member
+  node @async.await_type__ref
+  node @async.await_type__typeof
+
+  ; type arguments
+  edge @async.async_type__type_args -> @async.async_type__type_arg
+  ;
+  attr (@async.async_type__type_arg) pop_symbol = 0
+  edge @async.async_type__type_arg -> @async.await_type
+
+  ; type is applied Promise
+  edge @async.async_type -> @async.async_type__type_app
+  ;
+  attr (@async.async_type__type_app) push_scoped_symbol = "<>", scope = @async.async_type__type_args
+  edge @async.async_type__type_app -> @async.async_type__promise_ref
+  ;
+  attr (@async.async_type__promise_ref) symbol_reference = "Promise", source_node = @async
+  edge @async.async_type__promise_ref -> @async.async_type__promise_ref__ns
+  ;
+  attr (@async.async_type__promise_ref__ns) push_symbol = "%T"
+  edge @async.async_type__promise_ref__ns -> ROOT_NODE
+}

--- a/languages/tree-sitter-stack-graphs-typescript/test/base/cannot-resolve-field-in-shadowed-object.ts.skip
+++ b/languages/tree-sitter-stack-graphs-typescript/test/base/cannot-resolve-field-in-shadowed-object.ts.skip
@@ -1,0 +1,14 @@
+let x = {
+    f: 11
+};
+
+{
+    let x = {
+    };
+
+    x.f;
+  //^ defined: 6
+  //  ^ defined:
+}
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/base/for-var-scoped-in-file-and-visible-inside-function.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/base/for-var-scoped-in-file-and-visible-inside-function.ts
@@ -1,0 +1,11 @@
+for(var x = 0; x < 42; x++) {
+  let f = function() {
+    x = 2;
+  //^ defined: 1
+  };
+}
+
+  x = 1;
+//^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/base/for-var-scoped-in-function.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/base/for-var-scoped-in-function.ts
@@ -1,0 +1,13 @@
+function f() {
+  x = 2;
+//^ defined: 4
+  for(var x = 0; x < 42; x++) {
+  //             ^ defined: 4
+  //                     ^ defined: 4
+  }
+}
+
+  x = 1; // tsc: error: Cannot find name 'x'.
+//^ defined:
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/base/mutually-recursive-functions.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/base/mutually-recursive-functions.ts
@@ -1,0 +1,10 @@
+function odd(x) {
+  return x > 1 ? even(x - 1) : x === 1;
+  //             ^ defined: 5
+}
+function even(x) {
+  return x > 1 ? odd(x - 1) : x === 0;
+  //             ^ defined: 1
+}
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/base/nested-for-var-scoped-in-function.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/base/nested-for-var-scoped-in-function.ts
@@ -1,0 +1,15 @@
+function f() {
+  x = 2;
+//^ defined: 5
+  while(true) {
+    for(var x = 0; x < 42; x++) {
+    //             ^ defined: 5
+    //                     ^ defined: 5
+    }
+  }
+}
+
+  x = 1; // tsc: error: Cannot find name 'x'.
+//^ defined:
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/base/var-reference-before-def.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/base/var-reference-before-def.ts
@@ -1,0 +1,7 @@
+  x = 1;
+//^ defined: 4
+
+var x;
+
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/base/var-scoped-in-function.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/base/var-scoped-in-function.ts
@@ -1,0 +1,11 @@
+function f() {
+  x = 2;
+//^ defined: 4
+  var x;
+}
+
+  x = 1; // tsc: error: Cannot find name 'x'.
+//^ defined:
+
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/builtins/async-arrow-function.ts.skip
+++ b/languages/tree-sitter-stack-graphs-typescript/test/builtins/async-arrow-function.ts.skip
@@ -1,0 +1,9 @@
+let f = async () => ({ v: 42 });
+
+async function test() {
+  (await f()).v;
+  //     ^ defined: 1
+  //          ^ defined: 1
+}
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/builtins/async-function-definition.ts.skip
+++ b/languages/tree-sitter-stack-graphs-typescript/test/builtins/async-function-definition.ts.skip
@@ -1,0 +1,14 @@
+interface V {
+  v: number;
+}
+
+async function f(): Promise<V> { return { v: 42 } };
+//                          ^ defined: 1
+
+async function test() {
+  (await f()).v;
+  //     ^ defined: 5
+  //          ^ defined: 2
+}
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/builtins/async-function-expression.ts.skip
+++ b/languages/tree-sitter-stack-graphs-typescript/test/builtins/async-function-expression.ts.skip
@@ -1,0 +1,14 @@
+interface V {
+  v: number;
+}
+
+let f = async function(): Promise<V> { return { v: 42 } };
+//                                ^ defined: 1
+
+async function test() {
+  (await f()).v;
+  //     ^ defined: 5
+  //          ^ defined: 2
+}
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/builtins/async-function-inferred-return-type-not-directly-accessible.ts.skip
+++ b/languages/tree-sitter-stack-graphs-typescript/test/builtins/async-function-inferred-return-type-not-directly-accessible.ts.skip
@@ -1,0 +1,10 @@
+async function f() {
+    return { v: 42 };
+}
+
+async function test() {
+    f().v;
+    //  ^ defined:
+}
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/builtins/async-method-with-inferred-return-type.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/builtins/async-method-with-inferred-return-type.ts
@@ -1,0 +1,16 @@
+class A {
+    async m() {
+        return { v: 42 };
+    }
+}
+
+declare let x:A;
+
+async function test() {
+    (await x.m()).v;
+    //     ^ defined: 7
+    //       ^ defined: 2
+    //            ^ defined: 3
+}
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/builtins/await-async-function-with-inferred-return-type.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/builtins/await-async-function-with-inferred-return-type.ts
@@ -1,0 +1,11 @@
+async function f() {
+  return { v: 42 };
+};
+
+async function test() {
+  (await f()).v;
+  //     ^ defined: 1
+  //          ^ defined: 2
+};
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/builtins/await-function-with-explicit-return-type.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/builtins/await-function-with-explicit-return-type.ts
@@ -1,0 +1,12 @@
+interface V { v: number; }
+
+declare function f(): Promise<V>;
+//                            ^ defined: 1
+
+async function test() {
+  (await f()).v;
+  //     ^ defined: 3
+//            ^ defined: 1
+}
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/builtins/await-variable.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/builtins/await-variable.ts
@@ -1,0 +1,10 @@
+interface V { v: number; }
+
+declare let x: Promise<V>;
+//                     ^ defined: 1
+
+(await x).v;
+//     ^ defined: 3
+//        ^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/builtins/builtin-Array-type.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/builtins/builtin-Array-type.ts
@@ -1,0 +1,18 @@
+interface V {
+  v: number;
+}
+
+declare let xs: Array<V>;
+//                    ^ defined: 1
+
+  xs[0].v;
+//^ defined: 5
+//      ^ defined: 2
+
+  xs.find((x) => x.v === 42).v;
+//^ defined: 5
+//               ^ defined: 12
+//                 ^ defined: 2
+//                           ^ defined: 2
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/builtins/builtin-Map-type.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/builtins/builtin-Map-type.ts
@@ -1,0 +1,21 @@
+interface V {
+  v: number;
+}
+
+declare let kv: Map<string, V>;
+//                          ^ defined: 1
+
+  kv.get("fortytwo")?.v;
+//^ defined: 5
+//                    ^ defined: 2
+
+  kv.forEach((v, k, kv) => {
+      kv.get(k)?.v === v.v;
+    //^ defined: 12
+    //       ^ defined: 12
+    //           ^ defined: 2
+    //                 ^ defined: 12
+    //                   ^ defined: 2
+  });
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/builtins/builtin-Set-type.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/builtins/builtin-Set-type.ts
@@ -1,0 +1,17 @@
+interface V {
+  v: number;
+}
+
+declare let xs: Set<V>;
+//                  ^ defined: 1
+
+  xs.forEach((x1, x2) => {
+      x1.v;
+    //^ defined: 8
+    //   ^ defined: 2
+      x2.v;
+    //^ defined: 8
+    //   ^ defined: 2
+  });
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/access-property-in-abstract-super-class.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/access-property-in-abstract-super-class.ts
@@ -1,0 +1,19 @@
+type V = { value: number; }
+
+abstract class A {
+    f: V;
+    // ^ defined: 1
+}
+
+class C extends A {
+//              ^ defined: 3
+}
+
+let x:C;
+//    ^ defined: 8
+
+  x.f;
+//^ defined: 12
+//  ^ defined: 4
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/arrow-function.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/arrow-function.ts
@@ -1,0 +1,20 @@
+interface V {
+  v: number;
+}
+
+let f = x => x;
+//           ^ defined: 5
+
+let g = (y:V) => y;
+//         ^ defined: 1
+//               ^ defined: 8
+
+  g(null).v;
+//^ defined: 8
+//        ^ defined: 2
+
+let h = (x):V => x;
+//          ^ defined: 1
+//               ^ defined: 16
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-class-abstract-super-class-method.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-class-abstract-super-class-method.ts
@@ -1,0 +1,21 @@
+type V = { value: number; }
+
+abstract class A {
+    m(x: V): V { return x; };
+    //   ^ defined: 1
+    //       ^ defined: 1
+}
+
+class C extends A {
+//              ^ defined: 3
+}
+
+let foo: C;
+//       ^ defined: 9
+
+  foo.m(null).value;
+//^ defined: 13
+//    ^ defined: 4
+//            ^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-class-super-interface-method.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-class-super-interface-method.ts
@@ -1,0 +1,21 @@
+type V = { value: number; }
+
+interface I {
+    m(x: V): V;
+    //   ^ defined: 1
+    //       ^ defined: 1
+}
+
+class C implements I {
+    m(x:V) { return x; }
+}
+
+let foo: C;
+//       ^ defined: 9
+
+  foo.m(null).value;
+//^ defined: 13
+//    ^ defined: 4, 10
+//            ^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-declared-function.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-declared-function.ts
@@ -1,0 +1,13 @@
+type V = { value: number; }
+
+function foo(x:V): V {
+//                 ^ defined: 1
+    return null;
+}
+
+
+  foo(null).value;
+//^ defined: 3
+//          ^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-function-literal.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-function-literal.ts
@@ -1,0 +1,9 @@
+type V = { value: number; }
+
+(function foo(x:V): V {
+//                  ^ defined: 1
+    return null;
+})(null).value;
+//       ^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-function-type.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-function-type.ts
@@ -1,0 +1,11 @@
+type V = { value: number; }
+
+let foo: (x:V) => V;
+//          ^ defined: 1
+//                ^ defined: 1
+
+  foo(null).value;
+//^ defined: 3
+//          ^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-generic-function-signature.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-generic-function-signature.ts
@@ -1,0 +1,9 @@
+type V = { value: number; }
+
+function id<X>(x: X): X; // tsc: error TS2391: Function implementation is missing or not immediately following the declaration.
+
+  id<V>(null).value;
+//^ defined: 3
+//            ^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-generic-function-type.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-generic-function-type.ts
@@ -1,0 +1,9 @@
+type V = { value: number; }
+
+let id: <X>(x: X) => X;
+
+  id<V>(null).value;
+//^ defined: 3
+//            ^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-generic-function-with-concrete-return-type-without-type-arguments.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-generic-function-with-concrete-return-type-without-type-arguments.ts
@@ -1,0 +1,16 @@
+interface V {
+  value: number;
+}
+
+let id: <X>(x: X) => V;
+//             ^ defined: 5
+//                   ^ defined: 1
+
+let v: number;
+
+  id(v).value;
+//^ defined: 5
+//   ^ defined: 9
+//      ^ defined: 2
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-generic-function-with-default-without-type-arguments.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-generic-function-with-default-without-type-arguments.ts
@@ -1,0 +1,13 @@
+interface V {
+  v: number;
+}
+
+let id: <X = V>(x: X) => X;
+//                 ^ defined: 5
+//                       ^ defined: 5
+
+  id(null).v;
+//^ defined: 5
+//         ^ defined: 2
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-generic-function.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-generic-function.ts
@@ -1,0 +1,11 @@
+type V = { value: number; }
+
+function id<X>(x: X): X {
+    return x;
+}
+
+  id<V>(null).value;
+//^ defined: 3
+//            ^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-interface-generic-function.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-interface-generic-function.ts
@@ -1,0 +1,14 @@
+type V = { value: number; }
+
+interface I {
+    id<X>(x: X): X;
+}
+
+let x:I;
+
+  x.id<V>(null).value;
+//^ defined: 7
+//  ^ defined: 4
+//              ^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-interface-method.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-interface-method.ts
@@ -1,0 +1,17 @@
+type V = { value: number; }
+
+interface I {
+    m(x: V): V;
+    //   ^ defined: 1
+    //       ^ defined: 1
+}
+
+let foo: I;
+//       ^ defined: 3
+
+  foo.m(null).value;
+//^ defined: 9
+//    ^ defined: 4
+//            ^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-interface-super-interface-method.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-interface-super-interface-method.ts
@@ -1,0 +1,19 @@
+type V = { value: number; }
+
+interface I {
+    m(x: V): V;
+    //   ^ defined: 1
+    //       ^ defined: 1
+}
+
+interface J extends I {}
+
+let foo: J;
+//       ^ defined: 9
+
+  foo.m(null).value;
+//^ defined: 11
+//    ^ defined: 4
+//            ^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-let-bound-function-literal.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-let-bound-function-literal.ts
@@ -1,0 +1,12 @@
+type V = { value: number; }
+
+let foo = function(x:V): V {
+//                       ^ defined: 1
+    return null;
+}
+
+  foo(null).value;
+//^ defined: 3
+//          ^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-object-function-property.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-object-function-property.ts
@@ -1,0 +1,17 @@
+type V = { value: number; }
+
+type O = {
+    m: (x:V) => V;
+    //    ^ defined: 1
+    //          ^ defined: 1
+};
+
+let foo: O;
+//       ^ defined: 3
+
+  foo.m(null).value;
+//^ defined: 9
+//    ^ defined: 4
+//            ^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-object-method.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-object-method.ts
@@ -1,0 +1,17 @@
+type V = { value: number; }
+
+type O = {
+    m(x:V): V;
+    //  ^ defined: 1
+    //      ^ defined: 1
+};
+
+let foo: O;
+//       ^ defined: 3
+
+  foo.m(null).value;
+//^ defined: 9
+//    ^ defined: 4
+//            ^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-object-with-call-signature.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-object-with-call-signature.ts
@@ -1,0 +1,13 @@
+type V = { value: number; }
+
+let foo: {
+    (x:V): V;
+    // ^ defined: 1
+    //     ^ defined: 1
+};
+
+  foo(null).value;
+//^ defined: 3
+//          ^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-with-template-string.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/call-with-template-string.ts
@@ -1,0 +1,9 @@
+function id(x) {
+    return x;
+}
+
+let y = "world"
+
+  id`x${y}`
+//^ defined: 1
+//      ^ defined: 5

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/index-getter-property.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/index-getter-property.ts
@@ -1,0 +1,20 @@
+type V = { value: number; }
+
+class C {
+    get p(): V { return null; }
+    //       ^ defined: 1
+}
+
+let x:C;
+
+  x.p.value;
+//^ defined: 8
+//  ^ defined: 4
+//    ^ defined: 1
+
+  x['p'].value;
+//^ defined: 8
+//  ^ defined: 4
+//       ^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/index-into-array.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/index-into-array.ts
@@ -1,0 +1,20 @@
+interface V { v: number; }
+interface N { n: number; }
+
+let xs = [{ v: 42 }, { n: 42 }];
+
+  xs[0].v;
+//^ defined: 4
+//      ^ defined: 4
+
+  xs[0].n;
+//^ defined: 4
+//      ^ defined: 4
+
+declare let i: number;
+
+  xs[i].n;
+//^ defined: 4
+//      ^ defined: 4
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/index-into-object-with-index-signature.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/index-into-object-with-index-signature.ts
@@ -1,0 +1,11 @@
+type V = { value: number; }
+
+let foo: {
+    [index:number]: V;
+};
+
+  foo[1].value;
+//^ defined: 3
+//       ^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/index-named-property.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/index-named-property.ts
@@ -1,0 +1,11 @@
+type V = { value: number; }
+
+let foo: {
+    bar: V;
+};
+
+  foo["bar"].value;
+//^ defined: 3
+//           ^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/index-on-variable.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/index-on-variable.ts
@@ -1,0 +1,18 @@
+interface V {
+  v: number;
+}
+
+declare let ys: V[];
+//              ^ defined: 1
+
+declare let i: number;
+
+const y = ys[i];
+//        ^ defined: 5
+//           ^ defined: 8
+
+  y.v;
+//^ defined: 10
+//  ^ defined: 2
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/index-setter-property.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/index-setter-property.ts
@@ -1,0 +1,18 @@
+type V = { value: number; }
+
+class C {
+    set p(v: V) {}
+    //       ^ defined: 1
+}
+
+let x:C;
+
+  x.p = null;
+//^ defined: 8
+//  ^ defined: 4
+
+  x['p'] = null;
+//^ defined: 8
+//  ^ defined: 4
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/new-from-construct-signature.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/new-from-construct-signature.ts
@@ -1,0 +1,14 @@
+interface V {
+    v: number;
+    new () : V;
+    //       ^ defined: 1
+}
+
+let x: V;
+//     ^ defined: 1
+
+new x().v;
+//  ^ defined: 7
+//      ^ defined: 2
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/new-on-aliased-class-object.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/new-on-aliased-class-object.ts
@@ -1,0 +1,12 @@
+class V {
+  value: number = 1;
+}
+
+let VV = V;
+//       ^ defined: 1
+
+new VV().value;
+//  ^ defined: 5
+//       ^ defined: 2
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/new-on-expr-with-constructor-type.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/new-on-expr-with-constructor-type.ts
@@ -1,0 +1,11 @@
+class V {
+  value: number = 1;
+}
+
+declare let c: new() => V;
+
+new c().value;
+//  ^ defined: 5
+//      ^ defined: 2
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/new-target-property.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/new-target-property.ts
@@ -1,0 +1,6 @@
+// this test has no assertions and only exists to ensure coverage
+
+function Foo() {
+  if (!new.target) { throw 'Foo() must be called with new'; }
+}
+ export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/object-literal-type.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/object-literal-type.ts
@@ -1,0 +1,32 @@
+interface V {
+    v: number;
+}
+
+let p: V;
+//     ^ defined: 1
+
+let x = {
+    p,
+//  ^ defined: 5
+    q: p,
+//     ^ defined: 5
+    "r": p,
+//       ^ defined: 5
+};
+
+  x.p.v;
+//^ defined: 8
+//  ^ defined: 9
+//    ^ defined: 2
+
+  x.q.v;
+//^ defined: 8
+//  ^ defined: 11
+//    ^ defined: 2
+
+  x.r.v;
+//^ defined: 8
+//  ^ defined: 13
+//    ^ defined: 2
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/default-export-declaration-is-locally-visible.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/default-export-declaration-is-locally-visible.ts
@@ -1,0 +1,12 @@
+export default class T {
+    v = 42;
+};
+
+declare let x: T;
+//             ^ defined: 1
+
+  x.v;
+//^ defined: 5
+//  ^ defined: 2
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/default-exported-declaration-is-not-a-named-export.ts.skip
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/default-exported-declaration-is-not-a-named-export.ts.skip
@@ -1,0 +1,10 @@
+/*--- path: ModA.ts ---*/
+
+export default class T {
+    v = 42;
+};
+
+/*--- path: ModB.ts ---*/
+
+import { T } from "./ModA" // tsc: Module '"./ModA"' has no exported member 'T'.
+//       ^ defined:

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/export-as-namespace.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/export-as-namespace.ts
@@ -1,0 +1,16 @@
+/*--- path: ModA.ts ---*/
+
+export let x = {
+  v: 42
+};
+
+export as namespace A;
+
+/*--- path: ModB.ts ---*/
+
+  A.x.v;
+//^ defined: 7
+//  ^ defined: 3
+//    ^ defined: 4
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-as-namespace.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-as-namespace.ts
@@ -1,0 +1,14 @@
+/*--- path: ModA.ts ---*/
+
+export let x = {
+  v: 42
+};
+
+/*--- path: ModB.ts ---*/
+
+import * as A from "./ModA";
+
+  A.x.v;
+//^ defined: 9
+//  ^ defined: 3
+//    ^ defined: 4

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-default-class-definition-type-and-expression.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-default-class-definition-type-and-expression.ts
@@ -1,0 +1,19 @@
+/*--- path: ModA.ts ---*/
+
+export default class T {
+    v = 42;
+};
+
+/*--- path: ModB.ts ---*/
+
+import T from "./ModA";
+
+let x = T;
+//      ^ defined: 9, 3
+
+declare let a: T;
+//             ^ defined: 9, 3
+
+  a.v;
+//^ defined: 14
+//  ^ defined: 4

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-default-class-reference-type-and-expression.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-default-class-reference-type-and-expression.ts
@@ -1,0 +1,21 @@
+/*--- path: ModA.ts ---*/
+
+class T {
+    v = 42;
+};
+
+export default T;
+
+/*--- path: ModB.ts ---*/
+
+import T from "./ModA";
+
+let x = T;
+//      ^ defined: 11, 7
+
+declare let a: T;
+//             ^ defined: 11, 7, 3
+
+  a.v;
+//^ defined: 16
+//  ^ defined: 4

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-default-enum-reference-type-and-expression.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-default-enum-reference-type-and-expression.ts
@@ -1,0 +1,16 @@
+/*--- path: ModA.ts ---*/
+
+enum E {
+  C
+};
+
+export default E;
+
+/*--- path: ModB.ts ---*/
+
+import E from "./ModA";
+
+let x: E = E.C;
+//     ^ defined: 11, 7, 3
+//         ^ defined: 11, 7
+//           ^ defined: 4

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-default-expression.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-default-expression.ts
@@ -1,0 +1,13 @@
+/*--- path: ModA.ts ---*/
+
+export default {
+    v: 42
+};
+
+/*--- path: ModB.ts ---*/
+
+import a from "./ModA";
+
+  a.v;
+//^ defined: 9, 3
+//  ^ defined: 4

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-default-interface.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-default-interface.ts
@@ -1,0 +1,16 @@
+/*--- path: ModA.ts ---*/
+
+export default interface T {
+  v: number;
+};
+
+/*--- path: ModB.ts ---*/
+
+import T from "./ModA"
+
+declare let x: T;
+//             ^ defined: 9, 3
+
+  x.v;
+//^ defined: 11
+//  ^ defined: 4

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-default-type.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-default-type.ts
@@ -1,0 +1,19 @@
+/*--- path: ModA.ts ---*/
+
+export default T;
+//             ^ defined: 6
+
+type T = {
+    v: number;
+};
+
+/*--- path: ModB.ts ---*/
+
+import T from "./ModA";
+
+declare let a: T;
+//             ^ defined: 12, 3, 6
+
+  a.v;
+//^ defined: 14
+//  ^ defined: 7

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-directly-exported-variable.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-directly-exported-variable.ts
@@ -1,0 +1,14 @@
+/*--- path: ./ModA.ts ---*/
+
+export let a = {
+    v: 42
+};
+
+/*--- path: ./ModB.ts ---*/
+
+import { a } from "./ModA";
+//       ^ defined: 3
+
+  a.v;
+//^ defined: 9, 3
+//  ^ defined: 4

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-exports-class.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-exports-class.ts
@@ -1,0 +1,19 @@
+/* --- path: A.ts --- */
+
+export = A;
+
+class A {
+    f = 42;
+}
+
+/* --- path: B.ts --- */
+
+import C = require("./A");
+
+let c: C = new C();
+//     ^ defined: 11, 3, 5
+//             ^ defined: 11, 3
+
+  c.f;
+//^ defined: 13
+//  ^ defined: 6

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-exports-object.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-exports-object.ts
@@ -1,0 +1,15 @@
+/*--- path: ModA.ts ---*/
+
+export = A;
+
+let A = {
+    f: 42
+};
+
+/*--- path: ModB.ts ---*/
+
+import a = require('./ModA');
+
+  a.f;
+//^ defined: 11, 3
+//  ^ defined: 6

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-exports-of-indirect-class.ts.skip
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-exports-of-indirect-class.ts.skip
@@ -1,0 +1,21 @@
+/* --- path: A.ts --- */
+
+export = A;
+
+class B {
+    f = 42;
+}
+
+const A = B;
+
+/* --- path: B.ts --- */
+
+import C = require("./A");
+
+let c: C = new C();
+//     ^ defined:
+//             ^ defined: 13
+
+  c.f;
+//^ defined: 15
+//  ^ defined: 6

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-from-subdirectory.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-from-subdirectory.ts
@@ -1,0 +1,14 @@
+/*--- path: ./A/ModA.ts ---*/
+
+export let a = {
+    v: 42
+};
+
+/*--- path: ./ModB.ts ---*/
+
+import { a } from "./A/ModA";
+//       ^ defined: 3
+
+  a.v;
+//^ defined: 9, 3
+//  ^ defined: 4

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-from-superdirectory.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-from-superdirectory.ts
@@ -1,0 +1,14 @@
+/*--- path: ./ModA.ts ---*/
+
+export let a = {
+    v: 42
+};
+
+/*--- path: ./B/ModB.ts ---*/
+
+import { a } from "../ModA";
+//       ^ defined: 3
+
+  a.v;
+//^ defined: 9, 3
+//  ^ defined: 4

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-indirectly-exported-variable.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-indirectly-exported-variable.ts
@@ -1,0 +1,17 @@
+/*--- path: ./ModA.ts ---*/
+
+let a = {
+    v: 42
+};
+
+export { a };
+//       ^ defined: 3
+
+/*--- path: ./ModB.ts ---*/
+
+import { a } from "./ModA";
+//       ^ defined: 7, 3
+
+  a.v;
+//^ defined: 12, 7, 3
+//  ^ defined: 4

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-via-index.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-via-index.ts
@@ -1,0 +1,14 @@
+/*--- path: ./A/index.ts ---*/
+
+export let a = {
+    v: 42
+};
+
+/*--- path: ./B/ModB.ts ---*/
+
+import { a } from "../A";
+//       ^ defined: 3
+
+  a.v;
+//^ defined: 9, 3
+//  ^ defined: 4

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-via-superdirectory.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-via-superdirectory.ts
@@ -1,0 +1,14 @@
+/*--- path: ./A/ModA.ts ---*/
+
+export let a = {
+    v: 42
+};
+
+/*--- path: ./B/ModB.ts ---*/
+
+import { a } from "../A/ModA";
+//       ^ defined: 3
+
+  a.v;
+//^ defined: 9, 3
+//  ^ defined: 4

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/module-declaration-not-visible-in-other-module.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/module-declaration-not-visible-in-other-module.ts
@@ -1,0 +1,12 @@
+// --- path: a.ts ---
+
+let x = 42;
+
+export {}
+
+// --- path: b.ts ---
+
+let y = x;
+//      ^ defined:
+
+export {}

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/namespace-type-export.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/namespace-type-export.ts
@@ -1,0 +1,15 @@
+namespace A {
+    export type T = {
+        v: number;
+    };
+};
+
+let x: A.T;
+//     ^ defined: 1
+//       ^ defined: 2
+
+  x.v;
+//^ defined: 7
+//  ^ defined: 3
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/namespace-variable-export.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/namespace-variable-export.ts
@@ -1,0 +1,10 @@
+namespace A {
+    export let b = { v: 42 };
+};
+
+  A.b.v;
+//^ defined: 1
+//  ^ defined: 2
+//    ^ defined: 2
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/refer-to-separately-defined-subnamespace-from-supernamespace.ts.skip
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/refer-to-separately-defined-subnamespace-from-supernamespace.ts.skip
@@ -1,0 +1,11 @@
+export {};
+
+namespace M.N.O.P {
+  export interface A {}
+}
+
+namespace M.N.O {
+  interface B extends P.A {}
+  //                  ^ defined: 3
+  //                    ^ defined: 4
+}

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/refer-to-type-in-aprent-namespace-from-split-qualified-namespace.ts.skip
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/refer-to-type-in-aprent-namespace-from-split-qualified-namespace.ts.skip
@@ -1,0 +1,12 @@
+export {};
+
+namespace M {
+  export interface A {};
+  export namespace N {
+  };
+};
+
+namespace M.N {
+  interface B extends A {};
+  //                  ^ defined: 5
+}

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/refer-to-type-in-nested-namespace-from-parent-namespace-with-partially-qualified-name.ts.skip
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/refer-to-type-in-nested-namespace-from-parent-namespace-with-partially-qualified-name.ts.skip
@@ -1,0 +1,13 @@
+export {};
+
+namespace M {
+  export namespace N {
+    export interface A {};
+  };
+};
+
+namespace M {
+  interface B extends N.A {};
+  //                  ^ defined: 4
+  //                    ^ defined: 5
+}

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/refer-to-type-in-nested-namespace-from-qualified-namespace.ts.skip
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/refer-to-type-in-nested-namespace-from-qualified-namespace.ts.skip
@@ -1,0 +1,12 @@
+export {};
+
+namespace M {
+  export namespace N {
+    export interface A {};
+  };
+};
+
+namespace M.N {
+  interface B extends A {};
+  //                  ^ defined: 5
+}

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/rename-imported-directly-exported-variable.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/rename-imported-directly-exported-variable.ts
@@ -1,0 +1,14 @@
+/*--- path: ./ModA.ts ---*/
+
+export let a = {
+    v: 42
+};
+
+/*--- path: ./ModB.ts ---*/
+
+import { a as b } from "./ModA";
+//       ^ defined: 3
+
+  b.v;
+//^ defined: 9, 3
+//  ^ defined: 4

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/rename-imported-indirectly-exported-variable.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/rename-imported-indirectly-exported-variable.ts
@@ -1,0 +1,17 @@
+/*--- path: ./ModA.ts ---*/
+
+let a = {
+    v: 42
+};
+
+export { a };
+//       ^ defined: 3
+
+/*--- path: ./ModB.ts ---*/
+
+import { a as b } from "./ModA";
+//       ^ defined: 7, 3
+
+  b.v;
+//^ defined: 12, 7, 3
+//  ^ defined: 4

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/script-declaration-visible-in-other-module.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/script-declaration-visible-in-other-module.ts
@@ -1,0 +1,10 @@
+// --- path: a.ts ---
+
+let x = 42;
+
+// --- path: b.ts ---
+
+let y = x;
+//      ^ defined: 3
+
+export {}

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/split-namespace-can-only-see-exports.ts.skip
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/split-namespace-can-only-see-exports.ts.skip
@@ -1,0 +1,10 @@
+export {};
+
+namespace N {
+  let x = 42;
+}
+
+namespace N {
+  export let y = x; // tsc: Cannot find name 'x'.
+  //             ^ defined:
+}

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/split-namespace-can-see-all-exports.ts.skip
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/split-namespace-can-see-all-exports.ts.skip
@@ -1,0 +1,10 @@
+export {};
+
+namespace N {
+  export let x = 42;
+}
+
+namespace N {
+  export let y = x;
+  //             ^ defined: 4
+}

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/abstract-class-with-constructor.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/abstract-class-with-constructor.ts
@@ -1,0 +1,34 @@
+type V = { value: number; }
+
+abstract class A {
+    f: V;
+    // ^ defined: 1
+
+    constructor(x:V) {
+        //        ^ defined: 1
+        this.f = { value: x.value };
+        //   ^ defined: 4
+        //                ^ defined: 7
+        //                  ^ defined: 1
+    }
+
+}
+
+class C extends A {
+//              ^ defined: 3
+    constructor(y:V) {
+    //            ^ defined: 1
+        super(y);
+        //    ^ defined: 19
+    }
+}
+
+let z:C = new C(null);
+//    ^ defined: 17
+//            ^ defined: 17
+
+  z.f;
+//^ defined: 26
+//  ^ defined: 4
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/ambient-module-declaration.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/ambient-module-declaration.ts
@@ -1,0 +1,3 @@
+declare module "*.ts" {
+    export {};
+}

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/call-argument-type-shadows-type-parameter-default.ts.skip
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/call-argument-type-shadows-type-parameter-default.ts.skip
@@ -1,0 +1,24 @@
+interface V {
+  val: number;
+}
+interface N {
+  num: number;
+}
+
+let id: <X = V>(x: X) => X;
+//                 ^ defined: 8
+//                       ^ defined: 8
+
+let n: N;
+
+  id(n).num;
+//^ defined: 8
+//   ^ defined: 12
+//      ^ defined: 5
+
+  id(n).val;
+//^ defined: 8
+//   ^ defined: 12
+//      ^ defined:
+
+export {}

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/class-with-constructor.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/class-with-constructor.ts
@@ -1,0 +1,25 @@
+type V = { value: number; }
+
+class C {
+    f: V;
+    // ^ defined: 1
+
+    constructor(x:V) {
+        //        ^ defined: 1
+        this.f = { value: x.value };
+        //   ^ defined: 4
+        //                ^ defined: 7
+        //                  ^ defined: 1
+    }
+
+}
+
+let y:C = new C(null);
+//    ^ defined: 3
+//            ^ defined: 3
+
+  y.f;
+//^ defined: 17
+//  ^ defined: 4
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/const-with-value.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/const-with-value.ts
@@ -1,0 +1,13 @@
+interface T {
+    f: number;
+}
+
+const a:T = { f: 42 } as T;
+//      ^ defined: 1
+//                       ^ defined: 1
+
+  a.f;
+//^ defined: 5
+//  ^ defined: 2
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/coverage.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/coverage.ts
@@ -1,0 +1,171 @@
+type T = number;
+
+// export
+
+// import
+
+debugger;
+
+1;
+
+var a:T;
+//    ^ defined: 1
+var b:T = (a as T);
+//    ^ defined: 1
+//         ^ defined: 11
+//              ^ defined: 1
+var c:T, d:T = (a as T), e:T;
+//    ^ defined: 1
+//         ^ defined: 1
+//              ^ defined: 11
+//                   ^ defined: 1
+//                         ^ defined: 1
+let f:T = (a as T);
+//    ^ defined: 1
+//         ^ defined: 11
+//              ^ defined: 1
+const g:T = (a as T);
+//      ^ defined: 1
+//           ^ defined: 11
+//                ^ defined: 1
+
+function foo(x:T) { return (x as T); }
+//             ^ defined: 1
+//                          ^ defined: 32
+//                               ^ defined: 1
+
+function* bar(x:T) { yield (x as T); }
+//              ^ defined: 1
+//                          ^ defined: 37
+//                               ^ defined: 1
+
+interface I { x:T; }
+//              ^ defined: 1
+interface J extends I { y:T; }
+//                  ^ defined: 42
+//                        ^ defined: 1
+
+class X { x:T; }
+//          ^ defined: 1
+class XX implements I { x:T; }
+//                  ^ defined: 42
+//                        ^ defined: 1
+class Y extends X { y:T; }
+//              ^ defined: 48
+//                    ^ defined: 1
+class YY extends XX implements J { y:T; }
+//               ^ defined: 50
+//                             ^ defined: 44
+//                                   ^ defined: 1
+
+abstract class A { x:T; }
+//                   ^ defined: 1
+abstract class B extends A {}
+//                       ^ defined: 61
+
+{}
+{
+    let x:T = 1;
+//        ^ defined: 1
+}
+{
+    let x:T = 1;
+//        ^ defined: 1
+    let y:T = x;
+//        ^ defined: 1
+    let z:T = x + y;
+//        ^ defined: 1
+}
+
+if (true) { let x:T = 1; };
+//                ^ defined: 1
+if (true) { let x:T = 1; } else { let x:T = 2; };
+//                ^ defined: 1
+//                                      ^ defined: 1
+
+switch (21*2) {
+}
+switch (21*2) {
+    case 0: { let x:U = 1; } break;
+//                  ^ defined: 91
+    case 1: type U = T;
+//                   ^ defined: 1
+    case 2: { let x:T = 1; } break;
+//                  ^ defined: 1
+    default: { let x:U = 1; } break;
+//                   ^ defined: 91
+}
+let y: U = 1; // tsc: Cannot find name 'U'
+//     ^ defined:
+
+for (var i: T = 0; i < 42; i++) { let x: T = 1; }
+//          ^ defined: 1
+//                 ^ defined: 101
+//                         ^ defined: 101
+//                                       ^ defined: 1
+
+for (var q in [1, 2, 3]) { let x: T = 1; }
+//                                ^ defined: 1
+
+while (1 < 2) { let x: T = 1; }
+//                     ^ defined: 1
+
+do { let x: T = 1; } while (1 < 2)
+//          ^ defined: 1
+
+try { let x: T = 1; } catch(ex) { let x: T = 1; }
+//           ^ defined: 1
+//                                       ^ defined: 1
+try { let x: T = 1; } catch(ex: any) { let x: T = 1; }
+//           ^ defined: 1
+//                                            ^ defined: 1
+try { let x: T = 1; } finally { let x: T = 1; }
+//           ^ defined: 1
+//                                     ^ defined: 1
+try { let x: T = 1; } catch(ex) { let x: T = 1; } finally { let x: T = 1; }
+//           ^ defined: 1
+//                                       ^ defined: 1
+//                                                                 ^ defined: 1
+
+with({}) { let x: T = 1; };
+//                ^ defined: 1
+
+while(true) { break; let x: T = 1; };
+//                          ^ defined: 1
+
+while(true) { continue; let x: T = 1; };
+//                             ^ defined: 1
+
+function baz() { return; let x: T = 1; }
+//                              ^ defined: 1
+
+function baq() { throw {}; let x: T = 1; }
+//                                ^ defined: 1
+
+;
+
+lbl: let o: T = 1;
+//          ^ defined: 1
+
+enum E {
+  C1 = 1,
+  C2 = (a as T),
+  //    ^ defined: 11
+  //         ^ defined: 1
+}
+
+let h:E = true ? E.C2 : E.C1;
+//    ^ defined: 150
+//               ^ defined: 150
+//                 ^ defined: 152
+//                      ^ defined: 150
+//                        ^ defined: 151
+
+type TT = T;
+//        ^ defined: 1
+
+// check that definition of `T` flows through all above statements
+let fin: T;
+//       ^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/deconstruct-tuple.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/deconstruct-tuple.ts
@@ -1,0 +1,18 @@
+interface V { v: number; }
+interface N { n: number; }
+
+type T = [V, N];
+
+declare let t: T;
+
+let [x, y] = t;
+
+  x.v;
+//^ defined: 8
+//  ^ defined: 1
+
+  y.n;
+//^ defined: 8
+//  ^ defined: 2
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/decorators.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/decorators.ts
@@ -1,0 +1,34 @@
+function Id(x, ignored) {
+    return x;
+}
+
+  @Id
+// ^ defined: 1
+class A {
+}
+
+  @Id()
+// ^ defined: 1
+class B {
+}
+
+let y = 42;
+
+  @Id(y)
+// ^ defined: 1
+//    ^ defined: 15
+class C {
+}
+
+class D {
+      @Id
+    // ^ defined: 1
+      @Id()
+    // ^ defined: 1
+      @Id(y)
+    // ^ defined: 1
+    //    ^ defined: 15
+    f: int;
+}
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/define-after-use.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/define-after-use.ts
@@ -1,0 +1,23 @@
+var x: T;
+//     ^ defined: 15
+
+{
+    var i: U;
+    //     ^ defined: 8
+
+    type U = T;
+    //       ^ defined: 15
+
+    var j: U;
+    //     ^ defined: 8
+}
+
+type T = number;
+
+var y: T;
+//     ^ defined: 15
+
+var z: U; // tsc: Cannot find name 'U'
+//     ^ defined:
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/destructuring-var-defs.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/destructuring-var-defs.ts
@@ -1,0 +1,32 @@
+interface N {
+  n: number;
+}
+interface V {
+  v: N;
+};
+
+var x: V;
+//     ^ defined: 4
+
+var { v } = x;
+//          ^ defined: 8
+
+  v.n;
+//^ defined: 11
+//  ^ defined: 2
+
+var { v: w } = x;
+//             ^ defined: 8
+
+  w.n;
+//^ defined: 18
+//  ^ defined: 2
+
+var { "v": p } = x;
+//               ^ defined: 8
+
+  p.n;
+//^ defined: 25
+//  ^ defined: 2
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/enum-constant-not-a-type-member.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/enum-constant-not-a-type-member.ts
@@ -1,0 +1,12 @@
+enum E {
+  C
+}
+
+var x: E;
+//     ^ defined: 1
+
+  x.C; // tsc: Property 'C' does not exist on type 'E'.
+//^ defined: 5
+//  ^ defined:
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/enum-object.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/enum-object.ts
@@ -1,0 +1,12 @@
+enum E {
+  C
+}
+
+let y = E;
+//      ^ defined: 1
+
+  y.C;
+//^ defined: 5
+//  ^ defined: 2
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/enum.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/enum.ts
@@ -1,0 +1,13 @@
+enum E {
+  C1 = 1,
+  C2,
+}
+
+let h:E = true ? E.C2 : E.C1;
+//    ^ defined: 1
+//               ^ defined: 1
+//                 ^ defined: 3
+//                      ^ defined: 1
+//                        ^ defined: 2
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/expression-statement.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/expression-statement.ts
@@ -1,0 +1,6 @@
+type T = number;
+
+1 as T;
+//   ^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/for-let-initializer-scoping.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/for-let-initializer-scoping.ts
@@ -1,0 +1,11 @@
+for(let x = 1; x < 42; x++) {
+//             ^ defined: 1
+//                     ^ defined: 1
+  x;
+//^ defined: 1
+}
+
+  x; // tsc: Cannot find name 'x'.
+//^ defined:
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/for-of-destructuring-var.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/for-of-destructuring-var.ts
@@ -1,0 +1,19 @@
+interface N {
+  n: number;
+}
+interface V {
+  v: N;
+//   ^ defined: 1
+}
+
+let xs: V[];
+//      ^ defined: 4
+
+for(let { v } of xs) {
+//               ^ defined: 9
+  v.n;
+//^ defined: 12
+//  ^ defined: 2
+}
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/for-of-var-type.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/for-of-var-type.ts
@@ -1,0 +1,15 @@
+interface V {
+  v: number;
+}
+
+let xs: V[];
+//      ^ defined: 1
+
+for(let x of xs) {
+//           ^ defined: 5
+  x.v;
+//^ defined: 8
+//  ^ defined: 2
+}
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/for-var-initializer-scoping.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/for-var-initializer-scoping.ts
@@ -1,0 +1,11 @@
+for(var x = 1; x < 42; x++) {
+//             ^ defined: 1
+//                     ^ defined: 1
+  x;
+//^ defined: 1
+}
+
+  x;
+//^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/function-declaration.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/function-declaration.ts
@@ -1,0 +1,18 @@
+type T = { f: number }
+
+function foo(x: T): T {
+//              ^ defined: 1
+    return { f: x.f } as T;
+    //          ^ defined: 3
+    //            ^ defined: 1
+    //                   ^ defined: 1
+}
+
+  foo;
+//^ defined: 3
+
+  foo(null).f;
+//^ defined: 3
+//          ^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/function-type-inferred-from-deeply-nested-return.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/function-type-inferred-from-deeply-nested-return.ts
@@ -1,0 +1,19 @@
+function f() {
+  try {
+    if(true) {
+      return { v: 42 };
+    }
+  } finally {
+    return { e: -1 };
+  }
+}
+
+  f().v;
+//^ defined: 1
+//    ^ defined: 4
+
+  f().e;
+//^ defined: 1
+//    ^ defined: 7
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/function-type-inferred-from-direct-return.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/function-type-inferred-from-direct-return.ts
@@ -1,0 +1,9 @@
+function f() {
+  return { v: 42 };
+}
+
+  f().v;
+//^ defined: 1
+//    ^ defined: 2
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/function-type-inferred-from-nested-return.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/function-type-inferred-from-nested-return.ts
@@ -1,0 +1,11 @@
+function f() {
+  if(true) {
+    return { v: 42 };
+  }
+}
+
+  f().v;
+//^ defined: 1
+//    ^ defined: 3
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/getter-not-accessible-as-method.ts.skip
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/getter-not-accessible-as-method.ts.skip
@@ -1,0 +1,13 @@
+interface I {
+    get p(): { v: number }
+}
+
+declare let x: I;
+//             ^ defined: 1
+
+  x.p().v;
+//^ defined: 5
+//  ^ defined: 2
+//  ^ defined:
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/infer-arrow-function-literal-parameter-type-from-use-site.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/infer-arrow-function-literal-parameter-type-from-use-site.ts
@@ -1,0 +1,13 @@
+interface V {
+  v: number;
+}
+
+declare function g(f: (v:V) => number): number;
+
+g(v => {
+  return v.v;
+  //     ^ defined: 7
+  //       ^ defined: 2
+});
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/infer-function-literal-parameter-type-from-let-type-annotation.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/infer-function-literal-parameter-type-from-let-type-annotation.ts
@@ -1,0 +1,12 @@
+interface V {
+  v: number;
+}
+
+let g: (_:V) => any = function(x) {
+//        ^ defined: 1
+    x.v;
+  //^ defined: 5
+  //  ^ defined: 2
+};
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/infer-function-literal-parameter-type-from-use-site.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/infer-function-literal-parameter-type-from-use-site.ts
@@ -1,0 +1,13 @@
+interface V {
+  v: number;
+}
+
+declare function g(f: (v:V) => number): number;
+
+g(function(v) {
+  return v.v;
+  //     ^ defined: 7
+  //       ^ defined: 2
+});
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/let-and-var-with-type-annotation.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/let-and-var-with-type-annotation.ts
@@ -1,0 +1,21 @@
+type my_number = number;
+
+let x1:my_number = 42;
+//     ^ defined: 1
+
+let x2:my_number;
+//     ^ defined: 1
+
+var x3:my_number = 42;
+//     ^ defined: 1
+
+var x4:my_number;
+//     ^ defined: 1
+
+   x1 + x2 + x3 + x4;
+// ^ defined: 3
+     // ^ defined: 6
+          // ^ defined: 9
+               // ^ defined: 12
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/let-bound-variable-has-value-type.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/let-bound-variable-has-value-type.ts
@@ -1,0 +1,9 @@
+type V = { value: number; }
+
+let x = null as V;
+
+  x.value;
+//^ defined: 3
+//  ^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/let-with-value.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/let-with-value.ts
@@ -1,0 +1,13 @@
+interface T {
+    f: number;
+}
+
+let a:T = { f: 42 } as T;
+//    ^ defined: 1
+//                     ^ defined: 1
+
+  a.f;
+//^ defined: 5
+//  ^ defined: 2
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/let-without-value.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/let-without-value.ts
@@ -1,0 +1,12 @@
+interface T {
+    f: number;
+}
+
+let a:T;
+//    ^ defined: 1
+
+  a.f;
+//^ defined: 5
+//  ^ defined: 2
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/member-and-subscript-expression-in-assignment-pattern.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/member-and-subscript-expression-in-assignment-pattern.ts
@@ -1,0 +1,9 @@
+let x = {
+    y: 0
+};
+
+  [ x.y, x["y"] ] = [ 42, 42 ];
+//  ^ defined: 1
+//    ^ defined: 2
+//       ^ defined: 1
+//         ^ defined: 2

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/multi-let.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/multi-let.ts
@@ -1,0 +1,18 @@
+interface T {
+    f: number;
+}
+
+let a:T, b:T = { f: 42 } as T;
+//    ^ defined: 1
+//         ^ defined: 1
+//                          ^ defined: 1
+
+  a.f;
+//^ defined: 5
+//  ^ defined: 2
+
+  b.f;
+//^ defined: 5
+//  ^ defined: 2
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/new-on-class-expression.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/new-on-class-expression.ts
@@ -1,0 +1,15 @@
+let x = class {
+    declare f: {
+        v: number
+    };
+}
+
+let y = new x();
+//          ^ defined: 1
+
+  y.f.v;
+//^ defined: 7
+//  ^ defined: 2
+//    ^ defined: 3
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/qualified-decorators.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/qualified-decorators.ts
@@ -1,0 +1,22 @@
+let D = {
+    Id: function(x, ignored) {
+        return x;
+    }
+};
+
+  @D.Id
+// ^ defined: 1
+//   ^ defined: 2
+class A {}
+
+  @D.Id()
+// ^ defined: 1
+//   ^ defined: 2
+class B {}
+
+let y = 42;
+
+  @D.Id(y)
+// ^ defined: 1
+//   ^ defined: 2
+class C {}

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/reexport-of-variable.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/reexport-of-variable.ts
@@ -1,0 +1,17 @@
+/*--- path: ModA.ts ---*/
+
+export let a = {
+    f: 42
+};
+
+/*--- path: ModB.ts ---*/
+
+export { a } from "./ModA";
+
+/*--- path: ModC.ts ---*/
+
+import { a } from "./ModB";
+
+  a.f;
+//^ defined: 13, 9, 3
+//  ^ defined: 4

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/refer-to-class-in-nested-namespace-by-qualified-name.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/refer-to-class-in-nested-namespace-by-qualified-name.ts
@@ -1,0 +1,15 @@
+export {};
+
+namespace M {
+  export namespace N {
+    export class A {
+      f = 42;
+    }
+  }
+}
+
+(new M.N.A()).f;
+//   ^ defined: 3
+//     ^ defined: 4
+//       ^ defined: 5
+//            ^ defined: 6

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/refer-to-interface-in-nested-namespace-by-fully-qualified-name.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/refer-to-interface-in-nested-namespace-by-fully-qualified-name.ts
@@ -1,0 +1,12 @@
+export {};
+
+namespace M {
+  export namespace N {
+    export interface A {}
+  };
+};
+
+interface B extends M.N.A {};
+//                  ^ defined: 3
+//                    ^ defined: 4
+//                      ^ defined: 5

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/refer-to-interface-in-qualified-namespace-by-fully-qualified-name.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/refer-to-interface-in-qualified-namespace-by-fully-qualified-name.ts
@@ -1,0 +1,10 @@
+export {};
+
+namespace M.N {
+  export interface A {}
+};
+
+interface B extends M.N.A {};
+//                  ^ defined: 3
+//                    ^ defined: 3
+//                      ^ defined: 4

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/rename-imported-default.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/rename-imported-default.ts
@@ -1,0 +1,13 @@
+/*--- path: ModA.ts ---*/
+
+export default {
+    f: 42
+};
+
+/*--- path: ModB.ts ---*/
+
+import { default as b } from "./ModA";
+
+  b.f;
+//^ defined: 9, 3
+//  ^ defined: 4

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/renamed-reexport-of-default.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/renamed-reexport-of-default.ts
@@ -1,0 +1,17 @@
+/*--- path: ModA.ts ---*/
+
+export default {
+    f: 42
+};
+
+/*--- path: ModB.ts ---*/
+
+export { default as b } from "./ModA";
+
+/*--- path: ModC.ts ---*/
+
+import { b } from "./ModB";
+
+  b.f;
+//^ defined: 13, 9, 3
+//  ^ defined: 4

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/renamed-reexport-of-variable.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/renamed-reexport-of-variable.ts
@@ -1,0 +1,17 @@
+/*--- path: ModA.ts ---*/
+
+export let a = {
+    f: 42
+};
+
+/*--- path: ModB.ts ---*/
+
+export { a as b } from "./ModA";
+
+/*--- path: ModC.ts ---*/
+
+import { b } from "./ModB";
+
+  b.f;
+//^ defined: 13, 9, 3
+//  ^ defined: 4

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/separate-expression-and-type-identifiers.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/separate-expression-and-type-identifiers.ts
@@ -1,0 +1,12 @@
+type my_number = number;
+
+let x1:my_number = 42;
+//     ^ defined: 1
+
+let x2 = my_number;
+//       ^ defined:
+
+let x3:x2 = 42;
+//     ^ defined:
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/shadowing.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/shadowing.ts
@@ -1,0 +1,31 @@
+type T = number;
+
+declare let x: T;
+
+class A<T> {
+  m(x: T) {
+  //   ^ defined: 5
+      x;
+    //^ defined: 6
+  }
+}
+
+function f(x) {
+    x;
+  //^ defined: 13
+};
+
+{
+  type T = number;
+  let x: T;
+  //     ^ defined: 19
+    x;
+  //^ defined: 20
+}
+
+function(x) {
+    x;
+  //^ defined: 26
+};
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/var-and-let-hoisting.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/var-and-let-hoisting.ts
@@ -1,0 +1,8 @@
+  x + y;
+//^ defined: 5
+//    ^ defined: 6
+
+var x = 2;
+let y = 1; // hoisted, but only here initialized
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/var-in-for-body-escapes.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/var-in-for-body-escapes.ts
@@ -1,0 +1,6 @@
+for(;;) var x = 42;
+
+  x;
+//^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/var-with-value.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/var-with-value.ts
@@ -1,0 +1,13 @@
+interface T {
+    f: number;
+}
+
+var a:T = { f: 42 } as T;
+//    ^ defined: 1
+//                     ^ defined: 1
+
+  a.f;
+//^ defined: 5
+//  ^ defined: 2
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/var-without-value.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/var-without-value.ts
@@ -1,0 +1,12 @@
+interface T {
+    f: number;
+}
+
+var a:T;
+//    ^ defined: 1
+
+  a.f;
+//^ defined: 5
+//  ^ defined: 2
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/with.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/with.ts
@@ -1,0 +1,13 @@
+let x = {
+    f: {
+        v: 42
+    }
+}
+
+with(x) {
+    f.v;
+//  ^ defined: 2
+//    ^ defined: 3
+}
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/types/call-generic-function-with-generic-return-type-without-type-arguments.ts.skip
+++ b/languages/tree-sitter-stack-graphs-typescript/test/types/call-generic-function-with-generic-return-type-without-type-arguments.ts.skip
@@ -1,0 +1,18 @@
+interface V {
+  value: number;
+}
+
+let id: <X>(x: X) => X;
+//             ^ defined: 5
+//                   ^ defined: 5
+
+let v: V;
+//     ^ defined: 1
+
+
+  id(v).value;
+//^ defined: 5
+//   ^ defined: 9
+//      ^ defined: 2
+
+export {}

--- a/languages/tree-sitter-stack-graphs-typescript/test/types/class-and-interface-inheritance.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/types/class-and-interface-inheritance.ts
@@ -1,0 +1,40 @@
+interface I {
+    i: number;
+    m(): I;
+    //   ^ defined: 1
+}
+
+interface J extends I {
+//                  ^ defined: 1
+    j: number;
+    n(): J;
+    //   ^ defined: 7
+}
+
+class A {
+    f: I;
+    // ^ defined: 1
+}
+
+class B extends A {
+//              ^ defined: 14
+    g: J;
+//     ^ defined: 7
+}
+
+var x: B;
+//     ^ defined: 19
+
+  x.f.m().i;
+//^ defined: 25
+//  ^ defined: 15
+//    ^ defined: 3
+//        ^ defined: 2
+
+  x.g.n().j;
+//^ defined: 25
+//  ^ defined: 21
+//    ^ defined: 10
+//        ^ defined: 9
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/types/class-extends-alias-of-generic-class.ts.skip
+++ b/languages/tree-sitter-stack-graphs-typescript/test/types/class-extends-alias-of-generic-class.ts.skip
@@ -1,0 +1,21 @@
+interface V { v: number; }
+
+class A<X> { declare f: X; };
+//              ^ defined: 3
+
+let a = A;
+//      ^ defined: 3
+
+class B extends a<V> {}
+//              ^ defined: 6
+//                ^ defined: 1
+
+declare let b: B;
+//             ^ defined: 9
+
+  b.f.v;
+//^ defined: 13
+//  ^ defined: 3
+//    ^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/types/class-extends-and-implements.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/types/class-extends-and-implements.ts
@@ -1,0 +1,27 @@
+interface V {
+    v: number;
+}
+class A {
+    f: number = 42;
+}
+
+
+
+
+class B extends A implements V {}
+//              ^ defined: 4
+//                           ^ defined: 1
+
+let b: B;
+//     ^ defined: 11
+
+  b.v;
+//^ defined: 15
+//  ^ defined: 2
+
+  b.f;
+//^ defined: 15
+//  ^ defined: 5
+
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/types/class-extends-class-returned-from-function.ts.skip
+++ b/languages/tree-sitter-stack-graphs-typescript/test/types/class-extends-class-returned-from-function.ts.skip
@@ -1,0 +1,20 @@
+interface V { v: number; }
+
+function f() {
+  return class A<X> { declare f: X; };
+}
+//              ^ defined: 3
+
+class B extends f()<V> {}
+//              ^ defined: 6
+//                  ^ defined: 1
+
+declare let b: B;
+//             ^ defined: 9
+
+  b.f.v;
+//^ defined: 13
+//  ^ defined: 3
+//    ^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/types/class-extends-instance-of-generic-constructor-type.ts.skip
+++ b/languages/tree-sitter-stack-graphs-typescript/test/types/class-extends-instance-of-generic-constructor-type.ts.skip
@@ -1,0 +1,21 @@
+interface V { v: number; }
+
+type A = new<X>() => { f: X; };
+//                        ^ defined: 3
+
+declare let a: A;
+//             ^ defined: 3
+
+class B extends a<V> {}
+//              ^ defined: 6
+//                ^ defined: 1
+
+declare let b: B;
+//             ^ defined: 9
+
+  b.f.v;
+//^ defined: 13
+//  ^ defined: 3
+//    ^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/types/class-extends-via-alias.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/types/class-extends-via-alias.ts
@@ -1,0 +1,18 @@
+class A {
+    f: number = 42;
+}
+
+let a = A;
+//      ^ defined: 1
+
+class B extends a {}
+//              ^ defined: 5
+
+let b: B;
+//     ^ defined: 8
+
+  b.f;
+//^ defined: 11
+//  ^ defined: 2
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/types/class-implements-multiple-interfaces.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/types/class-implements-multiple-interfaces.ts
@@ -1,0 +1,19 @@
+interface A {
+    f: number;
+}
+
+interface B {
+    g: number;
+}
+
+abstract class C
+    implements A, B
+//             ^ defined: 1
+//                ^ defined: 5
+{
+    test() {
+        return this.f + this.g;
+        //          ^ defined: 2
+        //                   ^ defined: 6
+    }
+}

--- a/languages/tree-sitter-stack-graphs-typescript/test/types/generic-interface-with-generic-field.ts.bug
+++ b/languages/tree-sitter-stack-graphs-typescript/test/types/generic-interface-with-generic-field.ts.bug
@@ -1,0 +1,26 @@
+interface V {
+  v: number;
+}
+
+interface I<T> {
+  f: T;
+  // ^ defined: 5
+}
+
+interface J<U> {
+  g: I<U>;
+//   ^ defined: 5
+//     ^ defined: 10
+}
+
+var x: J<V>;
+//     ^ defined: 10
+//       ^ defined: 1
+
+  x.g.f.v;
+//^ defined: 16
+//  ^ defined: 11
+//    ^ defined: 6
+//      ^ defined: 2
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/types/generic-interface-with-generic-method.ts.skip
+++ b/languages/tree-sitter-stack-graphs-typescript/test/types/generic-interface-with-generic-method.ts.skip
@@ -1,0 +1,126 @@
+interface V {
+  v: number;
+}
+interface C {
+  c: number;
+}
+
+interface I<X> {
+  m0<Y>(y: Y): V;
+  //      ^ defined: 9
+  //          ^ defined: 8
+  m1<Y>(y: Y): Y;
+  //      ^ defined: 9
+  //          ^ defined: 8
+  m2<Y>(y: Y): X;
+  //      ^ defined: 9
+  //          ^ defined: 8
+}
+
+{
+  let x: I<V>;
+  //     ^ defined: 8
+  //       ^ defined: 1
+
+    x.m0<C>(null).v;
+  //^ defined: 21
+  //  ^ defined: 9
+  //     ^ defined: 4
+  //              ^ defined: 2
+
+    x.m1<C>(null).c;
+  //^ defined: 21
+  //  ^ defined: 12
+  //     ^ defined: 4
+  //              ^ defined: 5
+
+    x.m2<C>(null).v;
+  //^ defined: 21
+  //  ^ defined: 15
+  //     ^ defined: 4
+  //              ^ defined: 2
+
+    x.m2<C>(null).c; // tsc: Property 'c' does not exist on type 'V'.
+  //^ defined: 21
+  //  ^ defined: 15
+  //     ^ defined: 4
+  //              ^ defined:
+}
+
+interface E { e: {}; }
+
+interface A<Q> {
+
+  f: I<Q>;
+
+  g<P>(): I<P>;
+
+}
+
+{
+  let x: A<V>;
+  //     ^ defined: 52
+  //       ^ defined: 1
+
+    x.f.m0<C>(null).v;
+  //^ defined: 61
+  //  ^ defined: 54
+  //    ^ defined: 9
+  //       ^ defined: 4
+  //                ^ defined: 2
+
+    x.f.m1<C>(null).c;
+  //^ defined: 61
+  //  ^ defined: 54
+  //    ^ defined: 12
+  //       ^ defined: 4
+  //                ^ defined: 5
+
+    x.f.m2<C>(null).v;
+  //^ defined: 61
+  //  ^ defined: 54
+  //    ^ defined: 15
+  //       ^ defined: 4
+  //                ^ defined: 2
+
+    x.f.m2<C>(null).c; // tsc: Property 'c' does not exist on type 'V'.
+  //^ defined: 61
+  //  ^ defined: 54
+  //    ^ defined: 15
+  //       ^ defined: 4
+  //                ^ defined:
+
+    x.g<E>().m0<C>(null).v;
+  //^ defined: 61
+  //  ^ defined: 56
+  //    ^ defined: 50
+  //         ^ defined: 9
+  //            ^ defined: 4
+  //                     ^ defined: 2
+
+    x.g<E>().m1<C>(null).c;
+  //^ defined: 61
+  //  ^ defined: 56
+  //    ^ defined: 50
+  //         ^ defined: 12
+  //            ^ defined: 4
+  //                     ^ defined: 5
+
+    x.g<E>().m2<C>(null).e;
+  //^ defined: 61
+  //  ^ defined: 56
+  //    ^ defined: 50
+  //         ^ defined: 15
+  //            ^ defined: 4
+  //                     ^ defined: 50
+
+    x.g<E>().m2<C>(null).e; // tsc: Property 'c' does not exist on type 'V'.
+  //^ defined: 61
+  //  ^ defined: 56
+  //    ^ defined: 50
+  //         ^ defined: 15
+  //            ^ defined: 4
+  //                     ^ defined:
+}
+
+export {}

--- a/languages/tree-sitter-stack-graphs-typescript/test/types/generic-interface-with-generic-super-type.ts.bug
+++ b/languages/tree-sitter-stack-graphs-typescript/test/types/generic-interface-with-generic-super-type.ts.bug
@@ -1,0 +1,24 @@
+interface V {
+  v: number;
+}
+
+interface I<T> {
+  f: T;
+  // ^ defined: 5
+}
+
+interface J<U> extends I<U> {
+//                     ^ defined: 5
+//                       ^ defined: 10
+}
+
+var x: J<V>;
+//     ^ defined: 10
+//       ^ defined: 1
+
+  x.f.v;
+//^ defined: 15
+//  ^ defined: 6
+//    ^ defined: 2
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/types/generic-interface.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/types/generic-interface.ts
@@ -1,0 +1,42 @@
+interface V {
+  v: number;
+}
+class C {
+  c: number;
+}
+
+interface I<T, U = T> {
+  f: T;
+  // ^ defined: 8
+  g: U;
+  // ^ defined: 8
+}
+
+var x: I<V>;
+//     ^ defined: 8
+//       ^ defined: 1
+
+  x.f.v;
+//^ defined: 15
+//  ^ defined: 9
+//    ^ defined: 2
+  x.g.v;
+//^ defined: 15
+//  ^ defined: 11
+//    ^ defined: 2
+
+var y: I<V, C>;
+//     ^ defined: 8
+//       ^ defined: 1
+//          ^ defined: 4
+
+  y.f.v;
+//^ defined: 28
+//  ^ defined: 9
+//    ^ defined: 2
+  y.g.c;
+//^ defined: 28
+//  ^ defined: 11
+//    ^ defined: 5
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/types/generic-type-alias.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/types/generic-type-alias.ts
@@ -1,0 +1,15 @@
+interface V {
+  v: number;
+}
+
+type Id<T> = T;
+
+declare let x: Id<V>;
+//             ^ defined: 5
+//                ^ defined: 1
+
+  x.v;
+//^ defined: 7
+//  ^ defined: 2
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/types/indexed-lookup-type.ts.skip
+++ b/languages/tree-sitter-stack-graphs-typescript/test/types/indexed-lookup-type.ts.skip
@@ -1,0 +1,13 @@
+type T = { X: number };
+
+type U = { X: { f: number } };
+
+let x: U[keyof T];
+//     ^ defined: 3
+//             ^ defined: 1
+
+  x.f;
+//^ defined: 5
+//  ^ defined: 3
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/types/indexed-type.ts.skip
+++ b/languages/tree-sitter-stack-graphs-typescript/test/types/indexed-type.ts.skip
@@ -1,0 +1,13 @@
+type T = "T";
+
+type U = { T: { f: number } };
+
+let x: U[T];
+//     ^ defined: 3
+//       ^ defined: 1
+
+  x.f;
+//^ defined: 5
+//  ^ defined: 3
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/types/interface-extends-multiple-interfaces.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/types/interface-extends-multiple-interfaces.ts
@@ -1,0 +1,20 @@
+interface A {
+    f: number;
+}
+
+interface B {
+    g: number;
+}
+
+interface C
+    extends A, B {}
+//          ^ defined: 1
+//             ^ defined: 5
+
+function test(c: C) {
+    return c.f + c.g;
+    //       ^ defined: 2
+    //             ^ defined: 6
+}
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/types/interface-extends.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/types/interface-extends.ts
@@ -1,0 +1,13 @@
+interface V {
+    v: number;
+}
+interface I extends V {}
+
+let x: I;
+//     ^ defined: 4
+
+  x.v;
+//^ defined: 6
+//  ^ defined: 2
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/types/mixins.ts.skip
+++ b/languages/tree-sitter-stack-graphs-typescript/test/types/mixins.ts.skip
@@ -1,0 +1,31 @@
+type Constructor<T = {}> = new (...args: any[]) => T;
+//                                                 ^ defined: 1
+
+function Timestamped<TBase extends Constructor>(Base: TBase) {
+//                                                    ^ defined: 4
+  return class extends Base {
+  //                   ^ defined: 4
+    timestamp: number;
+  };
+}
+
+class User {
+  name: string;
+}
+
+const TimestampedUser = Timestamped(User);
+//                      ^ defined: 4
+//                                  ^ defined: 12
+
+let tsu = new TimestampedUser();
+//            ^ defined: 16
+
+  tsu.name;
+//^ defined: 20
+//    ^ defined: 13
+
+  tsu.timestamp;
+//^ defined: 20
+//    ^ defined: 8
+
+export {}

--- a/languages/tree-sitter-stack-graphs-typescript/test/types/qualified-type-query.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/types/qualified-type-query.ts
@@ -1,0 +1,11 @@
+let x = {
+    y: {
+        z: number
+    }
+};
+
+function test(a: typeof x.y.z) {
+//                      ^ defined: 1
+//                        ^ defined: 2
+//                          ^ defined: 3
+}

--- a/languages/tree-sitter-stack-graphs-typescript/test/types/tuple-type.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/types/tuple-type.ts
@@ -1,0 +1,16 @@
+interface V { v: number; }
+interface N { n: number; }
+
+type T = [V, N];
+
+declare let t: T;
+
+  t[0].v;
+//^ defined: 6
+//     ^ defined: 1
+
+  t[1].n;
+//^ defined: 6
+//     ^ defined: 2
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/types/type-refs-in-type-expressions.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/types/type-refs-in-type-expressions.ts
@@ -1,0 +1,24 @@
+type ty1 = number;
+
+type ty2 = ty1;
+//         ^ defined: 1
+
+type ty3 = ty1 | string | ty2;
+//         ^ defined: 1
+//                        ^ defined: 3
+
+type ty4 = ty1 & ty2;
+//         ^ defined: 1
+//               ^ defined: 3
+
+type ty5 = ty1[];
+//         ^ defined: 1
+
+type ty6 = readonly ty1[];
+//                  ^ defined: 1
+
+type ty7 = [ty1, ty2];
+//          ^ defined: 1
+//               ^ defined: 3
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/types/typeof-call.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/types/typeof-call.ts
@@ -1,0 +1,12 @@
+function x(): { g: number } {
+  return { g: 42 };
+}
+
+let y: typeof x();
+//            ^ defined: 1
+
+  y.g;
+//^ defined: 5
+//  ^ defined: 1
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/types/typeof-member.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/types/typeof-member.ts
@@ -1,0 +1,15 @@
+let x: {
+  f: {
+    g: number;
+  }
+};
+
+let y: typeof x.f;
+//            ^ defined: 1
+//              ^ defined: 2
+
+  y.g;
+//^ defined: 7
+//  ^ defined: 3
+
+export {};

--- a/languages/tree-sitter-stack-graphs-typescript/test/types/typeof-variable.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/types/typeof-variable.ts
@@ -1,0 +1,10 @@
+let x: { f: string };
+
+let y: typeof x = { f: "fortytwo" };
+//            ^ defined: 1
+
+  y.f;
+//^ defined: 3
+//  ^ defined: 1
+
+export {};


### PR DESCRIPTION
This adds the stack graph rules and tests that were previously being developed in https://github.com/tree-sitter/tree-sitter-typescript/tree/add-stack-graph. This project would supersede the development there.

## PR Stack

- #146
- #140 
- ▶️ #142