### PR TITLE
Release stack-graphs v0.10.2 and tree-sitter-stack-graphs v0.5.0

### DIFF
--- a/languages/tree-sitter-stack-graphs-typescript/Cargo.toml
+++ b/languages/tree-sitter-stack-graphs-typescript/Cargo.toml
@@ -25,7 +25,7 @@ harness = false
 anyhow = "1.0"
 clap = "3"
 glob = "0.3"
-stack-graphs = { version = "~0.10.1", path = "../../stack-graphs" }
-tree-sitter-stack-graphs = { version = "~0.4.0", path = "../../tree-sitter-stack-graphs", features=["cli"] }
+stack-graphs = { version = "~0.10", path = "../../stack-graphs" }
+tree-sitter-stack-graphs = { version = "~0.5", path = "../../tree-sitter-stack-graphs", features=["cli"] }
 tree-sitter-typescript = { git = "https://github.com/tree-sitter/tree-sitter-typescript", rev="082da44a5263599186dadafd2c974c19f3a73d28" }
 tsconfig = "0.1.0"

--- a/stack-graphs/CHANGELOG.md
+++ b/stack-graphs/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.10.2 -- 2023-01-10
+
+### Changed
+
+- The up and down text arrows in the labels of push and pop nodes in the visualization have been replaced by bigger arrows that are part of the node shape. This makes it easier to quickly identify push and pop nodes in the graph.
+
+### Fixed
+
+- The `bitvec` dependency was updated to fix installation problems.
+
 ## 0.10.1 -- 2022-09-07
 
 ### Changed

--- a/stack-graphs/Cargo.toml
+++ b/stack-graphs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stack-graphs"
-version = "0.10.1"
+version = "0.10.2"
 description = "Name binding for arbitrary programming languages"
 homepage = "https://github.com/github/stack-graphs/tree/main/stack-graphs"
 repository = "https://github.com/github/stack-graphs/"

--- a/tree-sitter-stack-graphs/CHANGELOG.md
+++ b/tree-sitter-stack-graphs/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.5.0 -- 2023-01-10
+
+### Library
+
+#### Added
+
+- A new `cli` module contains the CLI implementation. It can be reused to create language-specific CLIs that do not rely on loading from the file system.
+- An `empty_source_span` attribute can be used in TSG rules to collapse the source span to its start, instead of covering the whole source node.
+- A new `FileAnalyzer` trait can be implemented to implement custom analysis of special project files such as package manifests or project configurations.
+
+#### Changed
+
+- Language loading has been redesigned to have clearer responsiilities for the various types involved. Loaders now return instances of `LanguageConfiguration`, which holds not just the `StackGraphLanguage` necessary to execute the TSG, but also other data about the language, such as file types, special file analyzers, and the builtins stack graph. The `StackGraphLanguage` is now only responsible for executing TSGs, and does not contain the language's `builtins` anymore.
+
+#### Fixed
+
+- A bug in path normalization that would lose `..` prefixes for paths whose normal form starts with `..` components.
+
+### CLI
+
 ## 0.4.1 -- 2022-10-19
 
 ### CLI

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-stack-graphs"
-version = "0.4.1"
+version = "0.5.0"
 description = "Create stack graphs using tree-sitter parsers"
 homepage = "https://github.com/github/stack-graphs/tree/main/tree-sitter-stack-graphs"
 repository = "https://github.com/github/stack-graphs/"


### PR DESCRIPTION
This bumps versions to enable a new release of tree-sitter-stack-graphs. The latest v0.4.1 release broke when the `bitvec` dependency yanked some versions from crates.io. This release should ensure installing via `cargo install` works again.

Addresses #159.