### PR TITLE
[TypeScript] Scope everything within projects

### DIFF
--- a/languages/tree-sitter-stack-graphs-typescript/rust/tsconfig.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/tsconfig.rs
@@ -33,10 +33,7 @@ impl FileAnalyzer for TsConfigAnalyzer {
         _cancellation_flag: &dyn tree_sitter_stack_graphs::CancellationFlag,
     ) -> Result<(), tree_sitter_stack_graphs::LoadError> {
         // read globals
-        let proj_name = globals
-            .get(crate::PROJECT_NAME_VAR)
-            .map(String::as_str)
-            .unwrap_or("");
+        let proj_name = globals.get(crate::PROJECT_NAME_VAR).map(String::as_str);
 
         // parse source
         let tsc = TsConfig::parse_str(path, source).map_err(|_| LoadError::ParseError)?;
@@ -45,17 +42,23 @@ impl FileAnalyzer for TsConfigAnalyzer {
         let root = StackGraph::root_node();
 
         // project scope
-        let proj_scope_id = graph.new_node_id(file);
-        let proj_scope = graph.add_scope_node(proj_scope_id, false).unwrap();
-        add_debug_name(graph, proj_scope, "tsconfig.proj_scope");
+        let proj_scope = if let Some(proj_name) = proj_name {
+            let proj_scope_id = graph.new_node_id(file);
+            let proj_scope = graph.add_scope_node(proj_scope_id, false).unwrap();
+            add_debug_name(graph, proj_scope, "tsconfig.proj_scope");
 
-        // project definition
-        let proj_def = add_ns_pop(graph, file, root, PROJ_NS, proj_name, "tsconfig.proj_def");
-        add_edge(graph, proj_def, proj_scope, 0);
+            // project definition
+            let proj_def = add_ns_pop(graph, file, root, PROJ_NS, proj_name, "tsconfig.proj_def");
+            add_edge(graph, proj_def, proj_scope, 0);
 
-        // project reference
-        let proj_ref = add_ns_push(graph, file, root, PROJ_NS, proj_name, "tsconfig.proj_ref");
-        add_edge(graph, proj_scope, proj_ref, 0);
+            // project reference
+            let proj_ref = add_ns_push(graph, file, root, PROJ_NS, proj_name, "tsconfig.proj_ref");
+            add_edge(graph, proj_scope, proj_ref, 0);
+
+            proj_scope
+        } else {
+            root
+        };
 
         // root directory
         let pkg_def = add_pop(graph, file, proj_scope, PKG_M_NS, "tsconfig.pkg_def");

--- a/languages/tree-sitter-stack-graphs-typescript/src/builtins.cfg
+++ b/languages/tree-sitter-stack-graphs-typescript/src/builtins.cfg
@@ -1,1 +1,2 @@
 [globals]
+PROJECT_NAME=<builtins>

--- a/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
@@ -236,14 +236,19 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
 
 ;; Project and module definitions
 (program)@prog {
-  ; project definition
-  node proj_def__ns
-  attr (proj_def__ns) pop_symbol = "%Proj"
-  edge ROOT_NODE -> proj_def__ns
-  ;
-  node proj_def
-  attr (proj_def) pop_symbol = PROJECT_NAME
-  edge proj_def__ns -> proj_def
+  var proj_scope = ROOT_NODE
+  if (not (eq PROJECT_NAME "")) {
+    ; project definition
+    node proj_def__ns
+    attr (proj_def__ns) pop_symbol = "%Proj"
+    edge proj_scope -> proj_def__ns
+    ;
+    node proj_def
+    attr (proj_def) pop_symbol = PROJECT_NAME
+    edge proj_def__ns -> proj_def
+    ;
+    set proj_scope = proj_def
+  }
 
   ; module definition
   let mod_name = (path-filestem FILE_PATH)
@@ -251,7 +256,7 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
   ;
   node mod_def__ns
   attr (mod_def__ns) pop_symbol = "%M"
-  edge proj_def -> mod_def__ns
+  edge proj_scope -> mod_def__ns
   ;
   var mod_scope = mod_def__ns
   scan mod_path {
@@ -274,22 +279,27 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
 
 ;; Project and module reference
 (program)@prog {
-  ; project reference
-  node proj_ref__ns
-  attr (proj_ref__ns) push_symbol = "%Proj"
-  edge proj_ref__ns -> ROOT_NODE
-  ;
-  node proj_ref
-  attr (proj_ref) push_symbol = PROJECT_NAME
-  edge proj_ref -> proj_ref__ns
-  ; compose all packages files by adding edge to the package reference
-  edge @prog.lexical_scope -> proj_ref
+  var proj_scope = ROOT_NODE
+  if (not (eq PROJECT_NAME "")) {
+    ; project reference
+    node proj_ref__ns
+    attr (proj_ref__ns) push_symbol = "%Proj"
+    edge proj_ref__ns -> proj_scope
+    ;
+    node proj_ref
+    attr (proj_ref) push_symbol = PROJECT_NAME
+    edge proj_ref -> proj_ref__ns
+    ;
+    set proj_scope = proj_ref
+    ; compose all project files by adding edge to the project reference
+    edge @prog.lexical_scope -> proj_scope
+  }
 
   ; module reference
   ;
   node mod_ref__ns
   attr (mod_ref__ns) push_symbol = "%M"
-  edge mod_ref__ns -> proj_ref
+  edge mod_ref__ns -> proj_scope
   ;
   let mod_dir = (path-normalize (path-dir FILE_PATH))
   var mod_scope = mod_ref__ns

--- a/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
@@ -227,15 +227,23 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
 }
 
 (program)@prog {
-  ; propagate lexical scope
-  edge @prog.lexical_scope -> ROOT_NODE
-
   ; expose definitions
   edge @prog.lexical_scope -> @prog.defs
+
+  ; import builtins
+  node builtins_ref__ns
+  attr (builtins_ref__ns) symbol_reference = "%Proj"
+  edge builtins_ref__ns -> ROOT_NODE
+  ;
+  node builtins_ref
+  attr (builtins_ref) symbol_reference = "<builtins>"
+  edge builtins_ref -> builtins_ref__ns
+  ;
+  edge @prog.lexical_scope -> builtins_ref
 }
 
 ;; Project and module definitions
-(program)@prog {
+(program [(import_statement) (export_statement)]* @imexs)@prog {
   var proj_scope = ROOT_NODE
   if (not (eq PROJECT_NAME "")) {
     ; project definition
@@ -250,35 +258,39 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
     set proj_scope = proj_def
   }
 
-  ; module definition
-  let mod_name = (path-filestem FILE_PATH)
-  let mod_path = (path-normalize (path-join (path-dir FILE_PATH) mod_name))
-  ;
-  node mod_def__ns
-  attr (mod_def__ns) pop_symbol = "%M"
-  edge proj_scope -> mod_def__ns
-  ;
-  var mod_scope = mod_def__ns
-  scan mod_path {
-    "index$" {
-      ; skip last component for index files
+  var mod_scope = proj_scope
+  if (not (is-empty @imexs)) {
+    ; module definition
+    let mod_name = (path-filestem FILE_PATH)
+    let mod_path = (path-normalize (path-join (path-dir FILE_PATH) mod_name))
+    ;
+    node mod_def__ns
+    attr (mod_def__ns) pop_symbol = "%M"
+    edge mod_scope -> mod_def__ns
+    set mod_scope = mod_def__ns
+    ;
+    scan mod_path {
+      "index$" {
+        ; skip last component for index files
+      }
+      "([^/]+)/?" {
+        node mod_def
+        attr (mod_def) pop_symbol = $1
+        edge mod_scope -> mod_def
+        set mod_scope = mod_def
+      }
     }
-    "([^/]+)/?" {
-      node mod_def
-      attr (mod_def) pop_symbol = $1
-      edge mod_scope -> mod_def
-      ;
-      set mod_scope = mod_def
-    }
+    ; make the last one a definition
+    attr (mod_scope) is_definition, source_node = @prog, empty_source_span
+    ; expose exports via module definition
+    edge mod_scope -> @prog.exports
+  } else {
+    edge mod_scope -> @prog.defs
   }
-  ; make the last one a definition
-  attr (mod_scope) is_definition, source_node = @prog, empty_source_span
-  ; expose exports via module definition
-  edge mod_scope -> @prog.exports
 }
 
 ;; Project and module reference
-(program)@prog {
+(program [(import_statement) (export_statement)]* @imexs)@prog {
   var proj_scope = ROOT_NODE
   if (not (eq PROJECT_NAME "")) {
     ; project reference
@@ -291,44 +303,47 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
     edge proj_ref -> proj_ref__ns
     ;
     set proj_scope = proj_ref
-    ; compose all project files by adding edge to the project reference
-    edge @prog.lexical_scope -> proj_scope
   }
 
-  ; module reference
-  ;
-  node mod_ref__ns
-  attr (mod_ref__ns) push_symbol = "%M"
-  edge mod_ref__ns -> proj_scope
-  ;
-  let mod_dir = (path-normalize (path-dir FILE_PATH))
-  var mod_scope = mod_ref__ns
-  scan mod_dir {
-    "([^/]+)/?" {
-      node mod_ref
-      attr (mod_ref) push_symbol = $1
-      edge mod_ref -> mod_scope
+  ; compose all project files by adding edge to the project reference
+  edge @prog.lexical_scope -> proj_scope
 
-      node mod_node
-      edge mod_node -> mod_ref
+  var mod_scope = proj_scope
+  if (not (is-empty @imexs)) {
+    ; module reference
+    node mod_ref__ns
+    attr (mod_ref__ns) push_symbol = "%M"
+    edge mod_ref__ns -> mod_scope
+    set mod_scope = mod_ref__ns
+    ;
+    let mod_dir = (path-normalize (path-dir FILE_PATH))
+    scan mod_dir {
+      "([^/]+)/?" {
+        node mod_ref
+        attr (mod_ref) push_symbol = $1
+        edge mod_ref -> mod_scope
 
-      node parent_def
-      attr (parent_def) pop_symbol = ".."
-      edge parent_def -> mod_scope
-      edge mod_node -> parent_def
-      attr (mod_node -> parent_def) precedence = 1 ; consume dots eagerly
+        node mod_node
+        edge mod_node -> mod_ref
 
-      set mod_scope = mod_node
+        node parent_def
+        attr (parent_def) pop_symbol = ".."
+        edge parent_def -> mod_scope
+        edge mod_node -> parent_def
+        attr (mod_node -> parent_def) precedence = 1 ; consume dots eagerly
+
+        set mod_scope = mod_node
+      }
     }
+
+    ; relative import definition
+    node rel_def
+    attr (rel_def) pop_symbol = "%RelM"
+    edge rel_def -> mod_scope
+
+    ; expose reference in lexical scope
+    edge @prog.lexical_scope -> rel_def
   }
-
-  ; relative import definition
-  node rel_def
-  attr (rel_def) pop_symbol = "%RelM"
-  edge rel_def -> mod_scope
-
-  ; expose reference in lexical scope
-  edge @prog.lexical_scope -> rel_def
 }
 
 (program
@@ -343,13 +358,6 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
 
   ; exports are visible via module definition
   edge @prog.exports -> @stmt.exports
-}
-
-(program [(import_statement) (export_statement)]* @imexs)@prog {
-  if (is-empty @imexs) {
-    ; expose global definitions in ROOT_NODE
-    edge ROOT_NODE -> @prog.defs
-  }
 }
 
 
@@ -6129,5 +6137,5 @@ if none @is_acc {
   edge @async.async_type__promise_ref -> @async.async_type__promise_ref__ns
   ;
   attr (@async.async_type__promise_ref__ns) push_symbol = "%T"
-  edge @async.async_type__promise_ref__ns -> ROOT_NODE
+  edge @async.async_type__promise_ref__ns -> @async.lexical_scope
 }

--- a/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
@@ -104,6 +104,7 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
   node @comment.expr_def__ns
   node @comment.expr_ref
   node @comment.expr_ref__ns
+  node @comment.global_defs
   node @comment.lexical_defs
   node @comment.lexical_scope
   node @comment.member
@@ -223,6 +224,7 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
 (program)@prog {
   node @prog.defs
   node @prog.exports
+  node @prog.globals
   node @prog.lexical_scope
 }
 
@@ -258,6 +260,9 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
     set proj_scope = proj_def
   }
 
+  ; expose globals
+  edge proj_scope -> @prog.globals
+
   var mod_scope = proj_scope
   if (not (is-empty @imexs)) {
     ; module definition
@@ -285,6 +290,7 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
     ; expose exports via module definition
     edge mod_scope -> @prog.exports
   } else {
+    ; expose definitions via project scope
     edge mod_scope -> @prog.defs
   }
 }
@@ -358,6 +364,9 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
 
   ; exports are visible via module definition
   edge @prog.exports -> @stmt.exports
+
+  ; globals are visible in the project scope
+  edge @prog.globals -> @stmt.global_defs
 }
 
 
@@ -447,6 +456,7 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
 ]@stmt {
   node @stmt.default_export
   node @stmt.exports
+  node @stmt.global_defs
   node @stmt.lexical_defs
   node @stmt.lexical_scope
   node @stmt.return_type
@@ -921,16 +931,16 @@ if none @is_default {
 
 (program (export_statement
   "as" "namespace" . (_)@name
-)@export_stmt)@program {
+)@export_stmt)@prog {
   ; namespace definitions are specified together with (module) and (internal_module)
 
   ; make definitions global
-  edge ROOT_NODE -> @name.expr_def__ns
-  edge ROOT_NODE -> @name.type_def__ns
+  edge @prog.globals -> @name.expr_def__ns
+  edge @prog.globals -> @name.type_def__ns
 
   ; connect definitions to exports
-  edge @export_stmt.expr_member__ns -> @program.exports
-  edge @export_stmt.type_member__ns -> @program.exports
+  edge @export_stmt.expr_member__ns -> @prog.exports
+  edge @export_stmt.type_member__ns -> @prog.exports
 }
 
 ;; Imports
@@ -2147,10 +2157,11 @@ if none @is_async {
 
 (statement_identifier)@stmt_identifier {
   ; FIXME remove when we bump tree-sitter-typescript version
-  node @stmt_identifier.lexical_scope
+  node @stmt_identifier.global_defs
   node @stmt_identifier.lexical_defs
-  node @stmt_identifier.var_defs
+  node @stmt_identifier.lexical_scope
   node @stmt_identifier.return_type
+  node @stmt_identifier.var_defs
 }
 
 ; FIXME match body: when we bump tree-sitter-typescript version
@@ -2172,13 +2183,6 @@ if none @is_async {
 
 ;; Ambient Declaration
 
-;; We expose the ambient declarations via the statement's .lexical_defs and .var_defs.
-;; Technically this means that the declarations could be scoped in an enclosing block,
-;; or hidden behind a module name.
-;; However, ambient declarations are only allowed at the top-level of script files, so
-;; these cases cannot occur. Therefore, we have not introduced a separate .global_defs
-;; that propagates all the way to the top.
-
 (ambient_declaration
   (declaration)@decl
 )@amb_decl {
@@ -2186,10 +2190,10 @@ if none @is_async {
   edge @decl.lexical_scope -> @amb_decl.lexical_scope
 
   ; expose lexical definitions
-  edge @amb_decl.lexical_defs -> @decl.lexical_defs
+  edge @amb_decl.global_defs -> @decl.lexical_defs
 
   ; expose variable definitions
-  edge @amb_decl.var_defs -> @decl.var_defs
+  edge @amb_decl.global_defs -> @decl.var_defs
 }
 
 (ambient_declaration
@@ -2200,10 +2204,10 @@ if none @is_async {
   edge @stmt_blk.lexical_scope -> @amb_decl.lexical_scope
 
   ; expose lexical definitions
-  edge @amb_decl.lexical_defs -> @stmt_blk.lexical_defs
+  edge @amb_decl.global_defs -> @stmt_blk.lexical_defs
 
   ; expose variable definitions
-  edge @amb_decl.var_defs -> @stmt_blk.var_defs
+  edge @amb_decl.global_defs -> @stmt_blk.var_defs
 }
 
 ; FIXME what is this? tsc doesn't recognize this syntax

--- a/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
@@ -2154,16 +2154,23 @@ if none @is_async {
 
 ;; Ambient Declaration
 
+;; We expose the ambient declarations via the statement's .lexical_defs and .var_defs.
+;; Technically this means that the declarations could be scoped in an enclosing block,
+;; or hidden behind a module name.
+;; However, ambient declarations are only allowed at the top-level of script files, so
+;; these cases cannot occur. Therefore, we have not introduced a separate .global_defs
+;; that propagates all the way to the top.
+
 (ambient_declaration
   (declaration)@decl
 )@amb_decl {
   ; propagate lexical scope
   edge @decl.lexical_scope -> @amb_decl.lexical_scope
 
-  ; lexical definitions are for ROOT_NODE
+  ; expose lexical definitions
   edge @amb_decl.lexical_defs -> @decl.lexical_defs
 
-  ; variable definitions are for ROOT_NODE
+  ; expose variable definitions
   edge @amb_decl.var_defs -> @decl.var_defs
 }
 
@@ -2174,11 +2181,11 @@ if none @is_async {
   ; propagate lexical scope
   edge @stmt_blk.lexical_scope -> @amb_decl.lexical_scope
 
-  ; lexical definitions are for ROOT_NODE
-  edge ROOT_NODE -> @stmt_blk.lexical_defs
+  ; expose lexical definitions
+  edge @amb_decl.lexical_defs -> @stmt_blk.lexical_defs
 
-  ; variable definitions are for ROOT_NODE
-  edge ROOT_NODE -> @stmt_blk.var_defs
+  ; expose variable definitions
+  edge @amb_decl.var_defs -> @stmt_blk.var_defs
 }
 
 ; FIXME what is this? tsc doesn't recognize this syntax
@@ -2369,22 +2376,30 @@ if none @is_async {
 (ambient_declaration
   (module name:(string)@name body:(_)@body)
 )@amb_decl {
-  node @name.mod_def
-  node @name.mod_def__ns
-
   ; propagate lexical scope
   edge @body.lexical_scope -> @amb_decl.lexical_scope
 
-  ; global definition
-  edge ROOT_NODE -> @name.mod_def__ns
+  ; module definition
+  let mod_path = (replace (source-text @name) "[\"\']" "")
   ;
-  attr (@name.mod_def__ns) pop_symbol = "%M"
-  edge @name.mod_def__ns -> @name.mod_def
+  node mod_def__ns
+  attr (mod_def__ns) pop_symbol = "%NonRelM"
+  edge @amb_decl.lexical_defs -> mod_def__ns
   ;
-  attr (@name.mod_def) symbol_definition = (replace (source-text @name) "[\"\']" ""), source_node = @name
-
-  ; exports are reachable via module definition
-  edge @name.mod_def -> @body.exports
+  var mod_scope = mod_def__ns
+  scan mod_path {
+    "([^/]+)/?" {
+      node mod_def
+      attr (mod_def) pop_symbol = $1
+      edge mod_scope -> mod_def
+      ;
+      set mod_scope = mod_def
+    }
+  }
+  ; make the last one a definition
+  attr (mod_scope) is_definition, source_node = @name
+  ; expose exports via module definition
+  edge mod_scope -> @body.exports
 }
 
 

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-from-ambient-module-declaration.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-from-ambient-module-declaration.ts
@@ -1,0 +1,9 @@
+/* --- path: ./index.ts --- */
+import { foo } from "@my/lib";
+//       ^ defined: 8
+
+/* --- path: ./mod.ts --- */
+
+declare module "@my/lib" {
+    export const foo = 42;
+}


### PR DESCRIPTION
This PR removes almost all references to `ROOT_NODE` and ensures things are properly scoped within the project.
This ensures we have as much control as possible over where information is visible.
The builtins, as a result, or not a global thing anymore, but something that is explicitly imported into every file.

## PR stack

- [x] #167