### PR TITLE
Cleanup `test` command

### DIFF
--- a/tree-sitter-stack-graphs/CHANGELOG.md
+++ b/tree-sitter-stack-graphs/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - A new `analyze` command that computes stack graphs and partial paths for all given source files and directories. The command does not produce any output at the moment. Analysis per file can be limited using the `--max-file-time` flag.
 
+#### Changed
+
+- The `--show-ignored` flag of the `test` command has been renamed to `--show-skipped`. Only explicitly skipped test files (with a `.skip` extension) will be shown. Other unsupported files are, such as generated HTML files, are never shown.
+- The output of the `test` command has changed to print the test name before the test result, so that it clear which test is currently running.
+- The `--hide-passing` flag of the `test` command has been renamed to the more common `--quiet`/`-q`.
+
 ## v0.6.0 -- 2023-01-13
 
 ### Library

--- a/tree-sitter-stack-graphs/CHANGELOG.md
+++ b/tree-sitter-stack-graphs/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `LanguageConfiguration::matches_file` method takes a `ContentProvider` instead of an `Option<&str>` value. This allows lazy file reading *after* the filename is checked, instead of the unconditional loading required before. To give content readers the opportunity to cache read values, a mutable reference is required. The return type has changed to `std::io::Result` to propagate possible errors from content providers. A `FileReader` implementation that caches the last read file is provided as well.
 
+#### Fixed
+
+- Fix a panic condition when assertion refer to source lines beyond the end of the test file.
+
 ### CLI
 
 #### Added
@@ -26,8 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 
 - The `--show-ignored` flag of the `test` command has been renamed to `--show-skipped`. Only explicitly skipped test files (with a `.skip` extension) will be shown. Other unsupported files are, such as generated HTML files, are never shown.
-- The output of the `test` command has changed to print the test name before the test result, so that it clear which test is currently running.
 - The `--hide-passing` flag of the `test` command has been renamed to the more common `--quiet`/`-q`.
+- The output of the `test` command has changed to print the test name before the test result, so that it clear which test is currently running.
 
 ## v0.6.0 -- 2023-01-13
 

--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -81,9 +81,9 @@ pub struct TestArgs {
     )]
     pub test_paths: Vec<PathBuf>,
 
-    /// Hide passing tests.
-    #[clap(long)]
-    pub hide_passing: bool,
+    /// Hide passing tests in output.
+    #[clap(long, short = 'q')]
+    pub quiet: bool,
 
     /// Hide failure error details.
     #[clap(long)]
@@ -149,7 +149,7 @@ impl TestArgs {
     pub fn new(test_paths: Vec<PathBuf>) -> Self {
         Self {
             test_paths,
-            hide_passing: false,
+            quiet: false,
             hide_failure_errors: false,
             show_skipped: false,
             save_graph: None,
@@ -220,7 +220,7 @@ impl TestArgs {
         };
         let source = file_reader.get(test_path)?;
 
-        if !self.hide_passing {
+        if !self.quiet {
             print!("{}: ", test_path.display());
         }
 
@@ -317,11 +317,11 @@ impl TestArgs {
     fn handle_result(&self, test_path: &Path, result: &TestResult) -> anyhow::Result<bool> {
         let success = result.failure_count() == 0;
         if success {
-            if !self.hide_passing {
+            if !self.quiet {
                 println!("{}", "success".green());
             }
         } else {
-            if self.hide_passing {
+            if self.quiet {
                 print!("{}: ", test_path.display());
             }
             println!(
@@ -357,7 +357,7 @@ impl TestArgs {
             .map(|spec| spec.format(test_root, test_path))
         {
             self.save_graph(&path, &graph, filter)?;
-            if !success || !self.hide_passing {
+            if !success || !self.quiet {
                 println!("{}: graph at {}", test_path.display(), path.display());
             }
         }
@@ -367,7 +367,7 @@ impl TestArgs {
             .map(|spec| spec.format(test_root, test_path))
         {
             self.save_paths(&path, paths, graph, filter)?;
-            if !success || !self.hide_passing {
+            if !success || !self.quiet {
                 println!("{}: paths at {}", test_path.display(), path.display());
             }
         }
@@ -377,7 +377,7 @@ impl TestArgs {
             .map(|spec| spec.format(test_root, test_path))
         {
             self.save_visualization(&path, paths, graph, filter, &test_path)?;
-            if !success || !self.hide_passing {
+            if !success || !self.quiet {
                 println!(
                     "{}: visualization at {}",
                     test_path.display(),

--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -71,7 +71,13 @@ impl OutputMode {
 "#)]
 pub struct TestArgs {
     /// Test file or directory paths.
-    #[clap(value_name = "TEST_PATH", required = true, value_hint = ValueHint::AnyPath, parse(from_os_str), validator_os = path_exists)]
+    #[clap(
+        value_name = "TEST_PATH",
+        required = true,
+        value_hint = ValueHint::AnyPath,
+        parse(from_os_str),
+        validator_os = path_exists
+    )]
     pub test_paths: Vec<PathBuf>,
 
     /// Hide passing tests.
@@ -129,7 +135,12 @@ pub struct TestArgs {
     pub save_visualization: Option<PathSpec>,
 
     /// Controls when graphs, paths, or visualization are saved.
-    #[clap(long, arg_enum, default_value_t = OutputMode::OnFailure)]
+    #[clap(
+        long,
+        arg_enum,
+        default_value_t = OutputMode::OnFailure,
+        require_equals = true,
+    )]
     pub output_mode: OutputMode,
 }
 

--- a/tree-sitter-stack-graphs/src/test.rs
+++ b/tree-sitter-stack-graphs/src/test.rs
@@ -220,7 +220,7 @@ impl Test {
         }
 
         for fragment in &mut fragments {
-            fragment.parse_assertions(|line| line_files[line])?;
+            fragment.parse_assertions(|line| line_files.get(line).cloned().flatten())?;
         }
 
         Ok(Self {


### PR DESCRIPTION
This does some cleanup for the `test` command:

- Change `--show-ignored` to `--show-skipped`, which only displays explicitly skipped tests (with a `.skip` extension), instead of just any file that happens to be in the test folder (such as generated `.html`).
- Change console output to be debugging friendly. Test names are displayed before the test is run, making debugging excessive runtime and memory usage easier. It is now similar to the output of `analyze`.
- Fix a panic when an assertion refers to a line beyond the end of a file.

## Prerequisites

- [ ] #174