### PR TITLE
Bump bitvec to 1.0

### DIFF
--- a/stack-graphs/Cargo.toml
+++ b/stack-graphs/Cargo.toml
@@ -21,7 +21,7 @@ json = ["serde", "serde_json"]
 test = false
 
 [dependencies]
-bitvec = "0.22"
+bitvec = "1.0"
 controlled-option = "0.4"
 either = "1.6"
 fxhash = "0.2"

--- a/stack-graphs/src/arena.rs
+++ b/stack-graphs/src/arena.rs
@@ -361,7 +361,7 @@ where
 /// Contains a set of handles, encoded efficiently using a bit set.
 #[repr(C)]
 pub struct HandleSet<T> {
-    elements: BitVec<bitvec::order::Lsb0, u32>,
+    elements: BitVec<u32, bitvec::order::Lsb0>,
     _phantom: PhantomData<T>,
 }
 
@@ -409,7 +409,7 @@ impl<T> HandleSet<T> {
 
     /// Returns a pointer to this set's storage.
     pub(crate) fn as_ptr(&self) -> *const u32 {
-        self.elements.as_raw_ptr()
+        self.elements.as_bitptr().pointer()
     }
 
     /// Returns the number of instances stored in this arena.


### PR DESCRIPTION
Our bitvec dependency depended on another library version that was yanked from cargo. This updates bitvec to the latest version so that we can build again.