### PR TITLE
Expose cli logic through lib

### DIFF
--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -22,7 +22,7 @@ name = "tree-sitter-stack-graphs"
 required-features = ["cli"]
 
 [features]
-cli = ["clap", "colored", "dialoguer", "env_logger", "indoc", "stack-graphs/json", "tree-sitter-config", "walkdir"]
+cli = ["clap", "colored", "dialoguer", "env_logger", "indoc", "pathdiff", "stack-graphs/json", "tree-sitter-config", "walkdir"]
 
 [dependencies]
 anyhow = "1.0"
@@ -36,6 +36,7 @@ itertools = "0.10"
 lazy_static = "1.4"
 log = "0.4"
 lsp-positions = { version="0.3", path="../lsp-positions" }
+pathdiff = { version = "0.2.1", optional = true }
 regex = "1"
 rust-ini = "0.18"
 stack-graphs = { version="0.10", path="../stack-graphs" }

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/main.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/main.rs
@@ -18,11 +18,9 @@ struct Cli {
     command: Commands,
 }
 
-mod init;
-
 #[derive(Subcommand)]
 enum Commands {
-    Init(init::Command),
+    Init(Init),
     Parse(Parse),
     Test(Test),
 }
@@ -33,6 +31,19 @@ fn main() -> Result<()> {
         Commands::Init(cmd) => cmd.run(),
         Commands::Parse(cmd) => cmd.run(),
         Commands::Test(cmd) => cmd.run(),
+    }
+}
+
+/// Init command
+#[derive(clap::Parser)]
+pub struct Init {
+    #[clap(flatten)]
+    init_args: cli::init::InitArgs,
+}
+
+impl Init {
+    pub fn run(&self) -> anyhow::Result<()> {
+        self.init_args.run()
     }
 }
 

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/main.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/main.rs
@@ -6,77 +6,8 @@
 // ------------------------------------------------------------------------------------------------
 
 use anyhow::Result;
-use clap::Parser;
-use clap::Subcommand;
-use tree_sitter_stack_graphs::cli;
-
-/// The CLI
-#[derive(Parser)]
-#[clap(about, version)]
-struct Cli {
-    #[clap(subcommand)]
-    command: Commands,
-}
-
-#[derive(Subcommand)]
-enum Commands {
-    Init(Init),
-    Parse(Parse),
-    Test(Test),
-}
+use tree_sitter_stack_graphs::cli::Cli;
 
 fn main() -> Result<()> {
-    let cli = Cli::parse();
-    match &cli.command {
-        Commands::Init(cmd) => cmd.run(),
-        Commands::Parse(cmd) => cmd.run(),
-        Commands::Test(cmd) => cmd.run(),
-    }
-}
-
-/// Init command
-#[derive(clap::Parser)]
-pub struct Init {
-    #[clap(flatten)]
-    init_args: cli::init::InitArgs,
-}
-
-impl Init {
-    pub fn run(&self) -> anyhow::Result<()> {
-        self.init_args.run()
-    }
-}
-
-/// Parse command
-#[derive(clap::Parser)]
-pub struct Parse {
-    #[clap(flatten)]
-    load_args: cli::load::LoadArgs,
-
-    #[clap(flatten)]
-    parse_args: cli::parse::ParseArgs,
-}
-
-impl Parse {
-    pub fn run(&self) -> anyhow::Result<()> {
-        let mut loader = self.load_args.new_loader()?;
-        self.parse_args.run(&mut loader)
-    }
-}
-
-/// Test command
-#[derive(clap::Parser)]
-pub struct Test {
-    #[clap(flatten)]
-    load_args: cli::load::LoadArgs,
-
-    #[clap(flatten)]
-    test_args: cli::test::TestArgs,
-}
-
-impl Test {
-    pub fn run(&self) -> anyhow::Result<()> {
-        let mut loader = self.load_args.new_loader()?;
-        self.test_args.run(&mut loader)
-    }
+    Cli::main()
 }

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/main.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/main.rs
@@ -40,15 +40,16 @@ fn main() -> Result<()> {
 #[derive(clap::Parser)]
 pub struct Parse {
     #[clap(flatten)]
-    loader: cli::load::LoadArgs,
+    load_args: cli::load::LoadArgs,
 
     #[clap(flatten)]
-    parser: cli::parse::ParseArgs,
+    parse_args: cli::parse::ParseArgs,
 }
 
 impl Parse {
     pub fn run(&self) -> anyhow::Result<()> {
-        self.parser.run(&self.loader)
+        let mut loader = self.load_args.new_loader()?;
+        self.parse_args.run(&mut loader)
     }
 }
 
@@ -56,14 +57,15 @@ impl Parse {
 #[derive(clap::Parser)]
 pub struct Test {
     #[clap(flatten)]
-    loader: cli::load::LoadArgs,
+    load_args: cli::load::LoadArgs,
 
     #[clap(flatten)]
-    tester: cli::test::TestArgs,
+    test_args: cli::test::TestArgs,
 }
 
 impl Test {
     pub fn run(&self) -> anyhow::Result<()> {
-        self.tester.run(&self.loader)
+        let mut loader = self.load_args.new_loader()?;
+        self.test_args.run(&mut loader)
     }
 }

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/main.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/main.rs
@@ -8,9 +8,9 @@
 use anyhow::Result;
 use clap::Parser;
 use clap::Subcommand;
+use tree_sitter_stack_graphs::cli;
 
-pub(crate) const MAX_PARSE_ERRORS: usize = 5;
-
+/// The CLI
 #[derive(Parser)]
 #[clap(about, version)]
 struct Cli {
@@ -19,16 +19,12 @@ struct Cli {
 }
 
 mod init;
-mod loader;
-mod parse;
-mod test;
-mod util;
 
 #[derive(Subcommand)]
 enum Commands {
     Init(init::Command),
-    Parse(parse::Command),
-    Test(test::Command),
+    Parse(Parse),
+    Test(Test),
 }
 
 fn main() -> Result<()> {
@@ -37,5 +33,37 @@ fn main() -> Result<()> {
         Commands::Init(cmd) => cmd.run(),
         Commands::Parse(cmd) => cmd.run(),
         Commands::Test(cmd) => cmd.run(),
+    }
+}
+
+/// Parse command
+#[derive(clap::Parser)]
+pub struct Parse {
+    #[clap(flatten)]
+    loader: cli::load::LoadArgs,
+
+    #[clap(flatten)]
+    parser: cli::parse::ParseArgs,
+}
+
+impl Parse {
+    pub fn run(&self) -> anyhow::Result<()> {
+        self.parser.run(&self.loader)
+    }
+}
+
+/// Test command
+#[derive(clap::Parser)]
+pub struct Test {
+    #[clap(flatten)]
+    loader: cli::load::LoadArgs,
+
+    #[clap(flatten)]
+    tester: cli::test::TestArgs,
+}
+
+impl Test {
+    pub fn run(&self) -> anyhow::Result<()> {
+        self.tester.run(&self.loader)
     }
 }

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/main.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/main.rs
@@ -6,8 +6,8 @@
 // ------------------------------------------------------------------------------------------------
 
 use anyhow::Result;
-use tree_sitter_stack_graphs::cli::Cli;
+use tree_sitter_stack_graphs::cli::PathLoadingCli;
 
 fn main() -> Result<()> {
-    Cli::main()
+    PathLoadingCli::main()
 }

--- a/tree-sitter-stack-graphs/src/cli.rs
+++ b/tree-sitter-stack-graphs/src/cli.rs
@@ -108,7 +108,8 @@ mod provided_languages {
     use crate::cli::parse::ParseArgs;
     use crate::cli::test::TestArgs;
     use crate::loader::LanguageConfiguration;
-    use crate::loader::Loader;
+
+    use super::load::LanguageConfigurationsLoadArgs;
 
     /// CLI implementation that loads from provided grammars and stack graph definitions.
     #[derive(Parser)]
@@ -121,10 +122,9 @@ mod provided_languages {
     impl Cli {
         pub fn main(configurations: Vec<LanguageConfiguration>) -> Result<()> {
             let cli = Cli::parse();
-            let mut loader = Loader::from_language_configurations(configurations)?;
             match &cli.command {
-                Commands::Parse(cmd) => cmd.run(&mut loader),
-                Commands::Test(cmd) => cmd.run(&mut loader),
+                Commands::Parse(cmd) => cmd.run(configurations),
+                Commands::Test(cmd) => cmd.run(configurations),
             }
         }
     }
@@ -139,12 +139,15 @@ mod provided_languages {
     #[derive(clap::Parser)]
     pub struct Parse {
         #[clap(flatten)]
+        load_args: LanguageConfigurationsLoadArgs,
+        #[clap(flatten)]
         parse_args: ParseArgs,
     }
 
     impl Parse {
-        pub fn run(&self, loader: &mut Loader) -> anyhow::Result<()> {
-            self.parse_args.run(loader)
+        pub fn run(&self, configurations: Vec<LanguageConfiguration>) -> anyhow::Result<()> {
+            let mut loader = self.load_args.new_loader(configurations)?;
+            self.parse_args.run(&mut loader)
         }
     }
 
@@ -152,12 +155,15 @@ mod provided_languages {
     #[derive(clap::Parser)]
     pub struct Test {
         #[clap(flatten)]
+        load_args: LanguageConfigurationsLoadArgs,
+        #[clap(flatten)]
         test_args: TestArgs,
     }
 
     impl Test {
-        pub fn run(&self, loader: &mut Loader) -> anyhow::Result<()> {
-            self.test_args.run(loader)
+        pub fn run(&self, configurations: Vec<LanguageConfiguration>) -> anyhow::Result<()> {
+            let mut loader = self.load_args.new_loader(configurations)?;
+            self.test_args.run(&mut loader)
         }
     }
 }

--- a/tree-sitter-stack-graphs/src/cli.rs
+++ b/tree-sitter-stack-graphs/src/cli.rs
@@ -5,7 +5,11 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-//! Defines building blocks for CLI
+//! Defines CLI
+
+use anyhow::Result;
+use clap::Parser;
+use clap::Subcommand;
 
 pub(self) const MAX_PARSE_ERRORS: usize = 5;
 
@@ -14,3 +18,76 @@ pub mod load;
 pub mod parse;
 pub mod test;
 mod util;
+
+/// CLI implementation that loads grammars and stack graph definitions from paths.
+#[derive(Parser)]
+#[clap(about, version)]
+pub struct Cli {
+    #[clap(subcommand)]
+    command: Commands,
+}
+
+impl Cli {
+    pub fn main() -> Result<()> {
+        let cli = Cli::parse();
+        match &cli.command {
+            Commands::Init(cmd) => cmd.run(),
+            Commands::Parse(cmd) => cmd.run(),
+            Commands::Test(cmd) => cmd.run(),
+        }
+    }
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    Init(Init),
+    Parse(Parse),
+    Test(Test),
+}
+
+/// Init command
+#[derive(clap::Parser)]
+pub struct Init {
+    #[clap(flatten)]
+    init_args: self::init::InitArgs,
+}
+
+impl Init {
+    pub fn run(&self) -> anyhow::Result<()> {
+        self.init_args.run()
+    }
+}
+
+/// Parse command
+#[derive(clap::Parser)]
+pub struct Parse {
+    #[clap(flatten)]
+    load_args: self::load::PathsLoadArgs,
+
+    #[clap(flatten)]
+    parse_args: self::parse::ParseArgs,
+}
+
+impl Parse {
+    pub fn run(&self) -> anyhow::Result<()> {
+        let mut loader = self.load_args.new_loader()?;
+        self.parse_args.run(&mut loader)
+    }
+}
+
+/// Test command
+#[derive(clap::Parser)]
+pub struct Test {
+    #[clap(flatten)]
+    load_args: self::load::PathsLoadArgs,
+
+    #[clap(flatten)]
+    test_args: self::test::TestArgs,
+}
+
+impl Test {
+    pub fn run(&self) -> anyhow::Result<()> {
+        let mut loader = self.load_args.new_loader()?;
+        self.test_args.run(&mut loader)
+    }
+}

--- a/tree-sitter-stack-graphs/src/cli.rs
+++ b/tree-sitter-stack-graphs/src/cli.rs
@@ -12,4 +12,4 @@ pub(self) const MAX_PARSE_ERRORS: usize = 5;
 pub mod load;
 pub mod parse;
 pub mod test;
-pub mod util;
+mod util;

--- a/tree-sitter-stack-graphs/src/cli.rs
+++ b/tree-sitter-stack-graphs/src/cli.rs
@@ -9,6 +9,7 @@
 
 pub(self) const MAX_PARSE_ERRORS: usize = 5;
 
+pub mod init;
 pub mod load;
 pub mod parse;
 pub mod test;

--- a/tree-sitter-stack-graphs/src/cli.rs
+++ b/tree-sitter-stack-graphs/src/cli.rs
@@ -1,0 +1,15 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2022, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! Defines building blocks for CLI
+
+pub(self) const MAX_PARSE_ERRORS: usize = 5;
+
+pub mod load;
+pub mod parse;
+pub mod test;
+pub mod util;

--- a/tree-sitter-stack-graphs/src/cli.rs
+++ b/tree-sitter-stack-graphs/src/cli.rs
@@ -24,7 +24,7 @@ mod path_loading {
     use clap::Subcommand;
 
     use crate::cli::init::InitArgs;
-    use crate::cli::load::PathLoadArgs;
+    use crate::cli::load::PathLoaderArgs;
     use crate::cli::parse::ParseArgs;
     use crate::cli::test::TestArgs;
 
@@ -71,14 +71,14 @@ mod path_loading {
     #[derive(clap::Parser)]
     pub struct Parse {
         #[clap(flatten)]
-        load_args: PathLoadArgs,
+        load_args: PathLoaderArgs,
         #[clap(flatten)]
         parse_args: ParseArgs,
     }
 
     impl Parse {
         pub fn run(&self) -> anyhow::Result<()> {
-            let mut loader = self.load_args.new_loader()?;
+            let mut loader = self.load_args.get()?;
             self.parse_args.run(&mut loader)
         }
     }
@@ -87,14 +87,14 @@ mod path_loading {
     #[derive(clap::Parser)]
     pub struct Test {
         #[clap(flatten)]
-        load_args: PathLoadArgs,
+        load_args: PathLoaderArgs,
         #[clap(flatten)]
         test_args: TestArgs,
     }
 
     impl Test {
         pub fn run(&self) -> anyhow::Result<()> {
-            let mut loader = self.load_args.new_loader()?;
+            let mut loader = self.load_args.get()?;
             self.test_args.run(&mut loader)
         }
     }
@@ -109,7 +109,7 @@ mod provided_languages {
     use crate::cli::test::TestArgs;
     use crate::loader::LanguageConfiguration;
 
-    use super::load::LanguageConfigurationsLoadArgs;
+    use super::load::LanguageConfigurationsLoaderArgs;
 
     /// CLI implementation that loads from provided grammars and stack graph definitions.
     #[derive(Parser)]
@@ -139,14 +139,14 @@ mod provided_languages {
     #[derive(clap::Parser)]
     pub struct Parse {
         #[clap(flatten)]
-        load_args: LanguageConfigurationsLoadArgs,
+        load_args: LanguageConfigurationsLoaderArgs,
         #[clap(flatten)]
         parse_args: ParseArgs,
     }
 
     impl Parse {
         pub fn run(&self, configurations: Vec<LanguageConfiguration>) -> anyhow::Result<()> {
-            let mut loader = self.load_args.new_loader(configurations)?;
+            let mut loader = self.load_args.get(configurations)?;
             self.parse_args.run(&mut loader)
         }
     }
@@ -155,14 +155,14 @@ mod provided_languages {
     #[derive(clap::Parser)]
     pub struct Test {
         #[clap(flatten)]
-        load_args: LanguageConfigurationsLoadArgs,
+        load_args: LanguageConfigurationsLoaderArgs,
         #[clap(flatten)]
         test_args: TestArgs,
     }
 
     impl Test {
         pub fn run(&self, configurations: Vec<LanguageConfiguration>) -> anyhow::Result<()> {
-            let mut loader = self.load_args.new_loader(configurations)?;
+            let mut loader = self.load_args.get(configurations)?;
             self.test_args.run(&mut loader)
         }
     }

--- a/tree-sitter-stack-graphs/src/cli.rs
+++ b/tree-sitter-stack-graphs/src/cli.rs
@@ -16,7 +16,7 @@ pub mod test;
 mod util;
 
 pub use path_loading::Cli as PathLoadingCli;
-pub use provided_languages::Cli as ProvidedLanguagesCli;
+pub use provided_languages::Cli as LanguageConfigurationsCli;
 
 mod path_loading {
     use anyhow::Result;

--- a/tree-sitter-stack-graphs/src/cli/init.rs
+++ b/tree-sitter-stack-graphs/src/cli/init.rs
@@ -6,6 +6,7 @@
 // ------------------------------------------------------------------------------------------------
 
 use anyhow::anyhow;
+use clap::Args;
 use clap::ValueHint;
 use dialoguer::Confirm;
 use dialoguer::{Input, Validator};
@@ -28,14 +29,14 @@ lazy_static! {
 }
 
 /// Initialize project
-#[derive(clap::Parser)]
-pub struct Command {
+#[derive(Args)]
+pub struct InitArgs {
     /// Project directory path.
     #[clap(value_name = "PROJECT_PATH", required = false, default_value = ".", value_hint = ValueHint::AnyPath, parse(from_os_str))]
     project_path: PathBuf,
 }
 
-impl Command {
+impl InitArgs {
     pub fn run(&self) -> anyhow::Result<()> {
         self.check_project_dir()?;
         let config = ProjectSettings::read_from_console()?;

--- a/tree-sitter-stack-graphs/src/cli/init.rs
+++ b/tree-sitter-stack-graphs/src/cli/init.rs
@@ -33,10 +33,14 @@ lazy_static! {
 pub struct InitArgs {
     /// Project directory path.
     #[clap(value_name = "PROJECT_PATH", required = false, default_value = ".", value_hint = ValueHint::AnyPath, parse(from_os_str))]
-    project_path: PathBuf,
+    pub project_path: PathBuf,
 }
 
 impl InitArgs {
+    pub fn new(project_path: PathBuf) -> Self {
+        Self { project_path }
+    }
+
     pub fn run(&self) -> anyhow::Result<()> {
         self.check_project_dir()?;
         let config = ProjectSettings::read_from_console()?;

--- a/tree-sitter-stack-graphs/src/cli/load.rs
+++ b/tree-sitter-stack-graphs/src/cli/load.rs
@@ -15,8 +15,9 @@ use crate::loader::Loader;
 use crate::loader::DEFAULT_BUILTINS_PATHS;
 use crate::loader::DEFAULT_TSG_PATHS;
 
+/// CLI arguments for creating a path based loader.
 #[derive(Args)]
-pub struct LoadArgs {
+pub struct PathsLoadArgs {
     /// The TSG file to use for stack graph construction.
     /// If the file extension is omitted, `.tsg` is implicitly added.
     #[clap(long, value_name = "TSG_PATH")]
@@ -38,7 +39,7 @@ pub struct LoadArgs {
     scope: Option<String>,
 }
 
-impl LoadArgs {
+impl PathsLoadArgs {
     pub fn new_loader(&self) -> Result<Loader, LoadError> {
         let tsg_paths = match &self.tsg {
             Some(tsg_path) => vec![LoadPath::Regular(tsg_path.clone())],
@@ -60,7 +61,7 @@ impl LoadArgs {
             let loader_config = TsConfig::load()
                 .and_then(|v| v.get())
                 .map_err(LoadError::TreeSitter)?;
-            Loader::from_config(
+            Loader::from_tree_sitter_configuration(
                 &loader_config,
                 self.scope.clone(),
                 tsg_paths,

--- a/tree-sitter-stack-graphs/src/cli/load.rs
+++ b/tree-sitter-stack-graphs/src/cli/load.rs
@@ -17,7 +17,7 @@ use crate::loader::DEFAULT_TSG_PATHS;
 
 /// CLI arguments for creating a path based loader.
 #[derive(Args)]
-pub struct PathsLoadArgs {
+pub struct PathLoadArgs {
     /// The TSG file to use for stack graph construction.
     /// If the file extension is omitted, `.tsg` is implicitly added.
     #[clap(long, value_name = "TSG_PATH")]
@@ -39,7 +39,7 @@ pub struct PathsLoadArgs {
     scope: Option<String>,
 }
 
-impl PathsLoadArgs {
+impl PathLoadArgs {
     pub fn new_loader(&self) -> Result<Loader, LoadError> {
         let tsg_paths = match &self.tsg {
             Some(tsg_path) => vec![LoadPath::Regular(tsg_path.clone())],

--- a/tree-sitter-stack-graphs/src/cli/load.rs
+++ b/tree-sitter-stack-graphs/src/cli/load.rs
@@ -9,6 +9,7 @@ use clap::Args;
 use std::path::PathBuf;
 use tree_sitter_config::Config as TsConfig;
 
+use crate::loader::LanguageConfiguration;
 use crate::loader::LoadError;
 use crate::loader::LoadPath;
 use crate::loader::Loader;
@@ -68,6 +69,25 @@ impl PathLoadArgs {
                 builtins_paths,
             )?
         };
+        Ok(loader)
+    }
+}
+
+/// CLI arguments for creating a path based loader.
+#[derive(Args)]
+pub struct LanguageConfigurationsLoadArgs {
+    /// The scope of the tree-sitter grammar.
+    /// See https://tree-sitter.github.io/tree-sitter/syntax-highlighting#basics for details.
+    #[clap(long, value_name = "SCOPE")]
+    scope: Option<String>,
+}
+
+impl LanguageConfigurationsLoadArgs {
+    pub fn new_loader(
+        &self,
+        configurations: Vec<LanguageConfiguration>,
+    ) -> Result<Loader, LoadError> {
+        let loader = Loader::from_language_configurations(configurations, self.scope.clone())?;
         Ok(loader)
     }
 }

--- a/tree-sitter-stack-graphs/src/cli/load.rs
+++ b/tree-sitter-stack-graphs/src/cli/load.rs
@@ -8,14 +8,15 @@
 use clap::Args;
 use std::path::PathBuf;
 use tree_sitter_config::Config as TsConfig;
-use tree_sitter_stack_graphs::loader::LoadError;
-use tree_sitter_stack_graphs::loader::LoadPath;
-use tree_sitter_stack_graphs::loader::Loader;
-use tree_sitter_stack_graphs::loader::DEFAULT_BUILTINS_PATHS;
-use tree_sitter_stack_graphs::loader::DEFAULT_TSG_PATHS;
+
+use crate::loader::LoadError;
+use crate::loader::LoadPath;
+use crate::loader::Loader;
+use crate::loader::DEFAULT_BUILTINS_PATHS;
+use crate::loader::DEFAULT_TSG_PATHS;
 
 #[derive(Args)]
-pub struct LoaderArgs {
+pub struct LoadArgs {
     /// The TSG file to use for stack graph construction.
     /// If the file extension is omitted, `.tsg` is implicitly added.
     #[clap(long, value_name = "TSG_PATH")]
@@ -37,7 +38,7 @@ pub struct LoaderArgs {
     scope: Option<String>,
 }
 
-impl LoaderArgs {
+impl LoadArgs {
     pub fn new_loader(&self) -> Result<Loader, LoadError> {
         let tsg_paths = match &self.tsg {
             Some(tsg_path) => vec![LoadPath::Regular(tsg_path.clone())],

--- a/tree-sitter-stack-graphs/src/cli/load.rs
+++ b/tree-sitter-stack-graphs/src/cli/load.rs
@@ -18,30 +18,39 @@ use crate::loader::DEFAULT_TSG_PATHS;
 
 /// CLI arguments for creating a path based loader.
 #[derive(Args)]
-pub struct PathLoadArgs {
+pub struct PathLoaderArgs {
     /// The TSG file to use for stack graph construction.
     /// If the file extension is omitted, `.tsg` is implicitly added.
     #[clap(long, value_name = "TSG_PATH")]
-    tsg: Option<PathBuf>,
+    pub tsg: Option<PathBuf>,
 
     /// The builtins file to use for stack graph construction.
     /// If the file extension is omitted, the file extension of the language is implicitly added.
     #[clap(long, value_name = "BUILTINS_PATH")]
-    builtins: Option<PathBuf>,
+    pub builtins: Option<PathBuf>,
 
     /// The path to look for tree-sitter grammars.
     /// Can be specified multiple times.
     #[clap(long, value_name = "GRAMMAR_PATH")]
-    grammar: Vec<PathBuf>,
+    pub grammar: Vec<PathBuf>,
 
     /// The scope of the tree-sitter grammar.
     /// See https://tree-sitter.github.io/tree-sitter/syntax-highlighting#basics for details.
     #[clap(long, value_name = "SCOPE")]
-    scope: Option<String>,
+    pub scope: Option<String>,
 }
 
-impl PathLoadArgs {
-    pub fn new_loader(&self) -> Result<Loader, LoadError> {
+impl PathLoaderArgs {
+    pub fn new() -> Self {
+        Self {
+            tsg: None,
+            builtins: None,
+            grammar: Vec::new(),
+            scope: None,
+        }
+    }
+
+    pub fn get(&self) -> Result<Loader, LoadError> {
         let tsg_paths = match &self.tsg {
             Some(tsg_path) => vec![LoadPath::Regular(tsg_path.clone())],
             None => DEFAULT_TSG_PATHS.clone(),
@@ -75,18 +84,19 @@ impl PathLoadArgs {
 
 /// CLI arguments for creating a path based loader.
 #[derive(Args)]
-pub struct LanguageConfigurationsLoadArgs {
+pub struct LanguageConfigurationsLoaderArgs {
     /// The scope of the tree-sitter grammar.
     /// See https://tree-sitter.github.io/tree-sitter/syntax-highlighting#basics for details.
     #[clap(long, value_name = "SCOPE")]
     scope: Option<String>,
 }
 
-impl LanguageConfigurationsLoadArgs {
-    pub fn new_loader(
-        &self,
-        configurations: Vec<LanguageConfiguration>,
-    ) -> Result<Loader, LoadError> {
+impl LanguageConfigurationsLoaderArgs {
+    pub fn new() -> Self {
+        Self { scope: None }
+    }
+
+    pub fn get(&self, configurations: Vec<LanguageConfiguration>) -> Result<Loader, LoadError> {
         let loader = Loader::from_language_configurations(configurations, self.scope.clone())?;
         Ok(loader)
     }

--- a/tree-sitter-stack-graphs/src/cli/parse.rs
+++ b/tree-sitter-stack-graphs/src/cli/parse.rs
@@ -23,7 +23,7 @@ use crate::LoadError;
 pub struct ParseArgs {
     /// Input file path.
     #[clap(value_name = "FILE_PATH", required = true, value_hint = ValueHint::AnyPath, parse(from_os_str), validator_os = path_exists)]
-    file_path: PathBuf,
+    pub file_path: PathBuf,
 }
 
 impl ParseArgs {

--- a/tree-sitter-stack-graphs/src/cli/parse.rs
+++ b/tree-sitter-stack-graphs/src/cli/parse.rs
@@ -7,31 +7,29 @@
 
 use anyhow::anyhow;
 use anyhow::Context as _;
+use clap::Args;
 use clap::ValueHint;
 use std::path::Path;
 use std::path::PathBuf;
 use tree_sitter::Parser;
 use tree_sitter_graph::parse_error::ParseError;
-use tree_sitter_stack_graphs::loader::Loader;
-use tree_sitter_stack_graphs::LoadError;
 
-use crate::loader::LoaderArgs;
-use crate::util::path_exists;
+use crate::cli::load::LoadArgs;
+use crate::cli::util::path_exists;
+use crate::loader::Loader;
+use crate::LoadError;
 
 /// Parse file
-#[derive(clap::Parser)]
-pub struct Command {
-    #[clap(flatten)]
-    loader: LoaderArgs,
-
+#[derive(Args)]
+pub struct ParseArgs {
     /// Input file path.
     #[clap(value_name = "FILE_PATH", required = true, value_hint = ValueHint::AnyPath, parse(from_os_str), validator_os = path_exists)]
     file_path: PathBuf,
 }
 
-impl Command {
-    pub fn run(&self) -> anyhow::Result<()> {
-        let mut loader = self.loader.new_loader()?;
+impl ParseArgs {
+    pub fn run(&self, loader: &LoadArgs) -> anyhow::Result<()> {
+        let mut loader = loader.new_loader()?;
         self.parse_file(&self.file_path, &mut loader)
             .with_context(|| format!("Error parsing file {}", self.file_path.display()))?;
         Ok(())

--- a/tree-sitter-stack-graphs/src/cli/parse.rs
+++ b/tree-sitter-stack-graphs/src/cli/parse.rs
@@ -14,7 +14,6 @@ use std::path::PathBuf;
 use tree_sitter::Parser;
 use tree_sitter_graph::parse_error::ParseError;
 
-use crate::cli::load::LoadArgs;
 use crate::cli::util::path_exists;
 use crate::loader::Loader;
 use crate::LoadError;
@@ -28,9 +27,8 @@ pub struct ParseArgs {
 }
 
 impl ParseArgs {
-    pub fn run(&self, loader: &LoadArgs) -> anyhow::Result<()> {
-        let mut loader = loader.new_loader()?;
-        self.parse_file(&self.file_path, &mut loader)
+    pub fn run(&self, loader: &mut Loader) -> anyhow::Result<()> {
+        self.parse_file(&self.file_path, loader)
             .with_context(|| format!("Error parsing file {}", self.file_path.display()))?;
         Ok(())
     }

--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -21,7 +21,6 @@ use std::path::PathBuf;
 use tree_sitter_graph::Variables;
 use walkdir::WalkDir;
 
-use crate::cli::load::LoadArgs;
 use crate::cli::util::map_parse_errors;
 use crate::cli::util::path_exists;
 use crate::cli::util::PathSpec;
@@ -133,8 +132,7 @@ pub struct TestArgs {
 }
 
 impl TestArgs {
-    pub fn run(&self, loader: &LoadArgs) -> anyhow::Result<()> {
-        let mut loader = loader.new_loader()?;
+    pub fn run(&self, loader: &mut Loader) -> anyhow::Result<()> {
         let mut total_failure_count = 0;
         for test_path in &self.tests {
             if test_path.is_dir() {
@@ -147,12 +145,11 @@ impl TestArgs {
                 {
                     let test_path = test_entry.path();
                     total_failure_count +=
-                        self.run_test_with_context(test_root, test_path, &mut loader)?;
+                        self.run_test_with_context(test_root, test_path, loader)?;
                 }
             } else {
                 let test_root = test_path.parent().unwrap();
-                total_failure_count +=
-                    self.run_test_with_context(test_root, test_path, &mut loader)?;
+                total_failure_count += self.run_test_with_context(test_root, test_path, loader)?;
             }
         }
 

--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -70,19 +70,19 @@ impl OutputMode {
 pub struct TestArgs {
     /// Test file or directory paths.
     #[clap(value_name = "TEST_PATH", required = true, value_hint = ValueHint::AnyPath, parse(from_os_str), validator_os = path_exists)]
-    tests: Vec<PathBuf>,
+    pub test_paths: Vec<PathBuf>,
 
     /// Hide passing tests.
     #[clap(long)]
-    hide_passing: bool,
+    pub hide_passing: bool,
 
     /// Hide failure error details.
     #[clap(long)]
-    hide_failure_errors: bool,
+    pub hide_failure_errors: bool,
 
     /// Show ignored files in output.
     #[clap(long)]
-    show_ignored: bool,
+    pub show_ignored: bool,
 
     /// Save graph for tests matching output mode.
     /// Takes an optional path specification argument for the output file.
@@ -96,7 +96,7 @@ pub struct TestArgs {
         require_equals = true,
         default_missing_value = "%n.graph.json"
     )]
-    save_graph: Option<PathSpec>,
+    pub save_graph: Option<PathSpec>,
 
     /// Save paths for tests matching output mode.
     /// Takes an optional path specification argument for the output file.
@@ -110,7 +110,7 @@ pub struct TestArgs {
         require_equals = true,
         default_missing_value = "%n.paths.json"
     )]
-    save_paths: Option<PathSpec>,
+    pub save_paths: Option<PathSpec>,
 
     /// Save visualization for tests matching output mode.
     /// Takes an optional path specification argument for the output file.
@@ -124,17 +124,30 @@ pub struct TestArgs {
         require_equals = true,
         default_missing_value = "%n.html"
     )]
-    save_visualization: Option<PathSpec>,
+    pub save_visualization: Option<PathSpec>,
 
     /// Controls when graphs, paths, or visualization are saved.
     #[clap(long, arg_enum, default_value_t = OutputMode::OnFailure)]
-    output_mode: OutputMode,
+    pub output_mode: OutputMode,
 }
 
 impl TestArgs {
+    pub fn new(test_paths: Vec<PathBuf>) -> Self {
+        Self {
+            test_paths,
+            hide_passing: false,
+            hide_failure_errors: false,
+            show_ignored: false,
+            save_graph: None,
+            save_paths: None,
+            save_visualization: None,
+            output_mode: OutputMode::OnFailure,
+        }
+    }
+
     pub fn run(&self, loader: &mut Loader) -> anyhow::Result<()> {
         let mut total_failure_count = 0;
-        for test_path in &self.tests {
+        for test_path in &self.test_paths {
             if test_path.is_dir() {
                 let test_root = test_path;
                 for test_entry in WalkDir::new(test_path)

--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -150,7 +150,7 @@ impl TestArgs {
         for test_path in &self.test_paths {
             if test_path.is_dir() {
                 let test_root = test_path;
-                for test_entry in WalkDir::new(test_path)
+                for test_entry in WalkDir::new(test_root)
                     .follow_links(true)
                     .into_iter()
                     .filter_map(|e| e.ok())

--- a/tree-sitter-stack-graphs/src/cli/util.rs
+++ b/tree-sitter-stack-graphs/src/cli/util.rs
@@ -12,9 +12,9 @@ use std::path::Path;
 use std::path::PathBuf;
 use tree_sitter_graph::parse_error::TreeWithParseErrorVec;
 
-use crate::MAX_PARSE_ERRORS;
+use crate::cli::MAX_PARSE_ERRORS;
 
-pub(crate) fn path_exists(path: &OsStr) -> anyhow::Result<PathBuf> {
+pub fn path_exists(path: &OsStr) -> anyhow::Result<PathBuf> {
     let path = PathBuf::from(path);
     if !path.exists() {
         return Err(anyhow!("path does not exist"));
@@ -24,7 +24,7 @@ pub(crate) fn path_exists(path: &OsStr) -> anyhow::Result<PathBuf> {
 
 /// A path specification that can be formatted into a path based on a root and path
 /// contained in that root.
-pub(crate) struct PathSpec {
+pub struct PathSpec {
     spec: String,
 }
 
@@ -102,7 +102,7 @@ impl PathSpec {
             panic!("Unsupported '%' at end");
         }
         let path = Path::new(&path);
-        tree_sitter_stack_graphs::functions::path::normalize(&path)
+        crate::functions::path::normalize(&path)
     }
 }
 
@@ -119,7 +119,7 @@ impl From<&str> for PathSpec {
     }
 }
 
-pub(crate) fn map_parse_errors(
+pub fn map_parse_errors(
     test_path: &Path,
     parse_errors: &TreeWithParseErrorVec,
     source: &str,

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -318,6 +318,8 @@ use tree_sitter_graph::parse_error::TreeWithParseErrorVec;
 use tree_sitter_graph::ExecutionConfig;
 use tree_sitter_graph::Variables;
 
+#[cfg(feature = "cli")]
+pub mod cli;
 pub mod functions;
 pub mod loader;
 pub mod test;

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -235,11 +235,11 @@ impl From<crate::LoadError> for LoadError {
 // provided languages loader
 
 pub struct LanguageConfiguration {
-    language: Language,
-    file_types: Vec<String>,
-    tsg_source: String,
-    builtins_source: String,
-    builtins_config: String,
+    pub language: Language,
+    pub file_types: Vec<String>,
+    pub tsg_source: String,
+    pub builtins_source: String,
+    pub builtins_config: String,
 }
 
 impl LanguageConfiguration {

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -50,8 +50,9 @@ impl LoadPath {
     }
 }
 
-/// The loader is created from a tree-sitter configuration or list of search paths, an optional scope,
-/// and search paths for stack graphs definitions and builtins.
+/// The loader is created from either a tree-sitter configuration or a list of search paths, and an
+/// optional scope and search paths for stack graphs definitions and builtins; or a list of language
+/// configurations.
 ///
 /// The loader is called with a file path and optional file content and tries to find the language for
 /// that file. The loader will search for tree-sitter languages in the given search paths, or in current
@@ -90,7 +91,7 @@ impl Loader {
         })))
     }
 
-    pub fn from_config(
+    pub fn from_tree_sitter_configuration(
         config: &TsConfig,
         scope: Option<String>,
         tsg_paths: Vec<LoadPath>,
@@ -106,7 +107,7 @@ impl Loader {
         })))
     }
 
-    pub fn from_configurations(
+    pub fn from_language_configurations(
         configurations: Vec<LanguageConfiguration>,
     ) -> Result<Self, LoadError> {
         Ok(Self(LoaderImpl::Provided(ProvidedLoader {

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -240,6 +240,7 @@ impl From<crate::LoadError> for LoadError {
 // ------------------------------------------------------------------------------------------------
 // provided languages loader
 
+#[derive(Clone)]
 pub struct LanguageConfiguration {
     pub language: Language,
     pub scope: Option<String>,

--- a/tree-sitter-stack-graphs/src/test.rs
+++ b/tree-sitter-stack-graphs/src/test.rs
@@ -323,7 +323,7 @@ pub struct TestResult {
 }
 
 impl TestResult {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             failures: Vec::new(),
             success_count: 0,
@@ -359,6 +359,24 @@ impl TestResult {
     /// Total number of assertions that were run.
     pub fn count(&self) -> usize {
         self.success_count() + self.failure_count()
+    }
+
+    pub fn absorb(&mut self, other: TestResult) {
+        self.success_count += other.success_count;
+        let mut failures = other.failures;
+        self.failures.append(&mut failures);
+    }
+}
+
+impl std::fmt::Display for TestResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} tests: {} passed, {} failed",
+            self.count(),
+            self.success_count(),
+            self.failure_count()
+        )
     }
 }
 

--- a/tree-sitter-stack-graphs/tests/it/loader.rs
+++ b/tree-sitter-stack-graphs/tests/it/loader.rs
@@ -23,7 +23,7 @@ lazy_static! {
 #[test]
 fn can_load_from_provided_language_configuration() {
     let language = tree_sitter_python::language();
-    let mut loader = Loader::from_configurations(vec![LanguageConfiguration {
+    let mut loader = Loader::from_language_configurations(vec![LanguageConfiguration {
         language: language,
         file_types: vec!["py".into()],
         tsg_source: TSG.to_string(),

--- a/tree-sitter-stack-graphs/tests/it/loader.rs
+++ b/tree-sitter-stack-graphs/tests/it/loader.rs
@@ -30,8 +30,7 @@ fn can_load_from_provided_language_configuration() {
             content_regex: None,
             file_types: vec!["py".into()],
             tsg_source: TSG.to_string(),
-            builtins_source: "".into(),
-            builtins_config: "".into(),
+            builtins: None,
         }],
         None,
     )

--- a/tree-sitter-stack-graphs/tests/it/loader.rs
+++ b/tree-sitter-stack-graphs/tests/it/loader.rs
@@ -1,0 +1,44 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use lazy_static::lazy_static;
+use pretty_assertions::assert_eq;
+use std::path::PathBuf;
+use tree_sitter_stack_graphs::loader::LanguageConfiguration;
+use tree_sitter_stack_graphs::loader::Loader;
+use tree_sitter_stack_graphs::NoCancellation;
+
+lazy_static! {
+    static ref PATH: PathBuf = PathBuf::from("test.py");
+    static ref TSG: String = r#"
+      (module) {}
+    "#
+    .to_string();
+}
+
+#[test]
+fn can_load_from_provided_language_configuration() {
+    let language = tree_sitter_python::language();
+    let mut loader = Loader::from_configurations(vec![LanguageConfiguration {
+        language: language,
+        file_types: vec!["py".into()],
+        tsg_source: TSG.to_string(),
+        builtins_source: "".into(),
+        builtins_config: "".into(),
+    }])
+    .expect("Expected loader to succeed");
+
+    let tsl = loader
+        .load_tree_sitter_language_for_file(&PATH, None)
+        .expect("Expected loading tree-sitter language to succeed");
+    assert_eq!(tsl, Some(language));
+
+    let sgl = loader
+        .load_for_file(&PATH, None, &NoCancellation)
+        .expect("Expected loading stack graph language to succeed");
+    assert_eq!(sgl.map(|sgl| sgl.language()), Some(language));
+}

--- a/tree-sitter-stack-graphs/tests/it/loader.rs
+++ b/tree-sitter-stack-graphs/tests/it/loader.rs
@@ -23,13 +23,18 @@ lazy_static! {
 #[test]
 fn can_load_from_provided_language_configuration() {
     let language = tree_sitter_python::language();
-    let mut loader = Loader::from_language_configurations(vec![LanguageConfiguration {
-        language: language,
-        file_types: vec!["py".into()],
-        tsg_source: TSG.to_string(),
-        builtins_source: "".into(),
-        builtins_config: "".into(),
-    }])
+    let mut loader = Loader::from_language_configurations(
+        vec![LanguageConfiguration {
+            language: language,
+            scope: Some("source.py".into()),
+            content_regex: None,
+            file_types: vec!["py".into()],
+            tsg_source: TSG.to_string(),
+            builtins_source: "".into(),
+            builtins_config: "".into(),
+        }],
+        None,
+    )
     .expect("Expected loader to succeed");
 
     let tsl = loader

--- a/tree-sitter-stack-graphs/tests/it/main.rs
+++ b/tree-sitter-stack-graphs/tests/it/main.rs
@@ -15,6 +15,7 @@ use tree_sitter_stack_graphs::StackGraphLanguage;
 
 mod builder;
 mod edges;
+mod loader;
 mod nodes;
 mod test;
 


### PR DESCRIPTION
This PR moves most of the CLI logic to the library (though still behind the `cli` feature!). This makes it possible to (a) create specialized CLIs whith included languages, and (b) run them programmatically from tests.

# Context

- ▶️ #146
- #140 
- #142