### PR TITLE
Add file analyzers

### DIFF
--- a/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
@@ -5,8 +5,12 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+use tree_sitter_stack_graphs::loader::FileAnalyzers;
 use tree_sitter_stack_graphs::loader::LanguageConfiguration;
 use tree_sitter_stack_graphs::CancellationFlag;
+use tsconfig::TsConfigAnalyzer;
+
+pub mod tsconfig;
 
 /// The stack graphs tsg source for this language
 const STACK_GRAPHS_TSG_SOURCE: &str = include_str!("../src/stack-graphs.tsg");
@@ -25,6 +29,7 @@ pub fn language_configuration(cancellation_flag: &dyn CancellationFlag) -> Langu
         STACK_GRAPHS_TSG_SOURCE,
         Some(STACK_GRAPHS_BUILTINS_SOURCE),
         Some(STACK_GRAPHS_BUILTINS_CONFIG),
+        FileAnalyzers::new().add("tsconfig.json".to_string(), TsConfigAnalyzer {}),
         cancellation_flag,
     )
     .unwrap()

--- a/languages/tree-sitter-stack-graphs-typescript/rust/tsconfig.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/tsconfig.rs
@@ -5,8 +5,21 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-use tree_sitter_stack_graphs::loader::FileAnalyzer;
+use stack_graphs::arena::Handle;
+use stack_graphs::graph::File;
+use stack_graphs::graph::StackGraph;
+use tree_sitter_stack_graphs::FileAnalyzer;
 
 pub struct TsConfigAnalyzer {}
 
-impl FileAnalyzer for TsConfigAnalyzer {}
+impl FileAnalyzer for TsConfigAnalyzer {
+    fn build_stack_graph_into<'a>(
+        &'a self,
+        _stack_graph: &'a mut StackGraph,
+        _file: Handle<File>,
+        _source: &'a str,
+        _cancellation_flag: &'a dyn tree_sitter_stack_graphs::CancellationFlag,
+    ) -> Result<(), tree_sitter_stack_graphs::LoadError> {
+        todo!()
+    }
+}

--- a/languages/tree-sitter-stack-graphs-typescript/rust/tsconfig.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/tsconfig.rs
@@ -21,6 +21,7 @@ impl FileAnalyzer for TsConfigAnalyzer {
         _file: Handle<File>,
         _path: &Path,
         _source: &'a str,
+        _paths: Vec<&Path>,
         _cancellation_flag: &'a dyn tree_sitter_stack_graphs::CancellationFlag,
     ) -> Result<(), tree_sitter_stack_graphs::LoadError> {
         todo!()

--- a/languages/tree-sitter-stack-graphs-typescript/rust/tsconfig.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/tsconfig.rs
@@ -1,0 +1,12 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2022, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use tree_sitter_stack_graphs::loader::FileAnalyzer;
+
+pub struct TsConfigAnalyzer {}
+
+impl FileAnalyzer for TsConfigAnalyzer {}

--- a/languages/tree-sitter-stack-graphs-typescript/rust/tsconfig.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/tsconfig.rs
@@ -5,6 +5,7 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+use std::collections::HashMap;
 use std::path::Path;
 
 use stack_graphs::arena::Handle;
@@ -16,13 +17,14 @@ pub struct TsConfigAnalyzer {}
 
 impl FileAnalyzer for TsConfigAnalyzer {
     fn build_stack_graph_into<'a>(
-        &'a self,
-        _stack_graph: &'a mut StackGraph,
+        &self,
+        _graph: &mut StackGraph,
         _file: Handle<File>,
         _path: &Path,
-        _source: &'a str,
-        _paths: Vec<&Path>,
-        _cancellation_flag: &'a dyn tree_sitter_stack_graphs::CancellationFlag,
+        _source: &str,
+        _all_paths: &mut dyn Iterator<Item = &'a Path>,
+        _globals: &HashMap<String, String>,
+        _cancellation_flag: &dyn tree_sitter_stack_graphs::CancellationFlag,
     ) -> Result<(), tree_sitter_stack_graphs::LoadError> {
         todo!()
     }

--- a/languages/tree-sitter-stack-graphs-typescript/rust/tsconfig.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/tsconfig.rs
@@ -5,6 +5,8 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+use std::path::Path;
+
 use stack_graphs::arena::Handle;
 use stack_graphs::graph::File;
 use stack_graphs::graph::StackGraph;
@@ -17,6 +19,7 @@ impl FileAnalyzer for TsConfigAnalyzer {
         &'a self,
         _stack_graph: &'a mut StackGraph,
         _file: Handle<File>,
+        _path: &Path,
         _source: &'a str,
         _cancellation_flag: &'a dyn tree_sitter_stack_graphs::CancellationFlag,
     ) -> Result<(), tree_sitter_stack_graphs::LoadError> {

--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -209,7 +209,7 @@ impl TestArgs {
             .with_context(|| format!("Loading builtins into {}", test_path.display()))?;
         let mut globals = Variables::new();
         for test_fragment in &test.fragments {
-            let all_paths = test.fragments.iter().map(|f| f.path.as_path()).collect();
+            let mut all_paths = test.fragments.iter().map(|f| f.path.as_path());
             if let Some(fa) = test_fragment
                 .path
                 .file_name()
@@ -220,7 +220,8 @@ impl TestArgs {
                     test_fragment.file,
                     &test_fragment.path,
                     &test_fragment.source,
-                    all_paths,
+                    &mut all_paths,
+                    &test_fragment.globals,
                     &NoCancellation,
                 )?;
             } else if lc.matches_file(&test_fragment.path, Some(&test_fragment.source)) {

--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -217,6 +217,7 @@ impl TestArgs {
                 fa.build_stack_graph_into(
                     &mut test.graph,
                     test_fragment.file,
+                    &fragment_path,
                     &test_fragment.source,
                     &NoCancellation,
                 )?;

--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -210,7 +210,17 @@ impl TestArgs {
         let mut globals = Variables::new();
         for test_fragment in &test.fragments {
             let fragment_path = Path::new(test.graph[test_fragment.file].name()).to_path_buf();
-            if lc.matches_file(&fragment_path, Some(&test_fragment.source)) {
+            if let Some(fa) = fragment_path
+                .file_name()
+                .and_then(|f| lc.special_files.get(&f.to_string_lossy()))
+            {
+                fa.build_stack_graph_into(
+                    &mut test.graph,
+                    test_fragment.file,
+                    &test_fragment.source,
+                    &NoCancellation,
+                )?;
+            } else if lc.matches_file(&fragment_path, Some(&test_fragment.source)) {
                 globals.clear();
                 test_fragment.add_globals_to(&mut globals);
                 self.build_fragment_stack_graph_into(

--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -209,12 +209,12 @@ impl TestArgs {
             .with_context(|| format!("Loading builtins into {}", test_path.display()))?;
         let mut globals = Variables::new();
         for test_fragment in &test.fragments {
-            let mut all_paths = test.fragments.iter().map(|f| f.path.as_path());
             if let Some(fa) = test_fragment
                 .path
                 .file_name()
                 .and_then(|f| lc.special_files.get(&f.to_string_lossy()))
             {
+                let mut all_paths = test.fragments.iter().map(|f| f.path.as_path());
                 fa.build_stack_graph_into(
                     &mut test.graph,
                     test_fragment.file,

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -940,12 +940,13 @@ impl<'a> Builder<'a> {
 
 pub trait FileAnalyzer {
     fn build_stack_graph_into<'a>(
-        &'a self,
-        stack_graph: &'a mut StackGraph,
+        &self,
+        stack_graph: &mut StackGraph,
         file: Handle<File>,
         path: &Path,
-        source: &'a str,
-        paths: Vec<&Path>,
-        cancellation_flag: &'a dyn CancellationFlag,
+        source: &str,
+        all_paths: &mut dyn Iterator<Item = &'a Path>,
+        globals: &HashMap<String, String>,
+        cancellation_flag: &dyn CancellationFlag,
     ) -> Result<(), LoadError>;
 }

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -945,6 +945,7 @@ pub trait FileAnalyzer {
         file: Handle<File>,
         path: &Path,
         source: &'a str,
+        paths: Vec<&Path>,
         cancellation_flag: &'a dyn CancellationFlag,
     ) -> Result<(), LoadError>;
 }

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -578,6 +578,7 @@ impl<'a> Builder<'a> {
 pub trait CancellationFlag {
     fn flag(&self) -> Option<&AtomicUsize>;
 }
+
 impl stack_graphs::CancellationFlag for &dyn CancellationFlag {
     fn check(&self, at: &'static str) -> Result<(), stack_graphs::CancellationError> {
         if self.flag().map_or(0, |f| f.load(Ordering::Relaxed)) != 0 {
@@ -586,6 +587,7 @@ impl stack_graphs::CancellationFlag for &dyn CancellationFlag {
         Ok(())
     }
 }
+
 impl tree_sitter_graph::CancellationFlag for &dyn CancellationFlag {
     fn check(&self, at: &'static str) -> Result<(), tree_sitter_graph::CancellationError> {
         if self.flag().map_or(0, |f| f.load(Ordering::Relaxed)) != 0 {
@@ -596,6 +598,7 @@ impl tree_sitter_graph::CancellationFlag for &dyn CancellationFlag {
 }
 
 pub struct NoCancellation;
+
 impl CancellationFlag for NoCancellation {
     fn flag(&self) -> Option<&AtomicUsize> {
         None
@@ -932,4 +935,14 @@ impl<'a> Builder<'a> {
             }
         }
     }
+}
+
+pub trait FileAnalyzer {
+    fn build_stack_graph_into<'a>(
+        &'a self,
+        stack_graph: &'a mut StackGraph,
+        file: Handle<File>,
+        source: &'a str,
+        cancellation_flag: &'a dyn CancellationFlag,
+    ) -> Result<(), LoadError>;
 }

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -319,6 +319,7 @@ use stack_graphs::graph::StackGraph;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::mem::transmute;
+use std::path::Path;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use thiserror::Error;
@@ -942,6 +943,7 @@ pub trait FileAnalyzer {
         &'a self,
         stack_graph: &'a mut StackGraph,
         file: Handle<File>,
+        path: &Path,
         source: &'a str,
         cancellation_flag: &'a dyn CancellationFlag,
     ) -> Result<(), LoadError>;

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -108,8 +108,8 @@ impl FileAnalyzers {
         self
     }
 
-    pub fn get(&self, file_name: &str) -> Option<Arc<dyn FileAnalyzer>> {
-        self.file_analyzers.get(file_name).cloned()
+    pub fn get(&self, file_name: &str) -> Option<&Arc<dyn FileAnalyzer>> {
+        self.file_analyzers.get(file_name)
     }
 }
 

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -91,7 +91,7 @@ impl LanguageConfiguration {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct FileAnalyzers {
     file_analyzers: HashMap<String, Arc<dyn FileAnalyzer>>,
 }

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::Arc;
 use thiserror::Error;
 use tree_sitter::Language;
 use tree_sitter_graph::ast::File as TsgFile;
@@ -42,6 +43,7 @@ pub struct LanguageConfiguration {
     pub file_types: Vec<String>,
     pub sgl: StackGraphLanguage,
     pub builtins: StackGraph,
+    pub special_files: FileAnalyzers,
 }
 
 impl LanguageConfiguration {
@@ -53,6 +55,7 @@ impl LanguageConfiguration {
         tsg_source: &str,
         builtins_source: Option<&str>,
         builtins_config: Option<&str>,
+        special_files: FileAnalyzers,
         cancellation_flag: &dyn CancellationFlag,
     ) -> Result<Self, LoadError> {
         let sgl = StackGraphLanguage::from_str(language, tsg_source)?;
@@ -78,11 +81,36 @@ impl LanguageConfiguration {
             file_types,
             sgl,
             builtins,
+            special_files,
         })
     }
 
     pub fn matches_file(&self, path: &Path, content: Option<&str>) -> bool {
         matches_file(&self.file_types, &self.content_regex, path, content).is_some()
+    }
+}
+
+pub trait FileAnalyzer {}
+
+#[derive(Clone)]
+pub struct FileAnalyzers {
+    file_analyzers: HashMap<String, Arc<dyn FileAnalyzer>>,
+}
+
+impl FileAnalyzers {
+    pub fn new() -> Self {
+        FileAnalyzers {
+            file_analyzers: HashMap::new(),
+        }
+    }
+
+    pub fn add(mut self, file_name: String, analyzer: impl FileAnalyzer + 'static) -> Self {
+        self.file_analyzers.insert(file_name, Arc::new(analyzer));
+        self
+    }
+
+    pub fn get(&self, file_name: &str) -> Option<Arc<dyn FileAnalyzer>> {
+        self.file_analyzers.get(file_name).cloned()
     }
 }
 
@@ -415,6 +443,7 @@ impl PathLoader {
                     file_types: language.file_types,
                     sgl,
                     builtins,
+                    special_files: FileAnalyzers::new(),
                 };
                 self.cache.push((language.language, lc));
 

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -26,6 +26,7 @@ use tree_sitter_loader::LanguageConfiguration as TSLanguageConfiguration;
 use tree_sitter_loader::Loader as TsLoader;
 
 use crate::CancellationFlag;
+use crate::FileAnalyzer;
 use crate::StackGraphLanguage;
 
 lazy_static! {
@@ -89,8 +90,6 @@ impl LanguageConfiguration {
         matches_file(&self.file_types, &self.content_regex, path, content).is_some()
     }
 }
-
-pub trait FileAnalyzer {}
 
 #[derive(Clone)]
 pub struct FileAnalyzers {

--- a/tree-sitter-stack-graphs/src/test.rs
+++ b/tree-sitter-stack-graphs/src/test.rs
@@ -126,6 +126,7 @@ pub struct Test {
 #[derive(Debug, Clone)]
 pub struct TestFragment {
     pub file: Handle<File>,
+    pub path: PathBuf,
     pub source: String,
     pub assertions: Vec<Assertion>,
     pub globals: HashMap<String, String>,
@@ -167,6 +168,7 @@ impl Test {
                         .for_each(|_| line_files.push(Some(file)));
                     fragments.push(TestFragment {
                         file,
+                        path: current_path,
                         source: current_source,
                         assertions: Vec::new(),
                         globals: current_globals,
@@ -206,6 +208,7 @@ impl Test {
             (line_files.len()..line_count).for_each(|_| line_files.push(Some(file)));
             fragments.push(TestFragment {
                 file,
+                path: current_path,
                 source: current_source,
                 assertions: Vec::new(),
                 globals: current_globals,

--- a/tree-sitter-stack-graphs/tests/it/loader.rs
+++ b/tree-sitter-stack-graphs/tests/it/loader.rs
@@ -9,6 +9,7 @@ use lazy_static::lazy_static;
 use pretty_assertions::assert_eq;
 use stack_graphs::graph::StackGraph;
 use std::path::PathBuf;
+use tree_sitter_stack_graphs::loader::FileAnalyzers;
 use tree_sitter_stack_graphs::loader::LanguageConfiguration;
 use tree_sitter_stack_graphs::loader::Loader;
 use tree_sitter_stack_graphs::NoCancellation;
@@ -33,6 +34,7 @@ fn can_load_from_provided_language_configuration() {
         file_types: vec!["py".into()],
         sgl,
         builtins: StackGraph::new(),
+        special_files: FileAnalyzers::new(),
     };
     let mut loader =
         Loader::from_language_configurations(vec![lc], None).expect("Expected loader to succeed");


### PR DESCRIPTION
This PR adds support for custom file analyzers for specific file names, for example a file analyzer that generates stack graph for `tsconfig.json`. The idea is that this mechanism will be used for project or package configuration files.

These configuration files require more context than regular source files. For example, `tsconfig` needs all source paths in a project to infer the project's root directory. At the moment, all project paths are provided as a parameter, but we may need more information in the future. I wonder if that set is finite, if it is small or large, and whether parameters are the right way to provide this info, or something more similar to the global variables passed to TSG (that is, more open, but less typed).

## PR stack

- https://github.com/github/stack-graphs/pull/153
- https://github.com/github/stack-graphs/pull/154
- ➡️ https://github.com/github/stack-graphs/pull/155
- https://github.com/github/stack-graphs/pull/156