### PR TITLE
Bump tree-sitter-stack-graphs to version 0.4.1

### DIFF
--- a/tree-sitter-stack-graphs/CHANGELOG.md
+++ b/tree-sitter-stack-graphs/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.4.1 -- 2022-10-19
 
 ### CLI
 

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-stack-graphs"
-version = "0.4.0"
+version = "0.4.1"
 description = "Create stack graphs using tree-sitter parsers"
 homepage = "https://github.com/github/stack-graphs/tree/main/tree-sitter-stack-graphs"
 repository = "https://github.com/github/stack-graphs/"

--- a/tree-sitter-stack-graphs/npm/package.json
+++ b/tree-sitter-stack-graphs/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-stack-graphs",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Create stack graphs using tree-sitter parsers",
   "homepage": "https://github.com/github/stack-graphs/tree/main/tree-sitter-stack-graphs",
   "repository": {


### PR DESCRIPTION
Move tree-sitter-stack-graphs to version 0.4.1. This will incorporate some fixes and hopefully the CI release process will cooperate this time.

## Tasks

- [x] Reaffirm that we want to use `tree-sitter-stack-graphs-LANG` naming convention. If not, we should change the defaults for `init` before this release.
- [x] #143
