### PR TITLE
Analyze package.json

### DIFF
--- a/languages/tree-sitter-stack-graphs-typescript/Cargo.toml
+++ b/languages/tree-sitter-stack-graphs-typescript/Cargo.toml
@@ -25,6 +25,8 @@ harness = false
 anyhow = "1.0"
 clap = "3"
 glob = "0.3"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 stack-graphs = { version = "~0.10", path = "../../stack-graphs" }
 tree-sitter-stack-graphs = { version = "~0.5", path = "../../tree-sitter-stack-graphs", features=["cli"] }
 tree-sitter-typescript = { git = "https://github.com/tree-sitter/tree-sitter-typescript", rev="082da44a5263599186dadafd2c974c19f3a73d28" }

--- a/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
@@ -11,6 +11,7 @@ use tree_sitter_stack_graphs::loader::LanguageConfiguration;
 use tree_sitter_stack_graphs::CancellationFlag;
 
 pub mod tsconfig;
+pub mod util;
 
 /// The stack graphs tsg source for this language
 pub const STACK_GRAPHS_TSG_SOURCE: &str = include_str!("../src/stack-graphs.tsg");

--- a/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
@@ -5,11 +5,14 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-use crate::tsconfig::TsConfigAnalyzer;
 use tree_sitter_stack_graphs::loader::FileAnalyzers;
 use tree_sitter_stack_graphs::loader::LanguageConfiguration;
 use tree_sitter_stack_graphs::CancellationFlag;
 
+use crate::npm_package::NpmPackageAnalyzer;
+use crate::tsconfig::TsConfigAnalyzer;
+
+pub mod npm_package;
 pub mod tsconfig;
 pub mod util;
 
@@ -35,7 +38,9 @@ pub fn language_configuration(cancellation_flag: &dyn CancellationFlag) -> Langu
         STACK_GRAPHS_TSG_SOURCE,
         Some(STACK_GRAPHS_BUILTINS_SOURCE),
         Some(STACK_GRAPHS_BUILTINS_CONFIG),
-        FileAnalyzers::new().add("tsconfig.json".to_string(), TsConfigAnalyzer {}),
+        FileAnalyzers::new()
+            .add("tsconfig.json".to_string(), TsConfigAnalyzer {})
+            .add("package.json".to_string(), NpmPackageAnalyzer {}),
         cancellation_flag,
     )
     .unwrap()

--- a/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
@@ -20,6 +20,11 @@ pub const STACK_GRAPHS_BUILTINS_CONFIG: &str = include_str!("../src/builtins.cfg
 /// The stack graphs builtins source for this language
 pub const STACK_GRAPHS_BUILTINS_SOURCE: &str = include_str!("../src/builtins.ts");
 
+/// The name of the file path global variable
+pub const FILE_PATH_VAR: &str = "FILE_PATH";
+/// The name of the project name global variable
+pub const PROJECT_NAME_VAR: &str = "PROJECT_NAME";
+
 pub fn language_configuration(cancellation_flag: &dyn CancellationFlag) -> LanguageConfiguration {
     LanguageConfiguration::from_tsg_str(
         tree_sitter_typescript::language_typescript(),

--- a/languages/tree-sitter-stack-graphs-typescript/rust/npm_package.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/npm_package.rs
@@ -6,7 +6,6 @@
 // ------------------------------------------------------------------------------------------------
 
 use serde::Deserialize;
-use stack_graphs::graph::NodeID;
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -42,7 +41,7 @@ impl FileAnalyzer for NpmPackageAnalyzer {
             serde_json::from_str(source).map_err(|_| LoadError::ParseError)?;
 
         // root node
-        let root = graph.node_for_id(NodeID::root()).unwrap();
+        let root = StackGraph::root_node();
 
         // project scope
         let proj_scope_id = graph.new_node_id(file);

--- a/languages/tree-sitter-stack-graphs-typescript/rust/npm_package.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/npm_package.rs
@@ -1,0 +1,77 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2022, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use serde::Deserialize;
+use stack_graphs::graph::NodeID;
+use std::collections::HashMap;
+use std::path::Path;
+
+use stack_graphs::arena::Handle;
+use stack_graphs::graph::File;
+use stack_graphs::graph::StackGraph;
+use tree_sitter_stack_graphs::FileAnalyzer;
+use tree_sitter_stack_graphs::LoadError;
+
+use crate::util::*;
+
+pub struct NpmPackageAnalyzer {}
+
+impl FileAnalyzer for NpmPackageAnalyzer {
+    fn build_stack_graph_into<'a>(
+        &self,
+        graph: &mut StackGraph,
+        file: Handle<File>,
+        _path: &Path,
+        source: &str,
+        _all_paths: &mut dyn Iterator<Item = &'a Path>,
+        globals: &HashMap<String, String>,
+        _cancellation_flag: &dyn tree_sitter_stack_graphs::CancellationFlag,
+    ) -> Result<(), tree_sitter_stack_graphs::LoadError> {
+        // read globals
+        let proj_name = globals
+            .get(crate::PROJECT_NAME_VAR)
+            .map(String::as_str)
+            .unwrap_or("");
+
+        // parse source
+        let npm_pkg: NpmPackage =
+            serde_json::from_str(source).map_err(|_| LoadError::ParseError)?;
+
+        // root node
+        let root = graph.node_for_id(NodeID::root()).unwrap();
+
+        // project scope
+        let proj_scope_id = graph.new_node_id(file);
+        let proj_scope = graph.add_scope_node(proj_scope_id, false).unwrap();
+        add_debug_name(graph, proj_scope, "npm_package.proj_scope");
+
+        // project definition
+        let proj_def = add_ns_pop(graph, file, root, PROJ_NS, proj_name);
+        add_debug_name(graph, proj_def, "npm_package.proj_def");
+        add_edge(graph, proj_def, proj_scope, 0);
+
+        // project reference
+        let proj_ref = add_ns_push(graph, file, root, PROJ_NS, proj_name);
+        add_debug_name(graph, proj_ref, "npm_package.proj_ref");
+        add_edge(graph, proj_scope, proj_ref, 0);
+
+        // package definition
+        let pkg_def = add_module_pops(graph, file, NON_REL_M_NS, Path::new(&npm_pkg.name), root);
+        add_debug_name(graph, pkg_def, "npm_package.pkg_def");
+        let pkg_ref = add_push(graph, file, proj_scope, PKG_M_NS);
+        add_debug_name(graph, pkg_ref, "npm_package.pkg_ref");
+        add_edge(graph, pkg_def, pkg_ref, 0);
+
+        Ok(())
+    }
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NpmPackage {
+    pub name: String,
+}

--- a/languages/tree-sitter-stack-graphs-typescript/rust/tsconfig.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/tsconfig.rs
@@ -6,7 +6,6 @@
 // ------------------------------------------------------------------------------------------------
 
 use glob::Pattern;
-use stack_graphs::graph::NodeID;
 use std::collections::HashMap;
 use std::path::Component;
 use std::path::Path;
@@ -43,7 +42,7 @@ impl FileAnalyzer for TsConfigAnalyzer {
         let tsc = TsConfig::parse_str(path, source).map_err(|_| LoadError::ParseError)?;
 
         // root node
-        let root = graph.node_for_id(NodeID::root()).unwrap();
+        let root = StackGraph::root_node();
 
         // project scope
         let proj_scope_id = graph.new_node_id(file);

--- a/languages/tree-sitter-stack-graphs-typescript/rust/tsconfig.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/tsconfig.rs
@@ -389,7 +389,7 @@ impl TsConfig {
             }
 
             // reject files not in the include patterns
-            if include.iter().any(|i| i.matches_path(p)) {
+            if !include.iter().any(|i| i.matches_path(p)) {
                 return None;
             }
 

--- a/languages/tree-sitter-stack-graphs-typescript/rust/tsconfig.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/tsconfig.rs
@@ -38,10 +38,6 @@ impl FileAnalyzer for TsConfigAnalyzer {
         _cancellation_flag: &dyn tree_sitter_stack_graphs::CancellationFlag,
     ) -> Result<(), tree_sitter_stack_graphs::LoadError> {
         // read globals
-        let pkg_name = globals
-            .get("PACKAGE_NAME")
-            .map(String::as_str)
-            .unwrap_or("");
         let proj_name = globals
             .get("PROJECT_NAME")
             .map(String::as_str)
@@ -72,11 +68,7 @@ impl FileAnalyzer for TsConfigAnalyzer {
         let root_dir_ref =
             self.add_module_pushes(graph, file, M_NS, &tsc.root_dir(all_paths), proj_scope);
         self.add_debug_name(graph, root_dir_ref, "root_dir.ref");
-
-        // package definition
-        let pkg_def = self.add_module_pops(graph, file, NON_REL_M_NS, Path::new(pkg_name), root);
-        self.add_debug_name(graph, pkg_def, "pkg_def");
-        self.add_edge(graph, pkg_def, root_dir_ref, 0);
+        // TODO: Edge ??? -> root_dir_ref
 
         // auxiliary root directories, map relative imports to module paths
         for (idx, root_dir) in tsc.root_dirs().iter().enumerate() {

--- a/languages/tree-sitter-stack-graphs-typescript/rust/tsconfig.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/tsconfig.rs
@@ -61,9 +61,12 @@ impl FileAnalyzer for TsConfigAnalyzer {
         add_edge(graph, proj_scope, proj_ref, 0);
 
         // root directory
+        let pkg_def = add_pop(graph, file, proj_scope, PKG_M_NS);
+        add_debug_name(graph, pkg_def, "pkg_def");
         let root_dir_ref =
             add_module_pushes(graph, file, M_NS, &tsc.root_dir(all_paths), proj_scope);
         add_debug_name(graph, root_dir_ref, "root_dir.ref");
+        add_edge(graph, pkg_def, root_dir_ref, 0);
 
         // auxiliary root directories, map relative imports to module paths
         for (idx, root_dir) in tsc.root_dirs().iter().enumerate() {

--- a/languages/tree-sitter-stack-graphs-typescript/rust/util.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/util.rs
@@ -21,7 +21,7 @@ pub const PKG_M_NS: &str = "%PkgM";
 
 pub fn add_debug_name(graph: &mut StackGraph, node: Handle<Node>, name: &str) {
     let key = graph.add_string("name");
-    let value = graph.add_string(&["tsconfig", name].join("."));
+    let value = graph.add_string(name);
     graph.debug_info_mut(node).add(key, value);
 }
 

--- a/languages/tree-sitter-stack-graphs-typescript/rust/util.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/util.rs
@@ -1,0 +1,133 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2022, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use stack_graphs::graph::Node;
+use std::path::Component;
+use std::path::Path;
+
+use stack_graphs::arena::Handle;
+use stack_graphs::graph::File;
+use stack_graphs::graph::StackGraph;
+
+pub const M_NS: &str = "%M";
+pub const NON_REL_M_NS: &str = "%NonRelM";
+pub const PROJ_NS: &str = "%Proj";
+pub const REL_M_NS: &str = "%RelM";
+pub const PKG_M_NS: &str = "%PkgM";
+
+pub fn add_debug_name(graph: &mut StackGraph, node: Handle<Node>, name: &str) {
+    let key = graph.add_string("name");
+    let value = graph.add_string(&["tsconfig", name].join("."));
+    graph.debug_info_mut(node).add(key, value);
+}
+
+pub fn add_pop(
+    graph: &mut StackGraph,
+    file: Handle<File>,
+    from: Handle<Node>,
+    name: &str,
+) -> Handle<Node> {
+    let id = graph.new_node_id(file);
+    let sym = graph.add_symbol(name);
+    let node = graph.add_pop_symbol_node(id, sym, false).unwrap();
+    graph.add_edge(from, node, 0);
+    node
+}
+
+pub fn add_push(
+    graph: &mut StackGraph,
+    file: Handle<File>,
+    to: Handle<Node>,
+    name: &str,
+) -> Handle<Node> {
+    let id = graph.new_node_id(file);
+    let sym = graph.add_symbol(name);
+    let node = graph.add_push_symbol_node(id, sym, false).unwrap();
+    graph.add_edge(node, to, 0);
+    node
+}
+
+pub fn add_ns_pop(
+    graph: &mut StackGraph,
+    file: Handle<File>,
+    from: Handle<Node>,
+    ns: &str,
+    name: &str,
+) -> Handle<Node> {
+    let ns_node = add_pop(graph, file, from, ns);
+    let pop_node = add_pop(graph, file, ns_node, name);
+    pop_node
+}
+
+pub fn add_ns_push(
+    graph: &mut StackGraph,
+    file: Handle<File>,
+    to: Handle<Node>,
+    ns: &str,
+    name: &str,
+) -> Handle<Node> {
+    let ns_node = add_push(graph, file, to, ns);
+    let push_node = add_push(graph, file, ns_node, name);
+    push_node
+}
+
+pub fn add_edge(graph: &mut StackGraph, from: Handle<Node>, to: Handle<Node>, precedence: i32) {
+    if from == to {
+        return;
+    }
+    graph.add_edge(from, to, precedence);
+}
+
+pub fn add_module_pops(
+    graph: &mut StackGraph,
+    file: Handle<File>,
+    ns: &str,
+    path: &Path,
+    from: Handle<Node>,
+) -> Handle<Node> {
+    let ns_node = add_pop(graph, file, from, ns);
+    let mut node = ns_node;
+    for c in path.components() {
+        match c {
+            Component::Normal(name) => {
+                node = add_pop(graph, file, node, &name.to_string_lossy());
+            }
+            _ => {
+                eprintln!(
+                    "add_module_pops: expecting normalized, non-escaping, relative paths, got {}",
+                    path.display()
+                )
+            }
+        }
+    }
+    node
+}
+
+pub fn add_module_pushes(
+    graph: &mut StackGraph,
+    file: Handle<File>,
+    ns: &str,
+    path: &Path,
+    to: Handle<Node>,
+) -> Handle<Node> {
+    let ns_node = add_push(graph, file, to, ns);
+    let mut node = ns_node;
+    for c in path.components() {
+        match c {
+            Component::Normal(name) => {
+                node = add_push(graph, file, node, &name.to_string_lossy());
+            }
+            _ => {
+                eprintln!(
+                    "add_module_pushes: expecting normalized, non-escaping, relative paths, got {}",
+                    path.display()
+                )
+            }
+        }
+    }
+    node
+}

--- a/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
@@ -172,18 +172,22 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
 ;
 ;     proj_scope -> ↑"%RelM" -> ↓"util" -> ↓"src" -> ↓"%M" -> proj_scope
 ;
-; Non-relative imports appear as "%NonRelM" NAME* definitions in either a project scope, or the global scope. The global
-; definition rewrites the package name to a projects root dir.
-;
-; For example, a package `@my/pkg` with source directory `src` would appear as:
-;
-;     ROOT_NODE -> ↑"%NonRelM" -> ↑"@my" -> ↑"pkg" -> ↓"src" -> ↓"%M"
+; Non-relative imports appear as "%NonRelM" NAME* definitions in either a project scope, or the global scope.
 ;
 ; Non-relative definitions in a project scope are the result of path mappings in `tsconfig.json`.
 ;
 ; For example, given `paths: { "util": ["./my_util"] }` with base URL `./src`, we get:
 ;
 ;     proj_scope -> ↑"%NonRelM" -> ↑"%util" -> ↓"my_util" -> ↓"src" -> ↓"%M"
+;
+; The global definition rewrites the package name to a projects root dir, via a "%PkgM" node.
+; The "%PkgM" node maps to source files in the root directory. A "%NonRelM" NAME* definition in
+; the global scope maps non-relative module paths starting with the package name to the "%PkgM" node.
+;
+; For example, a package `@my/pkg` defined in project `MyProject` with source directory `src` would appear as:
+;
+;     ROOT_NODE -> ↑"%NonRelM" -> ↑"@my" -> ↑"pkg" -> ↓"%PkgM" -> proj_scope
+;     proj_scope -> ↑"%PkgM" -> ↓"src" -> ↓"%M"
 ;
 ; The various references and definitions for `tsconfig.json` are not created by this TSG file, but
 ; by the `TsConfigAnalyzer` defined in `rust/tsconfig.rs`.

--- a/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
@@ -190,7 +190,8 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
 ;     proj_scope -> ↑"%PkgM" -> ↓"src" -> ↓"%M"
 ;
 ; The various references and definitions for `tsconfig.json` are not created by this TSG file, but
-; by the `TsConfigAnalyzer` defined in `rust/tsconfig.rs`.
+; by the `TsConfigAnalyzer` defined in `rust/tsconfig.rs`. The global package definition is created
+; by the `NpmPackageAnalyzer` in `rust/npm_package.rs`.
 
 
 

--- a/languages/tree-sitter-stack-graphs-typescript/test/projects/package-with-baseurl.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/projects/package-with-baseurl.ts
@@ -1,0 +1,15 @@
+/* --- path: ./package.json --- */
+{
+    "name": "@my/pkg"
+}
+
+/* --- path: ./tsconfig.json --- */
+{
+}
+
+/* --- path: ./src/foo.ts --- */
+export const bar = 42;
+
+/* --- path: ./src/index.ts --- */
+import { bar } from "@my/pkg/foo";
+//       ^ defined: 11

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -524,18 +524,22 @@ impl<'a> Builder<'a> {
         let tree = parse_errors.into_tree();
 
         let mut globals = Variables::nested(globals);
-        let root_node = self.inject_node(NodeID::root());
-        globals
-            .add(ROOT_NODE_VAR.into(), root_node.into())
-            .expect("Failed to set ROOT_NODE");
+        if globals.get(&ROOT_NODE_VAR.into()).is_none() {
+            let root_node = self.inject_node(NodeID::root());
+            globals
+                .add(ROOT_NODE_VAR.into(), root_node.into())
+                .expect("Failed to set ROOT_NODE");
+        }
         let jump_to_scope_node = self.inject_node(NodeID::jump_to());
         globals
             .add(JUMP_TO_SCOPE_NODE_VAR.into(), jump_to_scope_node.into())
             .expect("Failed to set JUMP_TO_SCOPE_NODE");
-        let file_name = self.stack_graph[self.file].to_string();
-        globals
-            .add(FILE_PATH_VAR.into(), file_name.into())
-            .expect("Failed to set FILE_PATH");
+        if globals.get(&FILE_PATH_VAR.into()).is_none() {
+            let file_name = self.stack_graph[self.file].to_string();
+            globals
+                .add(FILE_PATH_VAR.into(), file_name.into())
+                .expect("Failed to set FILE_PATH");
+        }
 
         let mut config = ExecutionConfig::new(&self.sgl.functions, &globals)
             .lazy(true)

--- a/tree-sitter-stack-graphs/src/test.rs
+++ b/tree-sitter-stack-graphs/src/test.rs
@@ -183,6 +183,8 @@ impl Test {
                 current_path = m.get(1).unwrap().as_str().into();
                 current_source = prev_source.clone();
                 current_globals = HashMap::new();
+
+                Self::push_whitespace_for(&current_line, &mut current_source);
             } else if let Some(m) = GLOBAL_REGEX.captures_iter(current_line.content).next() {
                 have_globals = true;
                 let global_name = m.get(1).unwrap().as_str();
@@ -193,9 +195,11 @@ impl Test {
                 {
                     return Err(TestError::DuplicateGlobalVariable(global_name.to_string()));
                 }
-            }
 
-            current_source.push_str(current_line.content);
+                Self::push_whitespace_for(&current_line, &mut current_source);
+            } else {
+                current_source.push_str(current_line.content);
+            }
             current_source.push_str("\n");
 
             Self::push_whitespace_for(&current_line, &mut prev_source);


### PR DESCRIPTION
This adds a simple `package.json` analyzer that exposes the package in the global scope, and resolves imports into the package to the correct modules in the inferred root directory.

This is a very simple approach, but it shows that the encoding for modules and packages is refined enough to deal with package definitions based on `package.json`.

It is limited, because package visibility cannot be controlled. In particular, if the stack graphs of multiple repositories are combined, and packages with the same name are defined multiple times, this approach cannot ensure one particular one is used. Other approaches are possible, for example, keeping the package definitions local to a project, and resolving them in specific other projects. (Assuming project names are globally unique.) The good news is, that this is compatible with the encoding of `tsconfig.json`. It would mean swapping out the `NpmPackageAnalyzer` for a different method that can generate the correct mappings, but we wouldn't need to change `TsConfigAnalyzer`.