### PR TITLE
Release tree-sitter-stack-graphs v0.6.0

### DIFF
--- a/languages/tree-sitter-stack-graphs-typescript/Cargo.toml
+++ b/languages/tree-sitter-stack-graphs-typescript/Cargo.toml
@@ -27,7 +27,7 @@ clap = "3"
 glob = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-stack-graphs = { version = "~0.10", path = "../../stack-graphs" }
-tree-sitter-stack-graphs = { version = "~0.5", path = "../../tree-sitter-stack-graphs", features=["cli"] }
+stack-graphs = { version = "0.10", path = "../../stack-graphs" }
+tree-sitter-stack-graphs = { version = "0.6", path = "../../tree-sitter-stack-graphs", features=["cli"] }
 tree-sitter-typescript = { git = "https://github.com/tree-sitter/tree-sitter-typescript", rev="082da44a5263599186dadafd2c974c19f3a73d28" }
 tsconfig = "0.1.0"

--- a/tree-sitter-stack-graphs/CHANGELOG.md
+++ b/tree-sitter-stack-graphs/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## v0.6.0 -- 2023-01-13
 
 ### Library
 
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `cli` module has been reorganized. Instead of providing a fully derived CLI type, the subcommands are now exposed, while deriving the CLI type is left to the user. This makes sure that the name and version reported by the version command are ones from the user crate, and not from this crate. Instead of using `cli::LanguageConfigurationsCli` and `cli::PathLoadingCli`, users should using from `cli::provided_languages::Subcommands` and `cli::path_loading::Subcommands` repsectively. The `cli` module documentation shows complete examples of how to do this.
 - The `cli::CiTester` type has been moved to `ci::Tester`. Because it uses `cli` code internally, it is still hidden behind the `cli` feature flag.
+
+#### Fixed
+
+- Fix issue with test directives in languages that do not support comments.
 
 ## v0.5.1 -- 2023-01-10
 

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-stack-graphs"
-version = "0.5.1"
+version = "0.6.0"
 description = "Create stack graphs using tree-sitter parsers"
 homepage = "https://github.com/github/stack-graphs/tree/main/tree-sitter-stack-graphs"
 repository = "https://github.com/github/stack-graphs/"

--- a/tree-sitter-stack-graphs/README.md
+++ b/tree-sitter-stack-graphs/README.md
@@ -15,7 +15,7 @@ To use this library, add the following to your `Cargo.toml`:
 
 ``` toml
 [dependencies]
-tree-sitter-stack-graphs = "0.5"
+tree-sitter-stack-graphs = "0.6"
 ```
 
 Check out our [documentation](https://docs.rs/tree-sitter-stack-graphs/*/) for

--- a/tree-sitter-stack-graphs/npm/package.json
+++ b/tree-sitter-stack-graphs/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-stack-graphs",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Create stack graphs using tree-sitter parsers",
   "homepage": "https://github.com/github/stack-graphs/tree/main/tree-sitter-stack-graphs",
   "repository": {


### PR DESCRIPTION
Release tree-sitter-stack-graphs v0.6.0. This fixes a small issue which is a blocker for releasing `tree-sitter-stack-graphs-typescript`.

## PR stack

- [ ] #162
- [ ] #165