### PR TITLE
Add `analyze` command

### DIFF
--- a/tree-sitter-stack-graphs/CHANGELOG.md
+++ b/tree-sitter-stack-graphs/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - A new `CancelAfterDuration` implementation of `CancellationFlag` that cancels the computation after a certain amount of time.
 
+#### Changed
+
+- The `LanguageConfiguration::matches_file` method takes a `ContentProvider` instead of an `Option<&str>` value. This allows lazy file reading *after* the filename is checked, instead of the unconditional loading required before. To give content readers the opportunity to cache read values, a mutable reference is required. The return type has changed to `std::io::Result` to propagate possible errors from content providers. A `FileReader` implementation that caches the last read file is provided as well.
+
 ### CLI
 
 #### Added

--- a/tree-sitter-stack-graphs/CHANGELOG.md
+++ b/tree-sitter-stack-graphs/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Library
+
+#### Added
+
+- A new `CancelAfterDuration` implementation of `CancellationFlag` that cancels the computation after a certain amount of time.
+
+### CLI
+
+#### Added
+
+- A new `analyze` command that computes stack graphs and partial paths for all given source files and directories. The command does not produce any output at the moment. Analysis per file can be limited using the `--max-file-time` flag.
+
 ## v0.6.0 -- 2023-01-13
 
 ### Library

--- a/tree-sitter-stack-graphs/src/cli/analyze.rs
+++ b/tree-sitter-stack-graphs/src/cli/analyze.rs
@@ -16,12 +16,17 @@ use stack_graphs::stitching::Database;
 use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
 use tree_sitter_graph::Variables;
 use walkdir::WalkDir;
 
+use crate::cli::util::duration_from_seconds_str;
 use crate::cli::util::map_parse_errors;
 use crate::cli::util::path_exists;
 use crate::loader::Loader;
+use crate::CancelAfterDuration;
+use crate::CancellationFlag;
 use crate::LoadError;
 use crate::NoCancellation;
 
@@ -29,11 +34,26 @@ use crate::NoCancellation;
 #[derive(Args)]
 pub struct AnalyzeArgs {
     /// Source file or directory paths.
-    #[clap(value_name = "SOURCE_PATH", required = true, value_hint = ValueHint::AnyPath, parse(from_os_str), validator_os = path_exists)]
+    #[clap(
+        value_name = "SOURCE_PATH",
+        required = true,
+        value_hint = ValueHint::AnyPath,
+        parse(from_os_str),
+        validator_os = path_exists,
+    )]
     pub source_paths: Vec<PathBuf>,
 
-    #[clap(short = 'v')]
+    #[clap(long, short = 'v')]
     pub verbose: bool,
+
+    /// Maximum runtime per file in seconds.
+    #[clap(
+        long,
+        value_name = "SECONDS",
+        parse(try_from_str = duration_from_seconds_str),
+        require_equals = true,
+    )]
+    pub max_file_time: Option<Duration>,
 }
 
 impl AnalyzeArgs {
@@ -41,6 +61,7 @@ impl AnalyzeArgs {
         Self {
             source_paths,
             verbose: false,
+            max_file_time: None,
         }
     }
 
@@ -76,7 +97,6 @@ impl AnalyzeArgs {
             .with_context(|| format!("Error analyzing file {}", source_path.display()))
     }
 
-    /// Run test file.
     fn analyze_file(
         &self,
         source_root: &Path,
@@ -84,18 +104,27 @@ impl AnalyzeArgs {
         loader: &mut Loader,
     ) -> anyhow::Result<()> {
         if self.verbose {
-            eprint!("{} ", source_path.display());
+            eprint!("{}: ", source_path.display());
+        }
+
+        let mut cancellation_flag: Arc<dyn CancellationFlag> = Arc::new(NoCancellation);
+        if let Some(max_file_time) = self.max_file_time {
+            cancellation_flag = CancelAfterDuration::new(max_file_time);
         }
 
         let source = std::fs::read_to_string(source_path)?;
-        let lc = match loader.load_for_file(source_path, Some(&source), &NoCancellation)? {
-            Some(sgl) => sgl,
-            None => {
-                if self.verbose {
-                    eprintln!("{}", "⦵".dimmed());
+        let lc = match loader.load_for_file(source_path, Some(&source), cancellation_flag.as_ref())
+        {
+            Ok(Some(sgl)) => sgl,
+            Ok(None) => return Ok(()),
+            Err(crate::loader::LoadError::Cancelled(_)) => {
+                if !self.verbose {
+                    eprint!("{}: ", source_path.display());
                 }
+                eprintln!("{}", "language loading timed out".yellow());
                 return Ok(());
             }
+            Err(e) => return Err(e.into()),
         };
 
         let mut graph = StackGraph::new();
@@ -103,9 +132,6 @@ impl AnalyzeArgs {
             .add_file(&source_path.to_string_lossy())
             .map_err(|_| anyhow!("Duplicate file {}", source_path.display()))?;
 
-        if self.verbose {
-            eprint!("{} ", "🕸".yellow());
-        }
         let relative_source_path = source_path.strip_prefix(source_root).unwrap();
         let result = if let Some(fa) = source_path
             .file_name()
@@ -118,45 +144,63 @@ impl AnalyzeArgs {
                 &source,
                 &mut std::iter::empty(),
                 &HashMap::new(),
-                &NoCancellation,
+                cancellation_flag.as_ref(),
             )
         } else {
             let globals = Variables::new();
-            lc.sgl
-                .build_stack_graph_into(&mut graph, file, &source, &globals, &NoCancellation)
+            lc.sgl.build_stack_graph_into(
+                &mut graph,
+                file,
+                &source,
+                &globals,
+                cancellation_flag.as_ref(),
+            )
         };
         match result {
             Err(LoadError::ParseErrors(parse_errors)) => {
-                let parse_error = map_parse_errors(source_path, &parse_errors, &source);
+                let parse_error = map_parse_errors(source_path, &parse_errors, &source, "");
                 if !self.verbose {
-                    eprint!("{}", source_path.display());
+                    eprint!("{}: ", source_path.display());
                 }
-                eprintln!("{}", "✗".red());
+                eprintln!("{}", "parsing failed".red());
                 eprintln!("{}", parse_error);
+                return Ok(());
+            }
+            Err(LoadError::Cancelled(_)) => {
+                if !self.verbose {
+                    eprint!("{}: ", source_path.display());
+                }
+                eprintln!("{}", "parsing timed out".yellow());
                 return Ok(());
             }
             Err(e) => return Err(e.into()),
             Ok(_) => {}
         };
 
-        if self.verbose {
-            eprint!("{} ", "🦶".yellow());
-        }
         let mut partials = PartialPaths::new();
         let mut db = Database::new();
-        partials.find_all_partial_paths_in_file(
+        match partials.find_all_partial_paths_in_file(
             &graph,
             file,
-            &stack_graphs::NoCancellation,
+            &cancellation_flag.as_ref(),
             |g, ps, p| {
                 if p.is_complete_as_possible(g) {
                     db.add_partial_path(g, ps, p);
                 }
             },
-        )?;
+        ) {
+            Ok(_) => {}
+            Err(_) => {
+                if !self.verbose {
+                    eprint!("{}: ", source_path.display());
+                }
+                eprintln!("{}", "path computation timed out".yellow());
+                return Ok(());
+            }
+        }
 
         if self.verbose {
-            eprintln!("{}", "✓".green());
+            eprintln!("{}", "success".green());
         }
         Ok(())
     }

--- a/tree-sitter-stack-graphs/src/cli/analyze.rs
+++ b/tree-sitter-stack-graphs/src/cli/analyze.rs
@@ -53,7 +53,6 @@ pub struct AnalyzeArgs {
         long,
         value_name = "SECONDS",
         parse(try_from_str = duration_from_seconds_str),
-        require_equals = true,
     )]
     pub max_file_time: Option<Duration>,
 }

--- a/tree-sitter-stack-graphs/src/cli/analyze.rs
+++ b/tree-sitter-stack-graphs/src/cli/analyze.rs
@@ -1,0 +1,163 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use anyhow::anyhow;
+use anyhow::Context as _;
+use clap::Args;
+use clap::ValueHint;
+use colored::Colorize as _;
+use stack_graphs::graph::StackGraph;
+use stack_graphs::partial::PartialPaths;
+use stack_graphs::stitching::Database;
+use std::collections::HashMap;
+use std::path::Path;
+use std::path::PathBuf;
+use tree_sitter_graph::Variables;
+use walkdir::WalkDir;
+
+use crate::cli::util::map_parse_errors;
+use crate::cli::util::path_exists;
+use crate::loader::Loader;
+use crate::LoadError;
+use crate::NoCancellation;
+
+/// Analyze sources
+#[derive(Args)]
+pub struct AnalyzeArgs {
+    /// Source file or directory paths.
+    #[clap(value_name = "SOURCE_PATH", required = true, value_hint = ValueHint::AnyPath, parse(from_os_str), validator_os = path_exists)]
+    pub source_paths: Vec<PathBuf>,
+
+    #[clap(short = 'v')]
+    pub verbose: bool,
+}
+
+impl AnalyzeArgs {
+    pub fn new(source_paths: Vec<PathBuf>) -> Self {
+        Self {
+            source_paths,
+            verbose: false,
+        }
+    }
+
+    pub fn run(&self, loader: &mut Loader) -> anyhow::Result<()> {
+        for source_path in &self.source_paths {
+            if source_path.is_dir() {
+                let source_root = source_path;
+                for source_entry in WalkDir::new(source_root)
+                    .follow_links(true)
+                    .into_iter()
+                    .filter_map(|e| e.ok())
+                    .filter(|e| e.file_type().is_file())
+                {
+                    let source_path = source_entry.path();
+                    self.run_with_context(source_root, source_path, loader)?;
+                }
+            } else {
+                let source_root = source_path.parent().unwrap();
+                self.run_with_context(source_root, source_path, loader)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Run test file and add error context to any failures that are returned.
+    fn run_with_context(
+        &self,
+        source_root: &Path,
+        source_path: &Path,
+        loader: &mut Loader,
+    ) -> anyhow::Result<()> {
+        self.analyze_file(source_root, source_path, loader)
+            .with_context(|| format!("Error analyzing file {}", source_path.display()))
+    }
+
+    /// Run test file.
+    fn analyze_file(
+        &self,
+        source_root: &Path,
+        source_path: &Path,
+        loader: &mut Loader,
+    ) -> anyhow::Result<()> {
+        if self.verbose {
+            eprint!("{} ", source_path.display());
+        }
+
+        let source = std::fs::read_to_string(source_path)?;
+        let lc = match loader.load_for_file(source_path, Some(&source), &NoCancellation)? {
+            Some(sgl) => sgl,
+            None => {
+                if self.verbose {
+                    eprintln!("{}", "⦵".dimmed());
+                }
+                return Ok(());
+            }
+        };
+
+        let mut graph = StackGraph::new();
+        let file = graph
+            .add_file(&source_path.to_string_lossy())
+            .map_err(|_| anyhow!("Duplicate file {}", source_path.display()))?;
+
+        if self.verbose {
+            eprint!("{} ", "🕸".yellow());
+        }
+        let relative_source_path = source_path.strip_prefix(source_root).unwrap();
+        let result = if let Some(fa) = source_path
+            .file_name()
+            .and_then(|f| lc.special_files.get(&f.to_string_lossy()))
+        {
+            fa.build_stack_graph_into(
+                &mut graph,
+                file,
+                &relative_source_path,
+                &source,
+                &mut std::iter::empty(),
+                &HashMap::new(),
+                &NoCancellation,
+            )
+        } else {
+            let globals = Variables::new();
+            lc.sgl
+                .build_stack_graph_into(&mut graph, file, &source, &globals, &NoCancellation)
+        };
+        match result {
+            Err(LoadError::ParseErrors(parse_errors)) => {
+                let parse_error = map_parse_errors(source_path, &parse_errors, &source);
+                if !self.verbose {
+                    eprint!("{}", source_path.display());
+                }
+                eprintln!("{}", "✗".red());
+                eprintln!("{}", parse_error);
+                return Ok(());
+            }
+            Err(e) => return Err(e.into()),
+            Ok(_) => {}
+        };
+
+        if self.verbose {
+            eprint!("{} ", "🦶".yellow());
+        }
+        let mut partials = PartialPaths::new();
+        let mut db = Database::new();
+        partials.find_all_partial_paths_in_file(
+            &graph,
+            file,
+            &stack_graphs::NoCancellation,
+            |g, ps, p| {
+                if p.is_complete_as_possible(g) {
+                    db.add_partial_path(g, ps, p);
+                }
+            },
+        )?;
+
+        if self.verbose {
+            eprintln!("{}", "✓".green());
+        }
+        Ok(())
+    }
+}

--- a/tree-sitter-stack-graphs/src/cli/analyze.rs
+++ b/tree-sitter-stack-graphs/src/cli/analyze.rs
@@ -77,14 +77,23 @@ impl AnalyzeArgs {
                     .filter(|e| e.file_type().is_file())
                 {
                     let source_path = source_entry.path();
-                    if let Err(e) = self.analyze_file_with_context(source_root, source_path, loader) {
-                        eprintln!("Skipping file {} due to analysis failure {}", source_path.display(), e.to_string());
+                    if let Err(e) = self.analyze_file_with_context(source_root, source_path, loader)
+                    {
+                        eprintln!(
+                            "Skipping file {} due to analysis failure {}",
+                            source_path.display(),
+                            e.to_string()
+                        );
                     }
                 }
             } else {
                 let source_root = source_path.parent().unwrap();
                 if let Err(e) = self.analyze_file_with_context(source_root, source_path, loader) {
-                    eprintln!("Skipping file {} due to analysis failure {}", source_path.display(), e.to_string());
+                    eprintln!(
+                        "Skipping file {} due to analysis failure {}",
+                        source_path.display(),
+                        e.to_string()
+                    );
                 };
             }
         }

--- a/tree-sitter-stack-graphs/src/cli/analyze.rs
+++ b/tree-sitter-stack-graphs/src/cli/analyze.rs
@@ -103,10 +103,6 @@ impl AnalyzeArgs {
         source_path: &Path,
         loader: &mut Loader,
     ) -> anyhow::Result<()> {
-        if self.verbose {
-            eprint!("{}: ", source_path.display());
-        }
-
         let mut cancellation_flag: Arc<dyn CancellationFlag> = Arc::new(NoCancellation);
         if let Some(max_file_time) = self.max_file_time {
             cancellation_flag = CancelAfterDuration::new(max_file_time);
@@ -118,14 +114,19 @@ impl AnalyzeArgs {
             Ok(Some(sgl)) => sgl,
             Ok(None) => return Ok(()),
             Err(crate::loader::LoadError::Cancelled(_)) => {
-                if !self.verbose {
-                    eprint!("{}: ", source_path.display());
-                }
-                eprintln!("{}", "language loading timed out".yellow());
+                eprintln!(
+                    "{}: {}",
+                    source_path.display(),
+                    "language loading timed out".yellow()
+                );
                 return Ok(());
             }
             Err(e) => return Err(e.into()),
         };
+
+        if self.verbose {
+            eprint!("{}: ", source_path.display());
+        }
 
         let mut graph = StackGraph::new();
         let file = graph

--- a/tree-sitter-stack-graphs/src/cli/analyze.rs
+++ b/tree-sitter-stack-graphs/src/cli/analyze.rs
@@ -77,11 +77,15 @@ impl AnalyzeArgs {
                     .filter(|e| e.file_type().is_file())
                 {
                     let source_path = source_entry.path();
-                    self.analyze_file_with_context(source_root, source_path, loader)?;
+                    if let Err(e) = self.analyze_file_with_context(source_root, source_path, loader) {
+                        eprintln!("Skipping file {} due to analysis failure {}", source_path.display(), e.to_string());
+                    }
                 }
             } else {
                 let source_root = source_path.parent().unwrap();
-                self.analyze_file_with_context(source_root, source_path, loader)?;
+                if let Err(e) = self.analyze_file_with_context(source_root, source_path, loader) {
+                    eprintln!("Skipping file {} due to analysis failure {}", source_path.display(), e.to_string());
+                };
             }
         }
         Ok(())

--- a/tree-sitter-stack-graphs/src/cli/parse.rs
+++ b/tree-sitter-stack-graphs/src/cli/parse.rs
@@ -15,6 +15,7 @@ use tree_sitter::Parser;
 use tree_sitter_graph::parse_error::ParseError;
 
 use crate::cli::util::path_exists;
+use crate::loader::FileReader;
 use crate::loader::Loader;
 use crate::LoadError;
 
@@ -34,11 +35,12 @@ impl ParseArgs {
     }
 
     fn parse_file(&self, file_path: &Path, loader: &mut Loader) -> anyhow::Result<()> {
-        let source = std::fs::read_to_string(file_path)?;
-        let lang = match loader.load_tree_sitter_language_for_file(file_path, Some(&source))? {
+        let mut file_reader = FileReader::new();
+        let lang = match loader.load_tree_sitter_language_for_file(file_path, &mut file_reader)? {
             Some(sgl) => sgl,
             None => return Err(anyhow!("No stack graph language found")),
         };
+        let source = file_reader.get(file_path)?;
 
         let mut parser = Parser::new();
         parser.set_language(lang)?;

--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -281,7 +281,7 @@ impl TestArgs {
     ) -> anyhow::Result<()> {
         match sgl.build_stack_graph_into(graph, file, source, globals, &NoCancellation) {
             Err(LoadError::ParseErrors(parse_errors)) => {
-                Err(map_parse_errors(test_path, &parse_errors, source))
+                Err(map_parse_errors(test_path, &parse_errors, source, "  "))
             }
             Err(e) => Err(e.into()),
             Ok(_) => Ok(()),

--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -24,6 +24,7 @@ use walkdir::WalkDir;
 use crate::cli::util::map_parse_errors;
 use crate::cli::util::path_exists;
 use crate::cli::util::PathSpec;
+use crate::loader::FileReader;
 use crate::loader::LanguageConfiguration;
 use crate::loader::Loader;
 use crate::test::Test;
@@ -193,8 +194,8 @@ impl TestArgs {
         test_path: &Path,
         loader: &mut Loader,
     ) -> anyhow::Result<TestResult> {
-        let source = std::fs::read_to_string(test_path)?;
-        let lc = match loader.load_for_file(test_path, Some(&source), &NoCancellation)? {
+        let mut file_reader = FileReader::new();
+        let lc = match loader.load_for_file(test_path, &mut file_reader, &NoCancellation)? {
             Some(sgl) => sgl,
             None => {
                 if self.show_ignored {
@@ -203,6 +204,7 @@ impl TestArgs {
                 return Ok(TestResult::new());
             }
         };
+        let source = file_reader.get(test_path)?;
         let default_fragment_path = test_path.strip_prefix(test_root).unwrap();
         let mut test = Test::from_source(&test_path, &source, default_fragment_path)?;
         self.load_builtins_into(&lc, &mut test.graph)
@@ -224,7 +226,10 @@ impl TestArgs {
                     &test_fragment.globals,
                     &NoCancellation,
                 )?;
-            } else if lc.matches_file(&test_fragment.path, Some(&test_fragment.source)) {
+            } else if lc.matches_file(
+                &test_fragment.path,
+                &mut Some(test_fragment.source.as_ref()),
+            )? {
                 globals.clear();
                 test_fragment.add_globals_to(&mut globals);
                 self.build_fragment_stack_graph_into(

--- a/tree-sitter-stack-graphs/src/cli/util.rs
+++ b/tree-sitter-stack-graphs/src/cli/util.rs
@@ -10,6 +10,7 @@ use std::ffi::OsStr;
 use std::ffi::OsString;
 use std::path::Path;
 use std::path::PathBuf;
+use std::time::Duration;
 use tree_sitter_graph::parse_error::TreeWithParseErrorVec;
 
 use crate::cli::MAX_PARSE_ERRORS;
@@ -126,6 +127,7 @@ pub fn map_parse_errors(
     test_path: &Path,
     parse_errors: &TreeWithParseErrorVec,
     source: &str,
+    prefix: &str,
 ) -> anyhow::Error {
     let mut error = String::new();
     let parse_errors = parse_errors.errors();
@@ -133,7 +135,8 @@ pub fn map_parse_errors(
         let line = parse_error.node().start_position().row;
         let column = parse_error.node().start_position().column;
         error.push_str(&format!(
-            "  {}:{}:{}: {}\n",
+            "{}{}:{}:{}: {}\n",
+            prefix,
             test_path.display(),
             line + 1,
             column + 1,
@@ -149,4 +152,8 @@ pub fn map_parse_errors(
         ));
     }
     anyhow!(error)
+}
+
+pub fn duration_from_seconds_str(s: &str) -> Result<Duration, anyhow::Error> {
+    Ok(Duration::new(s.parse()?, 0))
 }

--- a/tree-sitter-stack-graphs/tests/it/loader.rs
+++ b/tree-sitter-stack-graphs/tests/it/loader.rs
@@ -40,12 +40,12 @@ fn can_load_from_provided_language_configuration() {
         Loader::from_language_configurations(vec![lc], None).expect("Expected loader to succeed");
 
     let tsl = loader
-        .load_tree_sitter_language_for_file(&PATH, None)
+        .load_tree_sitter_language_for_file(&PATH, &mut None)
         .expect("Expected loading tree-sitter language to succeed");
     assert_eq!(tsl, Some(language));
 
     let lc = loader
-        .load_for_file(&PATH, None, &NoCancellation)
+        .load_for_file(&PATH, &mut None, &NoCancellation)
         .expect("Expected loading stack graph language to succeed");
     assert_eq!(lc.map(|lc| lc.language), Some(language));
 }


### PR DESCRIPTION
This adds a rudimentary `analyze` command to the CLI. For now it takes a path, builds stack graphs for the sources, and computes partial files per file's stack graph.

- A `--max-file-time` flag sets a timeout on analysis for a single file. Default is unlimited.
- A `--verbose/-v` flag prints all files as they are being processed. Without it, only files with problems are printed.
- Console printing is made debug friendly by printing the file names _before_ analysis starts, so if excessive runtime of memory usage occurs, it is immediately clear which file is the cause.

In the future, it might store the graphs and/or paths in a database which can then be queried, etc.

Additionally, the language detection code, which accepted a `&str` parameter for the file content, has been changed to take a `ContentProvider` instead.

- The content provider is only called *after* we have determined that the file path matches the language. This prevents reading files from disk that we know are going to be rejected.
- This also fixes errors that resulted from reading non-UTF8 files only to pass them to language detection. 

## Example output

![image](https://user-images.githubusercontent.com/999073/214577694-6d07e5f4-53da-48eb-9d85-e13aa6fbc9db.png)
