### PR TITLE
Reorganize CLI code

### DIFF
--- a/languages/tree-sitter-stack-graphs-typescript/rust/bin.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/bin.rs
@@ -5,11 +5,20 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-use tree_sitter_stack_graphs::cli::LanguageConfigurationsCli as Cli;
+use clap::Parser;
+use tree_sitter_stack_graphs::cli::provided_languages::Subcommands;
 use tree_sitter_stack_graphs::NoCancellation;
 
 fn main() -> anyhow::Result<()> {
-    Cli::main(vec![
+    let cli = Cli::parse();
+    cli.subcommand.run(vec![
         tree_sitter_stack_graphs_typescript::language_configuration(&NoCancellation),
     ])
+}
+
+#[derive(Parser)]
+#[clap(about, version)]
+pub struct Cli {
+    #[clap(subcommand)]
+    subcommand: Subcommands,
 }

--- a/languages/tree-sitter-stack-graphs-typescript/rust/test.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/test.rs
@@ -6,12 +6,12 @@
 // ------------------------------------------------------------------------------------------------
 
 use std::path::PathBuf;
-use tree_sitter_stack_graphs::cli::CiTester;
+use tree_sitter_stack_graphs::ci::Tester;
 use tree_sitter_stack_graphs::NoCancellation;
 
 fn main() -> anyhow::Result<()> {
     let test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test");
-    CiTester::new(
+    Tester::new(
         vec![tree_sitter_stack_graphs_typescript::language_configuration(
             &NoCancellation,
         )],

--- a/tree-sitter-stack-graphs/CHANGELOG.md
+++ b/tree-sitter-stack-graphs/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Changed
 
-- The `cli` module has been reorganized. Instead of providing a fully derived CLI type, the subcommands are now exposed, while deriving the CLI type is left to the user. This makes sure that the name and version reported by the version command are ones from the user crate, and not from this crate. Instead of using `cli::LanguageConfigurationsCli` and `cli::PathLoadingCli`, users should using from `cli::provided_languages::Subcommands` and `cli::path_loading::Subcommands` repsectively. The `cli` module documentation shows complete examples of how to do this.
+- The `cli` module has been reorganized. Instead of providing a fully derived CLI type, the subcommands are now exposed, while deriving the CLI type is left to the user. This makes sure that the name and version reported by the version command are ones from the user crate, and not from this crate. Instead of using `cli::LanguageConfigurationsCli` and `cli::PathLoadingCli`, users should using from `cli::provided_languages::Subcommands` and `cli::path_loading::Subcommands` respectively. The `cli` module documentation shows complete examples of how to do this.
 - The `cli::CiTester` type has been moved to `ci::Tester`. Because it uses `cli` code internally, it is still hidden behind the `cli` feature flag.
 
 ## v0.5.1 -- 2023-01-10

--- a/tree-sitter-stack-graphs/CHANGELOG.md
+++ b/tree-sitter-stack-graphs/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Library
+
+#### Changed
+
+- The `cli` module has been reorganized. Instead of providing a fully derived CLI type, the subcommands are now exposed, while deriving the CLI type is left to the user. This makes sure that the name and version reported by the version command are ones from the user crate, and not from this crate. Instead of using `cli::LanguageConfigurationsCli` and `cli::PathLoadingCli`, users should using from `cli::provided_languages::Subcommands` and `cli::path_loading::Subcommands` repsectively. The `cli` module documentation shows complete examples of how to do this.
+- The `cli::CiTester` type has been moved to `ci::Tester`. Because it uses `cli` code internally, it is still hidden behind the `cli` feature flag.
+
 ## v0.5.1 -- 2023-01-10
 
 Patch release to update *all* version numbers.

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/main.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/main.rs
@@ -5,9 +5,17 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-use anyhow::Result;
-use tree_sitter_stack_graphs::cli::PathLoadingCli;
+use clap::Parser;
+use tree_sitter_stack_graphs::cli::path_loading::Subcommands;
 
-fn main() -> Result<()> {
-    PathLoadingCli::main()
+#[derive(Parser)]
+#[clap(about, version)]
+pub struct Cli {
+    #[clap(subcommand)]
+    subcommand: Subcommands,
+}
+
+fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    cli.subcommand.run()
 }

--- a/tree-sitter-stack-graphs/src/ci.rs
+++ b/tree-sitter-stack-graphs/src/ci.rs
@@ -1,0 +1,68 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2022, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! This crate defines a reusable CI test runner.
+//!
+//! Use the test runner as follows:
+//!
+//! ``` no_run
+//! use std::path::PathBuf;
+//! use tree_sitter_stack_graphs::ci::Tester;
+//! use tree_sitter_stack_graphs::NoCancellation;
+//!
+//! fn main() -> anyhow::Result<()> {
+//!     let language_configurations = vec![/* add your language configurations here */];
+//!     let test_paths = vec![PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test")];
+//!     Tester::new(
+//!         language_configurations,
+//!         test_paths,
+//!     )
+//!     .run()
+//! }
+//! ```
+
+use std::path::PathBuf;
+
+use crate::cli::test::TestArgs;
+use crate::loader::{LanguageConfiguration, Loader};
+
+/// Run tests for the given languages. Test locations are reported relative to the current directory, which
+/// results in better readable output when build tools only provides absolute test paths.
+pub struct Tester {
+    configurations: Vec<LanguageConfiguration>,
+    test_paths: Vec<PathBuf>,
+}
+
+impl Tester {
+    pub fn new(configurations: Vec<LanguageConfiguration>, test_paths: Vec<PathBuf>) -> Self {
+        Self {
+            configurations,
+            test_paths,
+        }
+    }
+
+    pub fn run(self) -> anyhow::Result<()> {
+        let test_paths = self
+            .test_paths
+            .into_iter()
+            .map(|test_path| {
+                std::env::current_dir()
+                    .ok()
+                    .and_then(|cwd| pathdiff::diff_paths(&test_path, &cwd))
+                    .unwrap_or(test_path)
+            })
+            .collect::<Vec<_>>();
+        for test_path in &test_paths {
+            if !test_path.exists() {
+                panic!("Test path {} does not exist", test_path.display());
+            }
+        }
+        let mut loader = Loader::from_language_configurations(self.configurations, None)
+            .expect("Expected loader");
+        TestArgs::new(test_paths).run(&mut loader)
+    }
+}

--- a/tree-sitter-stack-graphs/src/cli.rs
+++ b/tree-sitter-stack-graphs/src/cli.rs
@@ -5,7 +5,53 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-//! Defines CLI
+//! This crate defines reusable subcommands for clap-based CLI implementations.
+//!
+//! ## Path loading CLIs
+//!
+//! Path loading CLIs load language configurations from the file system, based on
+//! tree-sitter configuration files and provided arguments. Derive a path loading
+//! CLI from as follows:
+//!
+//! ``` no_run
+//! use clap::Parser;
+//! use tree_sitter_stack_graphs::cli::path_loading::Subcommands;
+//!
+//! #[derive(Parser)]
+//! #[clap(about, version)]
+//! pub struct Cli {
+//!     #[clap(subcommand)]
+//!     subcommand: Subcommands,
+//! }
+//!
+//! fn main() -> anyhow::Result<()> {
+//!     let cli = Cli::parse();
+//!     cli.subcommand.run()
+//! }
+//! ```
+//!
+//! ## Provided langauges CLIs
+//!
+//! Provided languages CLIs use directly provided language configuration instances.
+//! Derive a language configuration CLI as follows:
+//!
+//! ``` no_run
+//! use clap::Parser;
+//! use tree_sitter_stack_graphs::cli::provided_languages::Subcommands;
+//!
+//! #[derive(Parser)]
+//! #[clap(about, version)]
+//! pub struct Cli {
+//!     #[clap(subcommand)]
+//!     subcommand: Subcommands,
+//! }
+//!
+//! fn main() -> anyhow::Result<()> {
+//!     let language_configurations = vec![/* add your language configurations here */];
+//!     let cli = Cli::parse();
+//!     cli.subcommand.run(language_configurations)
+//! }
+//! ```
 
 pub(self) const MAX_PARSE_ERRORS: usize = 5;
 
@@ -15,13 +61,7 @@ pub mod parse;
 pub mod test;
 mod util;
 
-pub use ci::Tester as CiTester;
-pub use path_loading::Cli as PathLoadingCli;
-pub use provided_languages::Cli as LanguageConfigurationsCli;
-
-mod path_loading {
-    use anyhow::Result;
-    use clap::Parser;
+pub mod path_loading {
     use clap::Subcommand;
 
     use crate::cli::init::InitArgs;
@@ -29,30 +69,21 @@ mod path_loading {
     use crate::cli::parse::ParseArgs;
     use crate::cli::test::TestArgs;
 
-    /// CLI implementation that loads grammars and stack graph definitions from paths.
-    #[derive(Parser)]
-    #[clap(about, version)]
-    pub struct Cli {
-        #[clap(subcommand)]
-        command: Commands,
-    }
-
-    impl Cli {
-        pub fn main() -> Result<()> {
-            let cli = Cli::parse();
-            match &cli.command {
-                Commands::Init(cmd) => cmd.run(),
-                Commands::Parse(cmd) => cmd.run(),
-                Commands::Test(cmd) => cmd.run(),
-            }
-        }
-    }
-
     #[derive(Subcommand)]
-    enum Commands {
+    pub enum Subcommands {
         Init(Init),
         Parse(Parse),
         Test(Test),
+    }
+
+    impl Subcommands {
+        pub fn run(&self) -> anyhow::Result<()> {
+            match self {
+                Self::Init(cmd) => cmd.run(),
+                Self::Parse(cmd) => cmd.run(),
+                Self::Test(cmd) => cmd.run(),
+            }
+        }
     }
 
     /// Init command
@@ -101,9 +132,7 @@ mod path_loading {
     }
 }
 
-mod provided_languages {
-    use anyhow::Result;
-    use clap::Parser;
+pub mod provided_languages {
     use clap::Subcommand;
 
     use crate::cli::parse::ParseArgs;
@@ -112,28 +141,19 @@ mod provided_languages {
 
     use super::load::LanguageConfigurationsLoaderArgs;
 
-    /// CLI implementation that loads from provided grammars and stack graph definitions.
-    #[derive(Parser)]
-    #[clap(about, version)]
-    pub struct Cli {
-        #[clap(subcommand)]
-        command: Commands,
-    }
-
-    impl Cli {
-        pub fn main(configurations: Vec<LanguageConfiguration>) -> Result<()> {
-            let cli = Cli::parse();
-            match &cli.command {
-                Commands::Parse(cmd) => cmd.run(configurations),
-                Commands::Test(cmd) => cmd.run(configurations),
-            }
-        }
-    }
-
     #[derive(Subcommand)]
-    enum Commands {
+    pub enum Subcommands {
         Parse(Parse),
         Test(Test),
+    }
+
+    impl Subcommands {
+        pub fn run(&self, configurations: Vec<LanguageConfiguration>) -> anyhow::Result<()> {
+            match self {
+                Self::Parse(cmd) => cmd.run(configurations),
+                Self::Test(cmd) => cmd.run(configurations),
+            }
+        }
     }
 
     /// Parse command
@@ -165,50 +185,6 @@ mod provided_languages {
         pub fn run(&self, configurations: Vec<LanguageConfiguration>) -> anyhow::Result<()> {
             let mut loader = self.load_args.get(configurations)?;
             self.test_args.run(&mut loader)
-        }
-    }
-}
-
-mod ci {
-    use std::path::PathBuf;
-
-    use crate::cli::test::TestArgs;
-    use crate::loader::{LanguageConfiguration, Loader};
-
-    /// Run tests for the given languages. Test locations are reported relative to the current directory, which
-    /// results in better readable output when build tools only provides absolute test paths.
-    pub struct Tester {
-        configurations: Vec<LanguageConfiguration>,
-        test_paths: Vec<PathBuf>,
-    }
-
-    impl Tester {
-        pub fn new(configurations: Vec<LanguageConfiguration>, test_paths: Vec<PathBuf>) -> Self {
-            Self {
-                configurations,
-                test_paths,
-            }
-        }
-
-        pub fn run(self) -> anyhow::Result<()> {
-            let test_paths = self
-                .test_paths
-                .into_iter()
-                .map(|test_path| {
-                    std::env::current_dir()
-                        .ok()
-                        .and_then(|cwd| pathdiff::diff_paths(&test_path, &cwd))
-                        .unwrap_or(test_path)
-                })
-                .collect::<Vec<_>>();
-            for test_path in &test_paths {
-                if !test_path.exists() {
-                    panic!("Test path {} does not exist", test_path.display());
-                }
-            }
-            let mut loader = Loader::from_language_configurations(self.configurations, None)
-                .expect("Expected loader");
-            TestArgs::new(test_paths).run(&mut loader)
         }
     }
 }

--- a/tree-sitter-stack-graphs/src/cli.rs
+++ b/tree-sitter-stack-graphs/src/cli.rs
@@ -30,7 +30,7 @@
 //! }
 //! ```
 //!
-//! ## Provided langauges CLIs
+//! ## Provided languages CLIs
 //!
 //! Provided languages CLIs use directly provided language configuration instances.
 //! Derive a language configuration CLI as follows:

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -334,6 +334,8 @@ use tree_sitter_graph::parse_error::TreeWithParseErrorVec;
 use tree_sitter_graph::ExecutionConfig;
 
 #[cfg(feature = "cli")]
+pub mod ci;
+#[cfg(feature = "cli")]
 pub mod cli;
 pub mod functions;
 pub mod loader;


### PR DESCRIPTION
Instead of providing a fully derived CLI type, the subcommands are now exposed, while deriving the CLI type is left to the user.
This makes sure that the name and version reported by the version command are ones from the user crate, and not from this crate.

The effect can be seen in the version output of `tree-sitter-stack-graphs-typescript`. Before:

```
$ cargo run -- --version
tree-sitter-stack-graphs 0.5.1
```

And after:

```
$ cargo run -- --version
tree-sitter-stack-graphs-typescript 0.1.0
```
