### PR TITLE
Reorganize loader

### DIFF
--- a/languages/tree-sitter-stack-graphs-typescript/Cargo.toml
+++ b/languages/tree-sitter-stack-graphs-typescript/Cargo.toml
@@ -24,5 +24,6 @@ harness = false
 [dependencies]
 anyhow = "1.0"
 clap = "3"
+stack-graphs = { version = "~0.10.1", path = "../../stack-graphs" }
 tree-sitter-stack-graphs = { version = "~0.4.0", path = "../../tree-sitter-stack-graphs", features=["cli"] }
 tree-sitter-typescript = { git = "https://github.com/tree-sitter/tree-sitter-typescript", rev="082da44a5263599186dadafd2c974c19f3a73d28" }

--- a/languages/tree-sitter-stack-graphs-typescript/rust/bin.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/bin.rs
@@ -6,9 +6,10 @@
 // ------------------------------------------------------------------------------------------------
 
 use tree_sitter_stack_graphs::cli::LanguageConfigurationsCli as Cli;
+use tree_sitter_stack_graphs::NoCancellation;
 
 fn main() -> anyhow::Result<()> {
     Cli::main(vec![
-        tree_sitter_stack_graphs_typescript::language_configuration(),
+        tree_sitter_stack_graphs_typescript::language_configuration(&NoCancellation),
     ])
 }

--- a/languages/tree-sitter-stack-graphs-typescript/rust/bin.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/bin.rs
@@ -1,3 +1,10 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2022, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
 use tree_sitter_stack_graphs::cli::LanguageConfigurationsCli as Cli;
 
 fn main() -> anyhow::Result<()> {

--- a/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
@@ -1,3 +1,10 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2022, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
 use tree_sitter_stack_graphs::loader::BuiltinsConfiguration;
 use tree_sitter_stack_graphs::loader::LanguageConfiguration;
 

--- a/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
@@ -5,12 +5,8 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-use stack_graphs::graph::StackGraph;
 use tree_sitter_stack_graphs::loader::LanguageConfiguration;
-use tree_sitter_stack_graphs::loader::Loader;
 use tree_sitter_stack_graphs::CancellationFlag;
-use tree_sitter_stack_graphs::StackGraphLanguage;
-use tree_sitter_stack_graphs::Variables;
 
 /// The stack graphs tsg source for this language
 const STACK_GRAPHS_TSG_SOURCE: &str = include_str!("../src/stack-graphs.tsg");
@@ -21,27 +17,15 @@ const STACK_GRAPHS_BUILTINS_CONFIG: &str = include_str!("../src/builtins.cfg");
 const STACK_GRAPHS_BUILTINS_SOURCE: &str = include_str!("../src/builtins.ts");
 
 pub fn language_configuration(cancellation_flag: &dyn CancellationFlag) -> LanguageConfiguration {
-    let language = tree_sitter_typescript::language_typescript();
-    let sgl = StackGraphLanguage::from_str(language, STACK_GRAPHS_TSG_SOURCE).unwrap();
-    let mut builtins = StackGraph::new();
-    let file = builtins.add_file("<builtins>").unwrap();
-    let mut builtins_globals = Variables::new();
-    Loader::load_globals_from_config_str(STACK_GRAPHS_BUILTINS_CONFIG, &mut builtins_globals)
-        .unwrap();
-    sgl.build_stack_graph_into(
-        &mut builtins,
-        file,
-        STACK_GRAPHS_BUILTINS_SOURCE,
-        &builtins_globals,
+    LanguageConfiguration::from_tsg_str(
+        tree_sitter_typescript::language_typescript(),
+        Some(String::from("source.ts")),
+        None,
+        vec![String::from("ts")],
+        STACK_GRAPHS_TSG_SOURCE,
+        Some(STACK_GRAPHS_BUILTINS_SOURCE),
+        Some(STACK_GRAPHS_BUILTINS_CONFIG),
         cancellation_flag,
     )
-    .unwrap();
-    LanguageConfiguration {
-        language,
-        scope: Some(String::from("source.ts")),
-        content_regex: None,
-        file_types: vec![String::from("ts")],
-        sgl,
-        builtins,
-    }
+    .unwrap()
 }

--- a/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
@@ -5,8 +5,12 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-use tree_sitter_stack_graphs::loader::BuiltinsConfiguration;
+use stack_graphs::graph::StackGraph;
 use tree_sitter_stack_graphs::loader::LanguageConfiguration;
+use tree_sitter_stack_graphs::loader::Loader;
+use tree_sitter_stack_graphs::CancellationFlag;
+use tree_sitter_stack_graphs::StackGraphLanguage;
+use tree_sitter_stack_graphs::Variables;
 
 /// The stack graphs tsg source for this language
 const STACK_GRAPHS_TSG_SOURCE: &str = include_str!("../src/stack-graphs.tsg");
@@ -16,16 +20,28 @@ const STACK_GRAPHS_BUILTINS_CONFIG: &str = include_str!("../src/builtins.cfg");
 /// The stack graphs builtins source for this language
 const STACK_GRAPHS_BUILTINS_SOURCE: &str = include_str!("../src/builtins.ts");
 
-pub fn language_configuration() -> LanguageConfiguration {
+pub fn language_configuration(cancellation_flag: &dyn CancellationFlag) -> LanguageConfiguration {
+    let language = tree_sitter_typescript::language_typescript();
+    let sgl = StackGraphLanguage::from_str(language, STACK_GRAPHS_TSG_SOURCE).unwrap();
+    let mut builtins = StackGraph::new();
+    let file = builtins.add_file("<builtins>").unwrap();
+    let mut builtins_globals = Variables::new();
+    Loader::load_globals_from_config_str(STACK_GRAPHS_BUILTINS_CONFIG, &mut builtins_globals)
+        .unwrap();
+    sgl.build_stack_graph_into(
+        &mut builtins,
+        file,
+        STACK_GRAPHS_BUILTINS_SOURCE,
+        &builtins_globals,
+        cancellation_flag,
+    )
+    .unwrap();
     LanguageConfiguration {
-        language: tree_sitter_typescript::language_typescript(),
+        language,
         scope: Some(String::from("source.ts")),
         content_regex: None,
         file_types: vec![String::from("ts")],
-        tsg_source: STACK_GRAPHS_TSG_SOURCE.to_string(),
-        builtins: Some(BuiltinsConfiguration {
-            source: STACK_GRAPHS_BUILTINS_SOURCE.to_string(),
-            config: STACK_GRAPHS_BUILTINS_CONFIG.to_string(),
-        }),
+        sgl,
+        builtins,
     }
 }

--- a/languages/tree-sitter-stack-graphs-typescript/rust/test.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/test.rs
@@ -7,11 +7,14 @@
 
 use std::path::PathBuf;
 use tree_sitter_stack_graphs::cli::CiTester;
+use tree_sitter_stack_graphs::NoCancellation;
 
 fn main() -> anyhow::Result<()> {
     let test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test");
     CiTester::new(
-        vec![tree_sitter_stack_graphs_typescript::language_configuration()],
+        vec![tree_sitter_stack_graphs_typescript::language_configuration(
+            &NoCancellation,
+        )],
         vec![test_path],
     )
     .run()

--- a/languages/tree-sitter-stack-graphs-typescript/rust/test.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/test.rs
@@ -1,3 +1,10 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2022, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
 use std::path::PathBuf;
 use tree_sitter_stack_graphs::cli::CiTester;
 

--- a/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
@@ -1,3 +1,10 @@
+; -*- coding: utf-8 -*-
+; ------------------------------------------------------------------------------------------------
+; Copyright © 2022, stack-graphs authors.
+; Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+; Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+; ------------------------------------------------------------------------------------------------
+
 ; ########################################################################################
 ;
 ; ######## ##    ## ########  ########  ######   ######  ########  #### ########  ########

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -331,13 +331,15 @@ use tree_sitter_graph::graph::Value;
 use tree_sitter_graph::parse_error::ParseError;
 use tree_sitter_graph::parse_error::TreeWithParseErrorVec;
 use tree_sitter_graph::ExecutionConfig;
-use tree_sitter_graph::Variables;
 
 #[cfg(feature = "cli")]
 pub mod cli;
 pub mod functions;
 pub mod loader;
 pub mod test;
+
+pub use tree_sitter_graph::VariableError;
+pub use tree_sitter_graph::Variables;
 
 // Node type values
 static DROP_SCOPES_TYPE: &'static str = "drop_scopes";
@@ -387,7 +389,6 @@ pub struct StackGraphLanguage {
     language: tree_sitter::Language,
     tsg: tree_sitter_graph::ast::File,
     functions: Functions,
-    builtins: StackGraph,
 }
 
 impl StackGraphLanguage {
@@ -402,7 +403,6 @@ impl StackGraphLanguage {
             language,
             tsg,
             functions: Self::default_functions(),
-            builtins: StackGraph::new(),
         })
     }
 
@@ -417,7 +417,6 @@ impl StackGraphLanguage {
             language,
             tsg,
             functions: Self::default_functions(),
-            builtins: StackGraph::new(),
         })
     }
 
@@ -429,14 +428,6 @@ impl StackGraphLanguage {
 
     pub fn functions_mut(&mut self) -> &mut tree_sitter_graph::functions::Functions {
         &mut self.functions
-    }
-
-    pub fn builtins(&self) -> &StackGraph {
-        &self.builtins
-    }
-
-    pub fn builtins_mut(&mut self) -> &mut StackGraph {
-        &mut self.builtins
     }
 
     pub fn language(&self) -> tree_sitter::Language {

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -117,7 +117,6 @@ impl Loader {
             .collect();
         Ok(Self(LoaderImpl::Provided(LanguageConfigurationsLoader {
             configurations,
-            cache: Vec::new(),
         })))
     }
 
@@ -143,7 +142,7 @@ impl Loader {
         path: &Path,
         content: Option<&str>,
         cancellation_flag: &dyn CancellationFlag,
-    ) -> Result<Option<&mut StackGraphLanguage>, LoadError> {
+    ) -> Result<Option<&LanguageConfiguration>, LoadError> {
         match &mut self.0 {
             LoaderImpl::Paths(loader) => loader.load_for_file(path, content, cancellation_flag),
             LoaderImpl::Provided(loader) => loader.load_for_file(path, content, cancellation_flag),
@@ -174,19 +173,18 @@ impl Loader {
         Ok(tsg)
     }
 
-    fn load_builtins(
-        sgl: &mut StackGraphLanguage,
+    fn load_builtins_into(
+        sgl: &StackGraphLanguage,
         path: &Path,
         source: &str,
         config: &str,
+        graph: &mut StackGraph,
         cancellation_flag: &dyn CancellationFlag,
     ) -> Result<(), LoadError> {
-        let mut graph = StackGraph::new();
         let file = graph.add_file(&path.to_string_lossy()).unwrap();
         let mut globals = Variables::new();
         Self::load_globals_from_config_str(&config, &mut globals)?;
-        sgl.build_stack_graph_into(&mut graph, file, &source, &globals, cancellation_flag)?;
-        sgl.builtins_mut().add_from_graph(&graph).unwrap();
+        sgl.build_stack_graph_into(graph, file, &source, &globals, cancellation_flag)?;
         return Ok(());
     }
 
@@ -240,59 +238,23 @@ impl From<crate::LoadError> for LoadError {
 // ------------------------------------------------------------------------------------------------
 // provided languages loader
 
-#[derive(Clone)]
 pub struct LanguageConfiguration {
     pub language: Language,
     pub scope: Option<String>,
     pub content_regex: Option<Regex>,
     pub file_types: Vec<String>,
-    pub tsg_source: String,
-    pub builtins: Option<BuiltinsConfiguration>,
-}
-
-#[derive(Clone)]
-pub struct BuiltinsConfiguration {
-    pub source: String,
-    pub config: String,
+    pub sgl: StackGraphLanguage,
+    pub builtins: StackGraph,
 }
 
 impl LanguageConfiguration {
     pub fn matches_file(&self, path: &Path, content: Option<&str>) -> bool {
         matches_file(&self.file_types, &self.content_regex, path, content).is_some()
     }
-
-    pub fn to_stack_graph_language(
-        &self,
-        cancellation_flag: &dyn CancellationFlag,
-    ) -> Result<StackGraphLanguage, LoadError> {
-        let tsg = Loader::load_tsg(self.language, &self.tsg_source)?;
-        let mut sgl = StackGraphLanguage::new(self.language, tsg)?;
-        if let Some(builtins) = &self.builtins {
-            builtins.load_into_stack_graph_language(&mut sgl, cancellation_flag)?;
-        }
-        Ok(sgl)
-    }
-}
-
-impl BuiltinsConfiguration {
-    pub fn load_into_stack_graph_language(
-        &self,
-        sgl: &mut StackGraphLanguage,
-        cancellation_flag: &dyn CancellationFlag,
-    ) -> Result<(), LoadError> {
-        Loader::load_builtins(
-            sgl,
-            &Path::new("<builtins>"),
-            &self.source,
-            &self.config,
-            cancellation_flag,
-        )
-    }
 }
 
 struct LanguageConfigurationsLoader {
     configurations: Vec<LanguageConfiguration>,
-    cache: Vec<(Language, StackGraphLanguage)>,
 }
 
 impl LanguageConfigurationsLoader {
@@ -320,9 +282,9 @@ impl LanguageConfigurationsLoader {
         &mut self,
         path: &Path,
         content: Option<&str>,
-        cancellation_flag: &dyn CancellationFlag,
-    ) -> Result<Option<&mut StackGraphLanguage>, LoadError> {
-        let configuration = match self
+        _cancellation_flag: &dyn CancellationFlag,
+    ) -> Result<Option<&LanguageConfiguration>, LoadError> {
+        let language = match self
             .configurations
             .iter()
             .find(|l| l.matches_file(path, content))
@@ -330,21 +292,7 @@ impl LanguageConfigurationsLoader {
             Some(language) => language,
             None => return Ok(None),
         };
-        // the borrow checker is a hard master...
-        let index = self
-            .cache
-            .iter()
-            .position(|e| &e.0 == &configuration.language);
-        let index = match index {
-            Some(index) => index,
-            None => {
-                let sgl = configuration.to_stack_graph_language(cancellation_flag)?;
-                self.cache.push((configuration.language, sgl));
-                self.cache.len() - 1
-            }
-        };
-        let sgl = &mut self.cache[index].1;
-        Ok(Some(sgl))
+        Ok(Some(language))
     }
 }
 
@@ -357,7 +305,7 @@ struct PathLoader {
     scope: Option<String>,
     tsg_paths: Vec<LoadPath>,
     builtins_paths: Vec<LoadPath>,
-    cache: Vec<(Language, StackGraphLanguage)>,
+    cache: Vec<(Language, LanguageConfiguration)>,
 }
 
 impl PathLoader {
@@ -402,7 +350,7 @@ impl PathLoader {
         path: &Path,
         content: Option<&str>,
         cancellation_flag: &dyn CancellationFlag,
-    ) -> Result<Option<&mut StackGraphLanguage>, LoadError> {
+    ) -> Result<Option<&LanguageConfiguration>, LoadError> {
         let selected_language = self.select_language_for_file(path, content)?;
         let language = match selected_language {
             Some(selected_language) => selected_language.clone(),
@@ -414,9 +362,25 @@ impl PathLoader {
             Some(index) => index,
             None => {
                 let tsg = self.load_tsg_from_paths(&language)?;
-                let mut sgl = StackGraphLanguage::new(language.language, tsg)?;
-                self.load_builtins_from_paths(&language, &mut sgl, cancellation_flag)?;
-                self.cache.push((language.language, sgl));
+                let sgl = StackGraphLanguage::new(language.language, tsg)?;
+
+                let mut builtins = StackGraph::new();
+                self.load_builtins_from_paths_into(
+                    &language,
+                    &sgl,
+                    &mut builtins,
+                    cancellation_flag,
+                )?;
+
+                let lc = LanguageConfiguration {
+                    language: language.language,
+                    scope: language.scope,
+                    content_regex: language.content_regex,
+                    file_types: language.file_types,
+                    sgl,
+                    builtins,
+                };
+                self.cache.push((language.language, lc));
 
                 self.cache.len() - 1
             }
@@ -503,30 +467,42 @@ impl PathLoader {
     // Builtins are loaded from queries/builtins.EXT and an optional queries/builtins.cfg configuration.
     // In the future, we may extend this to support builtins spread over multiple files queries/builtins/NAME.EXT
     // and optional corresponding configuration files queries/builtins/NAME.cfg.
-    fn load_builtins_from_paths(
+    fn load_builtins_from_paths_into(
         &self,
         language: &SupplementedLanguage,
-        sgl: &mut StackGraphLanguage,
+        sgl: &StackGraphLanguage,
+        graph: &mut StackGraph,
         cancellation_flag: &dyn CancellationFlag,
     ) -> Result<(), LoadError> {
         for builtins_path in &self.builtins_paths {
             let mut builtins_path = builtins_path.get_for_grammar(&language.root_path);
             if builtins_path.exists() && !builtins_path.is_dir() {
-                return Self::load_builtins_from_path(sgl, &builtins_path, cancellation_flag);
+                return Self::load_builtins_from_path_into(
+                    sgl,
+                    &builtins_path,
+                    graph,
+                    cancellation_flag,
+                );
             }
             for extension in &language.file_types {
                 builtins_path.set_extension(extension);
                 if builtins_path.exists() && !builtins_path.is_dir() {
-                    return Self::load_builtins_from_path(sgl, &builtins_path, cancellation_flag);
+                    return Self::load_builtins_from_path_into(
+                        sgl,
+                        &builtins_path,
+                        graph,
+                        cancellation_flag,
+                    );
                 }
             }
         }
         Ok(())
     }
 
-    fn load_builtins_from_path(
-        sgl: &mut StackGraphLanguage,
+    fn load_builtins_from_path_into(
+        sgl: &StackGraphLanguage,
         builtins_path: &Path,
+        graph: &mut StackGraph,
         cancellation_flag: &dyn CancellationFlag,
     ) -> Result<(), LoadError> {
         let source = std::fs::read_to_string(builtins_path.clone())?;
@@ -537,7 +513,14 @@ impl PathLoader {
         } else {
             "".into()
         };
-        Loader::load_builtins(sgl, builtins_path, &source, &config, cancellation_flag)
+        Loader::load_builtins_into(
+            sgl,
+            builtins_path,
+            &source,
+            &config,
+            graph,
+            cancellation_flag,
+        )
     }
 }
 

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -197,7 +197,7 @@ impl Loader {
     ) -> Result<Option<&LanguageConfiguration>, LoadError> {
         match &mut self.0 {
             LoaderImpl::Paths(loader) => loader.load_for_file(path, content, cancellation_flag),
-            LoaderImpl::Provided(loader) => loader.load_for_file(path, content, cancellation_flag),
+            LoaderImpl::Provided(loader) => loader.load_for_file(path, content),
         }
     }
 
@@ -319,7 +319,6 @@ impl LanguageConfigurationsLoader {
         &mut self,
         path: &Path,
         content: Option<&str>,
-        _cancellation_flag: &dyn CancellationFlag,
     ) -> Result<Option<&LanguageConfiguration>, LoadError> {
         let language = match self
             .configurations

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -34,6 +34,22 @@ lazy_static! {
         vec![LoadPath::Grammar("queries/builtins".into())];
 }
 
+/// Data type that holds all information to recognize and analyze files for a language
+pub struct LanguageConfiguration {
+    pub language: Language,
+    pub scope: Option<String>,
+    pub content_regex: Option<Regex>,
+    pub file_types: Vec<String>,
+    pub sgl: StackGraphLanguage,
+    pub builtins: StackGraph,
+}
+
+impl LanguageConfiguration {
+    pub fn matches_file(&self, path: &Path, content: Option<&str>) -> bool {
+        matches_file(&self.file_types, &self.content_regex, path, content).is_some()
+    }
+}
+
 /// A load path specifies a file to load from, either as a regular path or relative to the grammar location.
 #[derive(Clone, Debug)]
 pub enum LoadPath {
@@ -237,21 +253,6 @@ impl From<crate::LoadError> for LoadError {
 
 // ------------------------------------------------------------------------------------------------
 // provided languages loader
-
-pub struct LanguageConfiguration {
-    pub language: Language,
-    pub scope: Option<String>,
-    pub content_regex: Option<Regex>,
-    pub file_types: Vec<String>,
-    pub sgl: StackGraphLanguage,
-    pub builtins: StackGraph,
-}
-
-impl LanguageConfiguration {
-    pub fn matches_file(&self, path: &Path, content: Option<&str>) -> bool {
-        matches_file(&self.file_types, &self.content_regex, path, content).is_some()
-    }
-}
 
 struct LanguageConfigurationsLoader {
     configurations: Vec<LanguageConfiguration>,

--- a/tree-sitter-stack-graphs/tests/it/loader.rs
+++ b/tree-sitter-stack-graphs/tests/it/loader.rs
@@ -7,10 +7,12 @@
 
 use lazy_static::lazy_static;
 use pretty_assertions::assert_eq;
+use stack_graphs::graph::StackGraph;
 use std::path::PathBuf;
 use tree_sitter_stack_graphs::loader::LanguageConfiguration;
 use tree_sitter_stack_graphs::loader::Loader;
 use tree_sitter_stack_graphs::NoCancellation;
+use tree_sitter_stack_graphs::StackGraphLanguage;
 
 lazy_static! {
     static ref PATH: PathBuf = PathBuf::from("test.py");
@@ -23,26 +25,25 @@ lazy_static! {
 #[test]
 fn can_load_from_provided_language_configuration() {
     let language = tree_sitter_python::language();
-    let mut loader = Loader::from_language_configurations(
-        vec![LanguageConfiguration {
-            language: language,
-            scope: Some("source.py".into()),
-            content_regex: None,
-            file_types: vec!["py".into()],
-            tsg_source: TSG.to_string(),
-            builtins: None,
-        }],
-        None,
-    )
-    .expect("Expected loader to succeed");
+    let sgl = StackGraphLanguage::from_str(language, &TSG).unwrap();
+    let lc = LanguageConfiguration {
+        language: language,
+        scope: Some("source.py".into()),
+        content_regex: None,
+        file_types: vec!["py".into()],
+        sgl,
+        builtins: StackGraph::new(),
+    };
+    let mut loader =
+        Loader::from_language_configurations(vec![lc], None).expect("Expected loader to succeed");
 
     let tsl = loader
         .load_tree_sitter_language_for_file(&PATH, None)
         .expect("Expected loading tree-sitter language to succeed");
     assert_eq!(tsl, Some(language));
 
-    let sgl = loader
+    let lc = loader
         .load_for_file(&PATH, None, &NoCancellation)
         .expect("Expected loading stack graph language to succeed");
-    assert_eq!(sgl.map(|sgl| sgl.language()), Some(language));
+    assert_eq!(lc.map(|lc| lc.language), Some(language));
 }


### PR DESCRIPTION
A `Loader` would return instances of `StackGraphLanguage`, given a language name or file name. This PR changes the loader to return `LanguageConfiguration` instances instead, which exposes more information about the language to the user, instead of hiding it.

- This makes it easier to check, after loading a language for a file, to check if another file belongs to the same language or not.
- This will make it easier (in a follow-on PR) to allow different stank graph construction methods for different files.
- This allows us to remove the builtins `StackGraph` instance from a `StackGraphLanguage`. This was a code smell, since the SGL and the builtins are independent, and used in different steps in the processing.

Previously, a `LanguageConfiguration` would hold the _sources_ of TSG and builtins. This has been changed to a TSG `File` instance, and a `StackGraph` instance for the builtins. This makes the configuration independent of how these are constructed, and means it is usable right away, without a user having to go through a parsing/construction step first. (As a consequence, the parsing/construction has moved to the `crate::language_configuration()` function.).

I have considered simplifying the loaders, by keeping only the one that takes `LanguageConfiguration`s and replacing the path-based loader by a function to generate those configurations for the discovered paths. However, with `LanguageConfiguration` now having TSG and stack graph instances, it would mean all discovered TSG files would be parsed, even if (often) only one is used. So I have kept both loaders, and made sure the path based loader is lazy with respect to TSG parsing and builtins stack graph construction.

## PR stack

- https://github.com/github/stack-graphs/pull/153
- ➡️ https://github.com/github/stack-graphs/pull/154
- https://github.com/github/stack-graphs/pull/155
- https://github.com/github/stack-graphs/pull/156