### PR TITLE
More partial path finding improvements

### DIFF
--- a/stack-graphs/Cargo.toml
+++ b/stack-graphs/Cargo.toml
@@ -15,7 +15,6 @@ edition = "2018"
 [features]
 copious-debugging = []
 json = ["serde", "serde_json"]
-partial-path-finding-v1 = []
 
 [lib]
 # All of our tests are in the tests/it "integration" test executable.

--- a/stack-graphs/Cargo.toml
+++ b/stack-graphs/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 [features]
 copious-debugging = []
 json = ["serde", "serde_json"]
-new-partial-paths = []
+partial-path-finding-v1 = []
 
 [lib]
 # All of our tests are in the tests/it "integration" test executable.

--- a/stack-graphs/Cargo.toml
+++ b/stack-graphs/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 [features]
 copious-debugging = []
 json = ["serde", "serde_json"]
+new-partial-paths = []
 
 [lib]
 # All of our tests are in the tests/it "integration" test executable.

--- a/stack-graphs/src/arena.rs
+++ b/stack-graphs/src/arena.rs
@@ -315,6 +315,15 @@ impl<H, T> SupplementalArena<H, T> {
     pub fn len(&self) -> usize {
         self.items.len()
     }
+
+    /// Iterate over the items in this arena.
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (Handle<T>, &T)> {
+        self.items
+            .iter()
+            .enumerate()
+            .skip(1)
+            .map(|(i, x)| (Handle::from_some(i as u32), unsafe { &*(x.as_ptr()) }))
+    }
 }
 
 impl<H, T> SupplementalArena<H, T>

--- a/stack-graphs/src/assert.rs
+++ b/stack-graphs/src/assert.rs
@@ -15,8 +15,10 @@ use crate::graph::File;
 use crate::graph::Node;
 use crate::graph::StackGraph;
 use crate::graph::Symbol;
-use crate::paths::Path;
-use crate::paths::Paths;
+use crate::partial::PartialPath;
+use crate::partial::PartialPaths;
+use crate::stitching::Database;
+use crate::stitching::ForwardPartialPathStitcher;
 use crate::CancellationError;
 use crate::CancellationFlag;
 
@@ -100,7 +102,7 @@ pub enum AssertionError {
         source: AssertionSource,
         references: Vec<Handle<Node>>,
         missing_targets: Vec<AssertionTarget>,
-        unexpected_paths: Vec<Path>,
+        unexpected_paths: Vec<PartialPath>,
     },
     IncorrectDefinitions {
         source: AssertionSource,
@@ -126,12 +128,13 @@ impl Assertion {
     pub fn run(
         &self,
         graph: &StackGraph,
-        paths: &mut Paths,
+        partials: &mut PartialPaths,
+        db: &mut Database,
         cancellation_flag: &dyn CancellationFlag,
     ) -> Result<(), AssertionError> {
         match self {
             Self::Defined { source, targets } => {
-                self.run_defined(graph, paths, source, targets, cancellation_flag)
+                self.run_defined(graph, partials, db, source, targets, cancellation_flag)
             }
             Self::Defines { source, symbols } => self.run_defines(graph, source, symbols),
             Self::Refers { source, symbols } => self.run_refers(graph, source, symbols),
@@ -141,7 +144,8 @@ impl Assertion {
     fn run_defined(
         &self,
         graph: &StackGraph,
-        paths: &mut Paths,
+        partials: &mut PartialPaths,
+        db: &mut Database,
         source: &AssertionSource,
         expected_targets: &Vec<AssertionTarget>,
         cancellation_flag: &dyn CancellationFlag,
@@ -154,12 +158,24 @@ impl Assertion {
         }
 
         let mut actual_paths = Vec::new();
-        paths.find_all_paths(graph, references.clone(), cancellation_flag, |g, _ps, p| {
-            if p.is_complete(g) {
-                actual_paths.push(p);
+        for reference in &references {
+            let reference_paths = ForwardPartialPathStitcher::find_all_complete_partial_paths(
+                graph,
+                partials,
+                db,
+                vec![*reference],
+                cancellation_flag,
+            )?;
+            for reference_path in &reference_paths {
+                if reference_paths
+                    .iter()
+                    .all(|other| !other.shadows(partials, reference_path))
+                {
+                    actual_paths.push(reference_path.clone());
+                }
             }
-        })?;
-        paths.remove_shadowed_paths(&mut actual_paths, cancellation_flag)?;
+        }
+
         let missing_targets = expected_targets
             .iter()
             .filter(|t| {

--- a/stack-graphs/src/assert.rs
+++ b/stack-graphs/src/assert.rs
@@ -159,12 +159,16 @@ impl Assertion {
 
         let mut actual_paths = Vec::new();
         for reference in &references {
-            let reference_paths = ForwardPartialPathStitcher::find_all_complete_partial_paths(
+            let mut reference_paths = Vec::new();
+            ForwardPartialPathStitcher::find_all_complete_partial_paths(
                 graph,
                 partials,
                 db,
                 vec![*reference],
                 cancellation_flag,
+                |_, _, p| {
+                    reference_paths.push(p.clone());
+                },
             )?;
             for reference_path in &reference_paths {
                 if reference_paths

--- a/stack-graphs/src/c.rs
+++ b/stack-graphs/src/c.rs
@@ -1602,6 +1602,7 @@ fn sg_partial_path_arena_find_partial_paths_in_file_inner(
             db.add_partial_path(graph, partials, path);
         },
     )?;
+    #[allow(deprecated)]
     ForwardPartialPathStitcher::find_locally_complete_partial_paths(
         graph,
         partials,

--- a/stack-graphs/src/c.rs
+++ b/stack-graphs/src/c.rs
@@ -1576,17 +1576,44 @@ pub extern "C" fn sg_partial_path_arena_find_partial_paths_in_file(
     let partial_path_list = unsafe { &mut *partial_path_list };
     let cancellation_flag: Option<&AtomicUsize> =
         unsafe { std::mem::transmute(cancellation_flag.as_ref()) };
-    partials
-        .find_all_partial_paths_in_file(
-            graph,
-            file,
-            &AtomicUsizeCancellationFlag(cancellation_flag),
-            |_graph, partials, mut path| {
-                path.ensure_both_directions(partials);
-                partial_path_list.partial_paths.push(path);
-            },
-        )
-        .into()
+    sg_partial_path_arena_find_partial_paths_in_file_inner(
+        graph,
+        partials,
+        file,
+        partial_path_list,
+        &AtomicUsizeCancellationFlag(cancellation_flag),
+    )
+    .into()
+}
+
+fn sg_partial_path_arena_find_partial_paths_in_file_inner(
+    graph: &StackGraph,
+    partials: &mut PartialPaths,
+    file: Handle<File>,
+    partial_path_list: &mut sg_partial_path_list,
+    cancellation_flag: &dyn CancellationFlag,
+) -> Result<(), CancellationError> {
+    let mut db = Database::new();
+    partials.find_minimal_partial_paths_set_in_file(
+        graph,
+        file,
+        cancellation_flag,
+        |graph, partials, path| {
+            db.add_partial_path(graph, partials, path);
+        },
+    )?;
+    ForwardPartialPathStitcher::find_locally_complete_partial_paths(
+        graph,
+        partials,
+        &mut db,
+        cancellation_flag,
+        |_graph, partials, path| {
+            let mut path = path.clone();
+            path.ensure_both_directions(partials);
+            partial_path_list.partial_paths.push(path);
+        },
+    )?;
+    Ok(())
 }
 
 /// A handle to a partial path in a partial path database.  A zero handle represents a missing

--- a/stack-graphs/src/graph.rs
+++ b/stack-graphs/src/graph.rs
@@ -579,6 +579,11 @@ impl Node {
         matches!(self, Node::Root(_))
     }
 
+    #[inline(always)]
+    pub fn is_endpoint(&self) -> bool {
+        self.is_definition() || self.is_exported_scope() || self.is_reference() || self.is_root()
+    }
+
     /// Returns this node's symbol, if it has one.  (_Pop symbol_, _pop scoped symbol_, _push
     /// symbol_, and _push scoped symbol_ nodes have symbols.)
     pub fn symbol(&self) -> Option<Handle<Symbol>> {

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -599,7 +599,7 @@ impl PartialSymbolStack {
         !self.symbols.is_empty()
     }
 
-    /// Returns whether this partial symbol stack has a symbol stack variable variable.
+    /// Returns whether this partial symbol stack has a symbol stack variable.
     #[inline(always)]
     pub fn has_variable(&self) -> bool {
         !self.variable.is_some()

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -2481,6 +2481,9 @@ impl PartialPaths {
     /// necessary pieces, then you should code up your own loop that calls
     /// [`PartialPath::extend`][] manually.
     ///
+    /// Caveat: Edges between nodes of different files are not used. Hence the returned set of partial
+    /// paths will not cover paths going through those edges.
+    ///
     /// [`PartialPath::extend`]: struct.PartialPath.html#method.extend
     pub fn find_minimal_partial_paths_set_in_file<F>(
         &mut self,

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -2063,6 +2063,10 @@ impl PartialPath {
         graph[self.end_node].is_endpoint()
     }
 
+    pub fn ends_in_jump(&self, graph: &StackGraph) -> bool {
+        graph[self.end_node].is_jump_to()
+    }
+
     /// Returns whether a partial path is "productive" — that is, whether it adds useful
     /// information to a path.  Non-productive paths are ignored.
     pub fn is_productive(&self, partials: &mut PartialPaths) -> bool {
@@ -2505,7 +2509,7 @@ impl PartialPaths {
         );
         while let Some(path) = queue.pop_front() {
             cancellation_flag.check("finding partial paths in file")?;
-            let is_seed = path.start_node == path.end_node && path.edges.len() == 0;
+            let is_seed = path.edges.is_empty();
             copious_debugging!(" => {}", path.display(graph, self));
             if !is_seed && as_complete_as_necessary(graph, &path) {
                 copious_debugging!("    * as complete as necessary");

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -185,7 +185,7 @@ impl SymbolStackVariable {
         SymbolStackVariable(unsafe { NonZeroU32::new_unchecked(offset_value) })
     }
 
-    fn as_u32(self) -> u32 {
+    pub(crate) fn as_u32(self) -> u32 {
         self.0.get()
     }
 
@@ -256,7 +256,7 @@ impl ScopeStackVariable {
         ScopeStackVariable(unsafe { NonZeroU32::new_unchecked(offset_value) })
     }
 
-    fn as_u32(self) -> u32 {
+    pub(crate) fn as_u32(self) -> u32 {
         self.0.get()
     }
 
@@ -597,6 +597,12 @@ impl PartialSymbolStack {
     #[inline(always)]
     pub fn contains_symbols(&self) -> bool {
         !self.symbols.is_empty()
+    }
+
+    /// Returns whether this partial symbol stack has a symbol stack variable variable.
+    #[inline(always)]
+    pub fn has_variable(&self) -> bool {
+        !self.variable.is_some()
     }
 
     #[inline(always)]
@@ -994,6 +1000,10 @@ impl PartialSymbolStack {
             .copied()
     }
 
+    pub fn variable(&self) -> Option<SymbolStackVariable> {
+        self.variable.clone().into_option()
+    }
+
     fn ensure_both_directions(&mut self, partials: &mut PartialPaths) {
         self.symbols
             .ensure_backwards(&mut partials.partial_symbol_stacks);
@@ -1094,6 +1104,12 @@ impl PartialScopeStack {
     #[inline(always)]
     pub fn contains_scopes(&self) -> bool {
         !self.scopes.is_empty()
+    }
+
+    /// Returns whether this partial scope stack has a scope stack variable.
+    #[inline(always)]
+    pub fn has_variable(&self) -> bool {
+        self.variable.is_some()
     }
 
     #[inline(always)]

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -2065,7 +2065,7 @@ impl PartialPath {
         node.is_endpoint() || node.is_jump_to()
     }
 
-    #[cfg(feature = "new-partial-paths")]
+    #[cfg(not(feature = "partial-path-finding-v1"))]
     pub fn as_complete_as_necessary(&self, graph: &StackGraph) -> bool {
         self.starts_at_endpoint(graph) && self.ends_at_endpoint(graph)
     }
@@ -2073,7 +2073,7 @@ impl PartialPath {
     /// A partial path is _as complete as possible_ if we cannot extend it any further within the
     /// current file.  This represents the maximal amount of work that we can pre-compute at index
     /// time.
-    #[cfg(not(feature = "new-partial-paths"))]
+    #[cfg(feature = "partial-path-finding-v1")]
     pub fn is_complete_as_possible(&self, graph: &StackGraph) -> bool {
         match &graph[self.start_node] {
             Node::Root(_) => (),
@@ -2505,7 +2505,7 @@ impl Node {
     }
 }
 
-#[cfg(not(feature = "new-partial-paths"))]
+#[cfg(feature = "partial-path-finding-v1")]
 impl PartialPaths {
     /// Finds all partial paths in a file, calling the `visit` closure for each one.
     ///
@@ -2563,7 +2563,7 @@ impl PartialPaths {
     }
 }
 
-#[cfg(feature = "new-partial-paths")]
+#[cfg(not(feature = "partial-path-finding-v1"))]
 impl PartialPaths {
     /// Finds all partial paths in a file, calling the `visit` closure for each one.
     ///

--- a/stack-graphs/src/paths.rs
+++ b/stack-graphs/src/paths.rs
@@ -651,19 +651,31 @@ impl Path {
             .then_with(|| self.edges.cmp(paths, other.edges))
     }
 
+    pub fn starts_at_reference(&self, graph: &StackGraph) -> bool {
+        graph[self.start_node].is_reference()
+    }
+
+    pub fn ends_at_definition(&self, graph: &StackGraph) -> bool {
+        graph[self.end_node].is_definition()
+            && self.symbol_stack.is_empty()
+            && self.scope_stack.is_empty()
+    }
+
+    pub fn starts_at_endpoint(&self, graph: &StackGraph) -> bool {
+        graph[self.start_node].is_endpoint()
+    }
+
+    pub fn ends_at_endpoint(&self, graph: &StackGraph) -> bool {
+        graph[self.end_node].is_endpoint()
+    }
+
+    pub fn ends_in_jump(&self, graph: &StackGraph) -> bool {
+        graph[self.end_node].is_jump_to()
+    }
+
     /// A _complete_ path represents a full name binding that resolves a reference to a definition.
     pub fn is_complete(&self, graph: &StackGraph) -> bool {
-        if !graph[self.start_node].is_reference() {
-            return false;
-        } else if !graph[self.end_node].is_definition() {
-            return false;
-        } else if !self.symbol_stack.is_empty() {
-            return false;
-        } else if !self.scope_stack.is_empty() {
-            return false;
-        } else {
-            true
-        }
+        self.starts_at_reference(graph) && self.ends_at_definition(graph)
     }
 
     pub fn display<'a>(&'a self, graph: &'a StackGraph, paths: &'a mut Paths) -> impl Display + 'a {

--- a/stack-graphs/src/stitching.rs
+++ b/stack-graphs/src/stitching.rs
@@ -1052,7 +1052,7 @@ impl ForwardPartialPathStitcher {
         let mut stitcher =
             ForwardPartialPathStitcher::from_nodes(graph, partials, db, starting_nodes);
         stitcher.should_extend =
-            Box::new(|g, _ps, p| p.edges.len() == 0 || !g[p.end_node].is_root());
+            Box::new(|g, _ps, p| p.edges.is_empty() || !g[p.end_node].is_root());
         while !stitcher.is_complete() {
             cancellation_flag.check("finding complete partial paths")?;
             let partial_paths = stitcher

--- a/stack-graphs/tests/it/c/can_find_partial_paths_in_file.rs
+++ b/stack-graphs/tests/it/c/can_find_partial_paths_in_file.rs
@@ -148,11 +148,11 @@ fn class_field_through_function_parameter() {
             // reference to `a` in import statement
             "<%1> ($1) [main.py(17) reference a] -> [root] <a,%1> ($1)",
             // `from a import *` means we can rewrite any lookup of `__main__.*` → `a.*`
-            "<__main__.,%1> ($1) [root] -> [root] <a.,%1> ($1)",
+            "<__main__.,%2> ($1) [root] -> [root] <a.,%2> ($1)",
             // reference to `b` in import statement
             "<%1> ($1) [main.py(15) reference b] -> [root] <b,%1> ($1)",
             // `from b import *` means we can rewrite any lookup of `__main__.*` → `b.*`
-            "<__main__.,%1> ($1) [root] -> [root] <b.,%1> ($1)",
+            "<__main__.,%2> ($1) [root] -> [root] <b.,%2> ($1)",
             // we can look for every reference in either `a` or `b`
             "<%1> ($1) [main.py(9) reference A] -> [root] <a.A,%1> ($1)",
             "<%1> ($1) [main.py(9) reference A] -> [root] <b.A,%1> ($1)",
@@ -172,7 +172,7 @@ fn class_field_through_function_parameter() {
             // definition of `a` module
             "<a,%1> ($1) [root] -> [a.py(0) definition a] <%1> ($1)",
             // definition of `foo` function
-            "<a.foo,%1> ($1) [root] -> [a.py(5) definition foo] <%1> ($1)",
+            "<a.foo,%2> ($1) [root] -> [a.py(5) definition foo] <%2> ($1)",
             // reference to `x` in function body can resolve to formal parameter, and may have passed in parameters...
             "<%1> ($1) [a.py(8) reference x] -> [a.py(14) definition x] <%1> ()",
             // ...which we can look up either the 0th actual positional parameter...
@@ -180,11 +180,11 @@ fn class_field_through_function_parameter() {
             // ...or the actual named parameter `x`
             "<%1> ($1) [a.py(8) reference x] -> [jump to scope] <x,%1> ($1)",
             // result of function is `x`, which is passed in as a formal parameter...
-            "<a.foo()/($2),%1> ($1) [root] -> [a.py(14) definition x] <%1> ()",
+            "<a.foo()/($3),%3> ($1) [root] -> [a.py(14) definition x] <%3> ()",
             // ...which we can look up either the 0th actual positional parameter...
-            "<a.foo()/($2),%1> ($1) [root] -> [jump to scope] <0,%1> ($2)",
+            "<a.foo()/($3),%3> ($1) [root] -> [jump to scope] <0,%3> ($3)",
             // ...or the actual named parameter `x`
-            "<a.foo()/($2),%1> ($1) [root] -> [jump to scope] <x,%1> ($2)",
+            "<a.foo()/($3),%3> ($1) [root] -> [jump to scope] <x,%3> ($3)",
         ],
     );
     check_partial_paths_in_file(
@@ -194,11 +194,11 @@ fn class_field_through_function_parameter() {
             // definition of `b` module
             "<b,%1> ($1) [root] -> [b.py(0) definition b] <%1> ($1)",
             // definition of class `A`
-            "<b.A,%1> ($1) [root] -> [b.py(5) definition A] <%1> ($1)",
+            "<b.A,%2> ($1) [root] -> [b.py(5) definition A] <%2> ($1)",
             // definition of class member `A.bar`
-            "<b.A.bar,%1> ($1) [root] -> [b.py(8) definition bar] <%1> ($1)",
+            "<b.A.bar,%3> ($1) [root] -> [b.py(8) definition bar] <%3> ($1)",
             // `bar` can also be accessed as an instance member
-            "<b.A()/($2).bar,%1> ($1) [root] -> [b.py(8) definition bar] <%1> ($2)",
+            "<b.A()/($3).bar,%3> ($1) [root] -> [b.py(8) definition bar] <%3> ($3)",
         ],
     );
 }
@@ -215,7 +215,7 @@ fn cyclic_imports_python() {
             // reference to `a` in import statement
             "<%1> ($1) [main.py(8) reference a] -> [root] <a,%1> ($1)",
             // `from a import *` means we can rewrite any lookup of `__main__.*` → `a.*`
-            "<__main__.,%1> ($1) [root] -> [root] <a.,%1> ($1)",
+            "<__main__.,%2> ($1) [root] -> [root] <a.,%2> ($1)",
             // reference to `foo` becomes `a.foo` because of import statement
             "<%1> ($1) [main.py(6) reference foo] -> [root] <a.foo,%1> ($1)",
         ],
@@ -229,7 +229,7 @@ fn cyclic_imports_python() {
             // reference to `b` in import statement
             "<%1> ($1) [a.py(6) reference b] -> [root] <b,%1> ($1)",
             // `from b import *` means we can rewrite any lookup of `a.*` → `b.*`
-            "<a.,%1> ($1) [root] -> [root] <b.,%1> ($1)",
+            "<a.,%2> ($1) [root] -> [root] <b.,%2> ($1)",
         ],
     );
     check_partial_paths_in_file(
@@ -241,9 +241,9 @@ fn cyclic_imports_python() {
             // reference to `a` in import statement
             "<%1> ($1) [b.py(8) reference a] -> [root] <a,%1> ($1)",
             // `from a import *` means we can rewrite any lookup of `b.*` → `a.*`
-            "<b.,%1> ($1) [root] -> [root] <a.,%1> ($1)",
+            "<b.,%2> ($1) [root] -> [root] <a.,%2> ($1)",
             // definition of `foo`
-            "<b.foo,%1> ($1) [root] -> [b.py(6) definition foo] <%1> ($1)",
+            "<b.foo,%2> ($1) [root] -> [b.py(6) definition foo] <%2> ($1)",
         ],
     );
 }
@@ -284,7 +284,7 @@ fn sequenced_import_star() {
             // reference to `a` in import statement
             "<%1> ($1) [main.py(8) reference a] -> [root] <a,%1> ($1)",
             // `from a import *` means we can rewrite any lookup of `__main__.*` → `a.*`
-            "<__main__.,%1> ($1) [root] -> [root] <a.,%1> ($1)",
+            "<__main__.,%2> ($1) [root] -> [root] <a.,%2> ($1)",
             // reference to `foo` becomes `a.foo` because of import statement
             "<%1> ($1) [main.py(6) reference foo] -> [root] <a.foo,%1> ($1)",
         ],
@@ -298,7 +298,7 @@ fn sequenced_import_star() {
             // reference to `b` in import statement
             "<%1> ($1) [a.py(6) reference b] -> [root] <b,%1> ($1)",
             // `from b import *` means we can rewrite any lookup of `a.*` → `b.*`
-            "<a.,%1> ($1) [root] -> [root] <b.,%1> ($1)",
+            "<a.,%2> ($1) [root] -> [root] <b.,%2> ($1)",
         ],
     );
     check_partial_paths_in_file(
@@ -308,7 +308,7 @@ fn sequenced_import_star() {
             // definition of `b` module
             "<b,%1> ($1) [root] -> [b.py(0) definition b] <%1> ($1)",
             // definition of `foo` inside of `b` module
-            "<b.foo,%1> ($1) [root] -> [b.py(5) definition foo] <%1> ($1)",
+            "<b.foo,%2> ($1) [root] -> [b.py(5) definition foo] <%2> ($1)",
         ],
     );
 }

--- a/stack-graphs/tests/it/can_find_local_nodes.rs
+++ b/stack-graphs/tests/it/can_find_local_nodes.rs
@@ -20,9 +20,14 @@ fn check_local_nodes(graph: &StackGraph, file: &str, expected_local_nodes: &[&st
     let mut partials = PartialPaths::new();
     let mut database = Database::new();
     partials
-        .find_all_partial_paths_in_file(graph, file, &NoCancellation, |graph, partials, path| {
-            database.add_partial_path(graph, partials, path);
-        })
+        .find_minimal_partial_paths_set_in_file(
+            graph,
+            file,
+            &NoCancellation,
+            |graph, partials, path| {
+                database.add_partial_path(graph, partials, path);
+            },
+        )
         .expect("should never be cancelled");
 
     let mut results = BTreeSet::new();

--- a/stack-graphs/tests/it/can_find_node_partial_paths_in_database.rs
+++ b/stack-graphs/tests/it/can_find_node_partial_paths_in_database.rs
@@ -40,6 +40,7 @@ fn check_node_partial_paths(
         )
         .expect("should never be cancelled");
     let mut db = Database::new();
+    #[allow(deprecated)]
     ForwardPartialPathStitcher::find_locally_complete_partial_paths(
         graph,
         &mut partials,

--- a/stack-graphs/tests/it/can_find_partial_paths_in_file.rs
+++ b/stack-graphs/tests/it/can_find_partial_paths_in_file.rs
@@ -10,6 +10,8 @@ use std::collections::BTreeSet;
 use pretty_assertions::assert_eq;
 use stack_graphs::graph::StackGraph;
 use stack_graphs::partial::PartialPaths;
+use stack_graphs::stitching::Database;
+use stack_graphs::stitching::ForwardPartialPathStitcher;
 use stack_graphs::NoCancellation;
 
 use crate::test_graphs;
@@ -17,17 +19,33 @@ use crate::test_graphs;
 fn check_partial_paths_in_file(graph: &StackGraph, file: &str, expected_paths: &[&str]) {
     let file = graph.get_file_unchecked(file);
     let mut partials = PartialPaths::new();
-    let mut results = BTreeSet::new();
+    let mut db = Database::new();
     partials
-        .find_all_partial_paths_in_file(graph, file, &NoCancellation, |graph, partials, path| {
-            results.insert(path.display(graph, partials).to_string());
-        })
+        .find_minimal_partial_paths_set_in_file(
+            graph,
+            file,
+            &NoCancellation,
+            |graph, partials, path| {
+                db.add_partial_path(graph, partials, path);
+            },
+        )
         .expect("should never be cancelled");
+    let mut results = BTreeSet::new();
+    ForwardPartialPathStitcher::find_locally_complete_partial_paths(
+        graph,
+        &mut partials,
+        &mut db,
+        &NoCancellation,
+        |g, ps, p| {
+            results.insert(p.display(g, ps).to_string());
+        },
+    )
+    .expect("should never be cancelled");
     let expected_paths = expected_paths
         .iter()
         .map(|s| s.to_string())
         .collect::<BTreeSet<_>>();
-    assert_eq!(expected_paths, results);
+    assert_eq!(expected_paths, results, "failed in file {}", graph[file]);
 }
 
 #[test]
@@ -42,11 +60,11 @@ fn class_field_through_function_parameter() {
             // reference to `a` in import statement
             "<%1> ($1) [main.py(17) reference a] -> [root] <a,%1> ($1)",
             // `from a import *` means we can rewrite any lookup of `__main__.*` → `a.*`
-            "<__main__.,%1> ($1) [root] -> [root] <a.,%1> ($1)",
+            "<__main__.,%2> ($1) [root] -> [root] <a.,%2> ($1)",
             // reference to `b` in import statement
             "<%1> ($1) [main.py(15) reference b] -> [root] <b,%1> ($1)",
             // `from b import *` means we can rewrite any lookup of `__main__.*` → `b.*`
-            "<__main__.,%1> ($1) [root] -> [root] <b.,%1> ($1)",
+            "<__main__.,%2> ($1) [root] -> [root] <b.,%2> ($1)",
             // we can look for every reference in either `a` or `b`
             "<%1> ($1) [main.py(9) reference A] -> [root] <a.A,%1> ($1)",
             "<%1> ($1) [main.py(9) reference A] -> [root] <b.A,%1> ($1)",
@@ -66,7 +84,7 @@ fn class_field_through_function_parameter() {
             // definition of `a` module
             "<a,%1> ($1) [root] -> [a.py(0) definition a] <%1> ($1)",
             // definition of `foo` function
-            "<a.foo,%1> ($1) [root] -> [a.py(5) definition foo] <%1> ($1)",
+            "<a.foo,%2> ($1) [root] -> [a.py(5) definition foo] <%2> ($1)",
             // reference to `x` in function body can resolve to formal parameter, which might get formal parameters...
             "<%1> ($1) [a.py(8) reference x] -> [a.py(14) definition x] <%1> ()",
             // ...which we can look up either the 0th actual positional parameter...
@@ -74,11 +92,11 @@ fn class_field_through_function_parameter() {
             // ...or the actual named parameter `x`
             "<%1> ($1) [a.py(8) reference x] -> [jump to scope] <x,%1> ($1)",
             // result of function is `x`, which is passed in as a formal parameter...
-            "<a.foo()/($2),%1> ($1) [root] -> [a.py(14) definition x] <%1> ()",
+            "<a.foo()/($3),%3> ($1) [root] -> [a.py(14) definition x] <%3> ()",
             // ...which we can look up either the 0th actual positional parameter...
-            "<a.foo()/($2),%1> ($1) [root] -> [jump to scope] <0,%1> ($2)",
+            "<a.foo()/($3),%3> ($1) [root] -> [jump to scope] <0,%3> ($3)",
             // ...or the actual named parameter `x`
-            "<a.foo()/($2),%1> ($1) [root] -> [jump to scope] <x,%1> ($2)",
+            "<a.foo()/($3),%3> ($1) [root] -> [jump to scope] <x,%3> ($3)",
         ],
     );
     check_partial_paths_in_file(
@@ -88,11 +106,11 @@ fn class_field_through_function_parameter() {
             // definition of `b` module
             "<b,%1> ($1) [root] -> [b.py(0) definition b] <%1> ($1)",
             // definition of class `A`
-            "<b.A,%1> ($1) [root] -> [b.py(5) definition A] <%1> ($1)",
+            "<b.A,%2> ($1) [root] -> [b.py(5) definition A] <%2> ($1)",
             // definition of class member `A.bar`
-            "<b.A.bar,%1> ($1) [root] -> [b.py(8) definition bar] <%1> ($1)",
+            "<b.A.bar,%3> ($1) [root] -> [b.py(8) definition bar] <%3> ($1)",
             // `bar` can also be accessed as an instance member
-            "<b.A()/($2).bar,%1> ($1) [root] -> [b.py(8) definition bar] <%1> ($2)",
+            "<b.A()/($3).bar,%3> ($1) [root] -> [b.py(8) definition bar] <%3> ($3)",
         ],
     );
 }
@@ -109,7 +127,7 @@ fn cyclic_imports_python() {
             // reference to `a` in import statement
             "<%1> ($1) [main.py(8) reference a] -> [root] <a,%1> ($1)",
             // `from a import *` means we can rewrite any lookup of `__main__.*` → `a.*`
-            "<__main__.,%1> ($1) [root] -> [root] <a.,%1> ($1)",
+            "<__main__.,%2> ($1) [root] -> [root] <a.,%2> ($1)",
             // reference to `foo` becomes `a.foo` because of import statement
             "<%1> ($1) [main.py(6) reference foo] -> [root] <a.foo,%1> ($1)",
         ],
@@ -123,7 +141,7 @@ fn cyclic_imports_python() {
             // reference to `b` in import statement
             "<%1> ($1) [a.py(6) reference b] -> [root] <b,%1> ($1)",
             // `from b import *` means we can rewrite any lookup of `a.*` → `b.*`
-            "<a.,%1> ($1) [root] -> [root] <b.,%1> ($1)",
+            "<a.,%2> ($1) [root] -> [root] <b.,%2> ($1)",
         ],
     );
     check_partial_paths_in_file(
@@ -135,9 +153,9 @@ fn cyclic_imports_python() {
             // reference to `a` in import statement
             "<%1> ($1) [b.py(8) reference a] -> [root] <a,%1> ($1)",
             // `from a import *` means we can rewrite any lookup of `b.*` → `a.*`
-            "<b.,%1> ($1) [root] -> [root] <a.,%1> ($1)",
+            "<b.,%2> ($1) [root] -> [root] <a.,%2> ($1)",
             // definition of `foo`
-            "<b.foo,%1> ($1) [root] -> [b.py(6) definition foo] <%1> ($1)",
+            "<b.foo,%2> ($1) [root] -> [b.py(6) definition foo] <%2> ($1)",
         ],
     );
 }
@@ -178,7 +196,7 @@ fn sequenced_import_star() {
             // reference to `a` in import statement
             "<%1> ($1) [main.py(8) reference a] -> [root] <a,%1> ($1)",
             // `from a import *` means we can rewrite any lookup of `__main__.*` → `a.*`
-            "<__main__.,%1> ($1) [root] -> [root] <a.,%1> ($1)",
+            "<__main__.,%2> ($1) [root] -> [root] <a.,%2> ($1)",
             // reference to `foo` becomes `a.foo` because of import statement
             "<%1> ($1) [main.py(6) reference foo] -> [root] <a.foo,%1> ($1)",
         ],
@@ -192,7 +210,7 @@ fn sequenced_import_star() {
             // reference to `b` in import statement
             "<%1> ($1) [a.py(6) reference b] -> [root] <b,%1> ($1)",
             // `from b import *` means we can rewrite any lookup of `a.*` → `b.*`
-            "<a.,%1> ($1) [root] -> [root] <b.,%1> ($1)",
+            "<a.,%2> ($1) [root] -> [root] <b.,%2> ($1)",
         ],
     );
     check_partial_paths_in_file(
@@ -202,7 +220,7 @@ fn sequenced_import_star() {
             // definition of `b` module
             "<b,%1> ($1) [root] -> [b.py(0) definition b] <%1> ($1)",
             // definition of `foo` inside of `b` module
-            "<b.foo,%1> ($1) [root] -> [b.py(5) definition foo] <%1> ($1)",
+            "<b.foo,%2> ($1) [root] -> [b.py(5) definition foo] <%2> ($1)",
         ],
     );
 }

--- a/stack-graphs/tests/it/can_find_partial_paths_in_file.rs
+++ b/stack-graphs/tests/it/can_find_partial_paths_in_file.rs
@@ -31,6 +31,7 @@ fn check_partial_paths_in_file(graph: &StackGraph, file: &str, expected_paths: &
         )
         .expect("should never be cancelled");
     let mut results = BTreeSet::new();
+    #[allow(deprecated)]
     ForwardPartialPathStitcher::find_locally_complete_partial_paths(
         graph,
         &mut partials,

--- a/stack-graphs/tests/it/can_find_root_partial_paths_in_database.rs
+++ b/stack-graphs/tests/it/can_find_root_partial_paths_in_database.rs
@@ -44,6 +44,7 @@ fn check_root_partial_paths(
         )
         .expect("should never be cancelled");
     let mut db = Database::new();
+    #[allow(deprecated)]
     ForwardPartialPathStitcher::find_locally_complete_partial_paths(
         graph,
         &mut partials,

--- a/stack-graphs/tests/it/can_jump_to_definition_with_forward_partial_path_stitching.rs
+++ b/stack-graphs/tests/it/can_jump_to_definition_with_forward_partial_path_stitching.rs
@@ -23,7 +23,7 @@ fn check_jump_to_definition(graph: &StackGraph, expected_partial_paths: &[&str])
     // Generate partial paths for everything in the database.
     for file in graph.iter_files() {
         partials
-            .find_all_partial_paths_in_file(
+            .find_minimal_partial_paths_set_in_file(
                 graph,
                 file,
                 &NoCancellation,
@@ -37,12 +37,16 @@ fn check_jump_to_definition(graph: &StackGraph, expected_partial_paths: &[&str])
     let references = graph
         .iter_nodes()
         .filter(|handle| graph[*handle].is_reference());
-    let complete_partial_paths = ForwardPartialPathStitcher::find_all_complete_partial_paths(
+    let mut complete_partial_paths = Vec::new();
+    ForwardPartialPathStitcher::find_all_complete_partial_paths(
         graph,
         &mut partials,
         &mut db,
         references,
         &NoCancellation,
+        |_, _, p| {
+            complete_partial_paths.push(p.clone());
+        },
     )
     .expect("should never be cancelled");
     let results = complete_partial_paths

--- a/stack-graphs/tests/it/can_jump_to_definition_with_forward_path_stitching.rs
+++ b/stack-graphs/tests/it/can_jump_to_definition_with_forward_path_stitching.rs
@@ -25,7 +25,7 @@ fn check_jump_to_definition(graph: &StackGraph, expected_paths: &[&str]) {
     // Generate partial paths for everything in the database.
     for file in graph.iter_files() {
         partials
-            .find_all_partial_paths_in_file(
+            .find_minimal_partial_paths_set_in_file(
                 graph,
                 file,
                 &NoCancellation,

--- a/stack-graphs/tests/it/json.rs
+++ b/stack-graphs/tests/it/json.rs
@@ -9,7 +9,11 @@ use serde_json::json;
 use stack_graphs::arena::Handle;
 use stack_graphs::graph::File;
 use stack_graphs::graph::StackGraph;
+use stack_graphs::json::NoFilter;
+use stack_graphs::partial::PartialPaths;
 use stack_graphs::paths::Paths;
+use stack_graphs::stitching::Database;
+use stack_graphs::NoCancellation;
 
 use crate::test_graphs;
 
@@ -1801,6 +1805,312 @@ fn can_serialize_paths() {
                     "local_id" : 1
                 },
                 "symbol_stack" : []
+            }
+        ]
+    );
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn can_serialize_partial_paths() {
+    let graph: StackGraph = test_graphs::simple::new();
+    let mut partials = PartialPaths::new();
+    let mut db = Database::new();
+    for file in graph.iter_files() {
+        partials
+            .find_all_partial_paths_in_file(&graph, file, &NoCancellation, |g, ps, p| {
+                db.add_partial_path(g, ps, p);
+            })
+            .expect("Expect path finding to work");
+    }
+    let actual = db
+        .to_json(&graph, &mut partials, &NoFilter)
+        .to_value()
+        .expect("Cannot serialize paths");
+    // formatted using: json_pp -json_opt utf8,canoncical,pretty,indent_length=4
+    let expected = json!(
+        [
+            {
+                "edges" : [
+                    {
+                        "precedence" : 0,
+                        "source" : {
+                            "file" : "test.py",
+                            "local_id" : 3
+                        }
+                    },
+                    {
+                        "precedence" : 0,
+                        "source" : {
+                            "file" : "test.py",
+                            "local_id" : 8
+                        }
+                    }
+                ],
+                "end_node" : {
+                    "file" : "test.py",
+                    "local_id" : 9
+                },
+                "scope_stack_postcondition" : {
+                    "scopes" : [],
+                    "variable" : 1
+                },
+                "scope_stack_precondition" : {
+                    "scopes" : [],
+                    "variable" : 1
+                },
+                "start_node" : {
+                    "file" : "test.py",
+                    "local_id" : 3
+                },
+                "symbol_stack_postcondition" : {
+                    "symbols" : [],
+                    "variable" : 1
+                },
+                "symbol_stack_precondition" : {
+                    "symbols" : [
+                        {
+                            "symbol" : "."
+                        },
+                        {
+                            "symbol" : "x"
+                        }
+                    ],
+                    "variable" : 1
+                }
+            },
+            {
+                "edges" : [
+                    {
+                        "precedence" : 0,
+                        "source" : {
+                            "file" : "test.py",
+                            "local_id" : 1
+                        }
+                    },
+                    {
+                        "precedence" : 0,
+                        "source" : {
+                            "file" : "test.py",
+                            "local_id" : 2
+                        }
+                    },
+                    {
+                        "precedence" : 0,
+                        "source" : {
+                            "file" : "test.py",
+                            "local_id" : 4
+                        }
+                    },
+                    {
+                        "precedence" : 0,
+                        "source" : {
+                            "file" : "test.py",
+                            "local_id" : 5
+                        }
+                    }
+                ],
+                "end_node" : {
+                    "local_id" : 1
+                },
+                "scope_stack_postcondition" : {
+                    "scopes" : [],
+                    "variable" : 1
+                },
+                "scope_stack_precondition" : {
+                    "scopes" : [],
+                    "variable" : 1
+                },
+                "start_node" : {
+                    "file" : "test.py",
+                    "local_id" : 1
+                },
+                "symbol_stack_postcondition" : {
+                    "symbols" : [
+                        {
+                            "scopes" : {
+                                "scopes" : [
+                                    {
+                                        "file" : "test.py",
+                                        "local_id" : 3
+                                    }
+                                ],
+                                "variable" : 1
+                            },
+                            "symbol" : "()"
+                        },
+                        {
+                            "symbol" : "."
+                        },
+                        {
+                            "symbol" : "x"
+                        }
+                    ],
+                    "variable" : 1
+                },
+                "symbol_stack_precondition" : {
+                    "symbols" : [],
+                    "variable" : 1
+                }
+            },
+            {
+                "edges" : [
+                    {
+                        "precedence" : 0,
+                        "source" : {
+                            "file" : "test.py",
+                            "local_id" : 1
+                        }
+                    },
+                    {
+                        "precedence" : 0,
+                        "source" : {
+                            "file" : "test.py",
+                            "local_id" : 2
+                        }
+                    },
+                    {
+                        "precedence" : 0,
+                        "source" : {
+                            "file" : "test.py",
+                            "local_id" : 4
+                        }
+                    },
+                    {
+                        "precedence" : 0,
+                        "source" : {
+                            "file" : "test.py",
+                            "local_id" : 5
+                        }
+                    },
+                    {
+                        "precedence" : 1,
+                        "source" : {
+                            "file" : "test.py",
+                            "local_id" : 6
+                        }
+                    },
+                    {
+                        "precedence" : 0,
+                        "source" : {
+                            "local_id" : 2
+                        }
+                    },
+                    {
+                        "precedence" : 0,
+                        "source" : {
+                            "file" : "test.py",
+                            "local_id" : 3
+                        }
+                    },
+                    {
+                        "precedence" : 0,
+                        "source" : {
+                            "file" : "test.py",
+                            "local_id" : 8
+                        }
+                    }
+                ],
+                "end_node" : {
+                    "file" : "test.py",
+                    "local_id" : 9
+                },
+                "scope_stack_postcondition" : {
+                    "scopes" : [],
+                    "variable" : 1
+                },
+                "scope_stack_precondition" : {
+                    "scopes" : [],
+                    "variable" : 1
+                },
+                "start_node" : {
+                    "file" : "test.py",
+                    "local_id" : 1
+                },
+                "symbol_stack_postcondition" : {
+                    "symbols" : [],
+                    "variable" : 1
+                },
+                "symbol_stack_precondition" : {
+                    "symbols" : [],
+                    "variable" : 1
+                }
+            },
+            {
+                "edges" : [
+                    {
+                        "precedence" : 0,
+                        "source" : {
+                            "file" : "test.py",
+                            "local_id" : 1
+                        }
+                    },
+                    {
+                        "precedence" : 0,
+                        "source" : {
+                            "file" : "test.py",
+                            "local_id" : 2
+                        }
+                    },
+                    {
+                        "precedence" : 0,
+                        "source" : {
+                            "file" : "test.py",
+                            "local_id" : 4
+                        }
+                    },
+                    {
+                        "precedence" : 0,
+                        "source" : {
+                            "file" : "test.py",
+                            "local_id" : 5
+                        }
+                    },
+                    {
+                        "precedence" : 0,
+                        "source" : {
+                            "file" : "test.py",
+                            "local_id" : 6
+                        }
+                    },
+                    {
+                        "precedence" : 0,
+                        "source" : {
+                            "file" : "test.py",
+                            "local_id" : 7
+                        }
+                    },
+                    {
+                        "precedence" : 0,
+                        "source" : {
+                            "file" : "test.py",
+                            "local_id" : 8
+                        }
+                    }
+                ],
+                "end_node" : {
+                    "file" : "test.py",
+                    "local_id" : 9
+                },
+                "scope_stack_postcondition" : {
+                    "scopes" : []
+                },
+                "scope_stack_precondition" : {
+                    "scopes" : [],
+                    "variable" : 1
+                },
+                "start_node" : {
+                    "file" : "test.py",
+                    "local_id" : 1
+                },
+                "symbol_stack_postcondition" : {
+                    "symbols" : [],
+                    "variable" : 1
+                },
+                "symbol_stack_precondition" : {
+                    "symbols" : [],
+                    "variable" : 1
+                }
             }
         ]
     );

--- a/stack-graphs/tests/it/json.rs
+++ b/stack-graphs/tests/it/json.rs
@@ -24,7 +24,7 @@ fn can_serialize_graph() {
         .to_json(&|_: &StackGraph, _: &Handle<File>| true)
         .to_value()
         .expect("Cannot serialize graph");
-    // formatted using: json_pp -json_opt utf8,canoncical,pretty,indent_length=4
+    // formatted using: json_pp -json_opt utf8,canonical,pretty,indent_length=4
     let expected = json!(
         {
             "edges" : [
@@ -495,7 +495,7 @@ fn can_serialize_paths() {
         .to_json(&graph, &|_: &StackGraph, _: &Handle<File>| true)
         .to_value()
         .expect("Cannot serialize paths");
-    // formatted using: json_pp -json_opt utf8,canoncical,pretty,indent_length=4
+    // formatted using: json_pp -json_opt utf8,canonical,pretty,indent_length=4
     let expected = json!(
         [
             {
@@ -1827,7 +1827,7 @@ fn can_serialize_partial_paths() {
         .to_json(&graph, &mut partials, &NoFilter)
         .to_value()
         .expect("Cannot serialize paths");
-    // formatted using: json_pp -json_opt utf8,canoncical,pretty,indent_length=4
+    // formatted using: json_pp -json_opt utf8,canonical,pretty,indent_length=4
     let expected = json!(
         [
             {
@@ -1995,25 +1995,11 @@ fn can_serialize_partial_paths() {
                         "source" : {
                             "local_id" : 2
                         }
-                    },
-                    {
-                        "precedence" : 0,
-                        "source" : {
-                            "file" : "test.py",
-                            "local_id" : 3
-                        }
-                    },
-                    {
-                        "precedence" : 0,
-                        "source" : {
-                            "file" : "test.py",
-                            "local_id" : 8
-                        }
                     }
                 ],
                 "end_node" : {
                     "file" : "test.py",
-                    "local_id" : 9
+                    "local_id" : 3
                 },
                 "scope_stack_postcondition" : {
                     "scopes" : [],
@@ -2028,7 +2014,14 @@ fn can_serialize_partial_paths() {
                     "local_id" : 1
                 },
                 "symbol_stack_postcondition" : {
-                    "symbols" : [],
+                    "symbols" : [
+                        {
+                            "symbol" : "."
+                        },
+                        {
+                            "symbol" : "x"
+                        }
+                    ],
                     "variable" : 1
                 },
                 "symbol_stack_precondition" : {

--- a/stack-graphs/tests/it/json.rs
+++ b/stack-graphs/tests/it/json.rs
@@ -1818,7 +1818,7 @@ fn can_serialize_partial_paths() {
     let mut db = Database::new();
     for file in graph.iter_files() {
         partials
-            .find_all_partial_paths_in_file(&graph, file, &NoCancellation, |g, ps, p| {
+            .find_minimal_partial_paths_set_in_file(&graph, file, &NoCancellation, |g, ps, p| {
                 db.add_partial_path(g, ps, p);
             })
             .expect("Expect path finding to work");

--- a/tree-sitter-stack-graphs/src/cli/analyze.rs
+++ b/tree-sitter-stack-graphs/src/cli/analyze.rs
@@ -221,9 +221,7 @@ impl AnalyzeArgs {
             file,
             &cancellation_flag.as_ref(),
             |g, ps, p| {
-                if p.is_complete_as_possible(g) {
-                    db.add_partial_path(g, ps, p);
-                }
+                db.add_partial_path(g, ps, p);
             },
         ) {
             Ok(_) => {}

--- a/tree-sitter-stack-graphs/src/cli/analyze.rs
+++ b/tree-sitter-stack-graphs/src/cli/analyze.rs
@@ -216,7 +216,7 @@ impl AnalyzeArgs {
 
         let mut partials = PartialPaths::new();
         let mut db = Database::new();
-        match partials.find_all_partial_paths_in_file(
+        match partials.find_minimal_partial_paths_set_in_file(
             &graph,
             file,
             &cancellation_flag.as_ref(),

--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -428,12 +428,16 @@ impl TestArgs {
             .iter_nodes()
             .filter(|n| filter.include_node(graph, n))
             .collect::<Vec<_>>();
-        let paths = ForwardPartialPathStitcher::find_all_complete_partial_paths(
+        let mut paths = Vec::new();
+        ForwardPartialPathStitcher::find_all_complete_partial_paths(
             graph,
             partials,
             db,
             references.clone(),
             &cancellation_flag,
+            |_, _, p| {
+                paths.push(p.clone());
+            },
         )?;
         let mut db = Database::new();
         for path in paths {

--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -14,7 +14,9 @@ use stack_graphs::arena::Handle;
 use stack_graphs::graph::File;
 use stack_graphs::graph::StackGraph;
 use stack_graphs::json::Filter;
-use stack_graphs::paths::Paths;
+use stack_graphs::partial::PartialPaths;
+use stack_graphs::stitching::Database;
+use stack_graphs::stitching::ForwardPartialPathStitcher;
 use std::path::Path;
 use std::path::PathBuf;
 use tree_sitter_graph::Variables;
@@ -269,7 +271,9 @@ impl TestArgs {
                 ));
             }
         }
-        let result = test.run(cancellation_flag)?;
+        let mut partials = PartialPaths::new();
+        let mut db = Database::new();
+        let result = test.run(&mut partials, &mut db, cancellation_flag)?;
         let success = self.handle_result(&result, &mut file_status)?;
         if self.output_mode.test(!success) {
             let files = test.fragments.iter().map(|f| f.file).collect::<Vec<_>>();
@@ -277,9 +281,11 @@ impl TestArgs {
                 test_root,
                 test_path,
                 &test.graph,
-                &mut test.paths,
+                &mut partials,
+                &mut db,
                 &|_: &StackGraph, h: &Handle<File>| files.contains(h),
                 success,
+                cancellation_flag,
             )?;
         }
         Ok(result)
@@ -343,36 +349,47 @@ impl TestArgs {
         test_root: &Path,
         test_path: &Path,
         graph: &StackGraph,
-        paths: &mut Paths,
+        partials: &mut PartialPaths,
+        db: &mut Database,
         filter: &dyn Filter,
         success: bool,
+        cancellation_flag: &dyn CancellationFlag,
     ) -> anyhow::Result<()> {
-        if let Some(path) = self
+        let save_graph = self
             .save_graph
             .as_ref()
-            .map(|spec| spec.format(test_root, test_path))
-        {
+            .map(|spec| spec.format(test_root, test_path));
+        let save_paths = self
+            .save_paths
+            .as_ref()
+            .map(|spec| spec.format(test_root, test_path));
+        let save_visualization = self
+            .save_visualization
+            .as_ref()
+            .map(|spec| spec.format(test_root, test_path));
+
+        if let Some(path) = save_graph {
             self.save_graph(&path, &graph, filter)?;
             if !success || !self.quiet {
                 println!("{}: graph at {}", test_path.display(), path.display());
             }
         }
-        if let Some(path) = self
-            .save_paths
-            .as_ref()
-            .map(|spec| spec.format(test_root, test_path))
-        {
-            self.save_paths(&path, paths, graph, filter)?;
+
+        let mut db = if save_paths.is_some() || save_visualization.is_some() {
+            self.compute_paths(graph, partials, db, filter, cancellation_flag)?
+        } else {
+            Database::new()
+        };
+
+        if let Some(path) = save_paths {
+            self.save_paths(&path, graph, partials, &mut db, filter)?;
             if !success || !self.quiet {
                 println!("{}: paths at {}", test_path.display(), path.display());
             }
         }
-        if let Some(path) = self
-            .save_visualization
-            .as_ref()
-            .map(|spec| spec.format(test_root, test_path))
-        {
-            self.save_visualization(&path, paths, graph, filter, &test_path)?;
+
+        if let Some(path) = save_visualization {
+            self.save_visualization(&path, graph, partials, &mut db, filter, &test_path)?;
             if !success || !self.quiet {
                 println!(
                     "{}: visualization at {}",
@@ -399,14 +416,41 @@ impl TestArgs {
         Ok(())
     }
 
+    fn compute_paths(
+        &self,
+        graph: &StackGraph,
+        partials: &mut PartialPaths,
+        db: &mut Database,
+        filter: &dyn Filter,
+        cancellation_flag: &dyn CancellationFlag,
+    ) -> anyhow::Result<Database> {
+        let references = graph
+            .iter_nodes()
+            .filter(|n| filter.include_node(graph, n))
+            .collect::<Vec<_>>();
+        let paths = ForwardPartialPathStitcher::find_all_complete_partial_paths(
+            graph,
+            partials,
+            db,
+            references.clone(),
+            &cancellation_flag,
+        )?;
+        let mut db = Database::new();
+        for path in paths {
+            db.add_partial_path(graph, partials, path);
+        }
+        Ok(db)
+    }
+
     fn save_paths(
         &self,
         path: &Path,
-        paths: &mut Paths,
         graph: &StackGraph,
+        partials: &mut PartialPaths,
+        db: &mut Database,
         filter: &dyn Filter,
     ) -> anyhow::Result<()> {
-        let json = paths.to_json(graph, filter).to_string_pretty()?;
+        let json = db.to_json(graph, partials, filter).to_string_pretty()?;
         if let Some(dir) = path.parent() {
             std::fs::create_dir_all(dir)?;
         }
@@ -418,12 +462,13 @@ impl TestArgs {
     fn save_visualization(
         &self,
         path: &Path,
-        paths: &mut Paths,
         graph: &StackGraph,
+        paths: &mut PartialPaths,
+        db: &mut Database,
         filter: &dyn Filter,
         test_path: &Path,
     ) -> anyhow::Result<()> {
-        let html = graph.to_html_string(&format!("{}", test_path.display()), paths, filter)?;
+        let html = graph.to_html_string(&format!("{}", test_path.display()), paths, db, filter)?;
         if let Some(dir) = path.parent() {
             std::fs::create_dir_all(dir)?;
         }

--- a/tree-sitter-stack-graphs/src/test.rs
+++ b/tree-sitter-stack-graphs/src/test.rs
@@ -628,7 +628,7 @@ impl Test {
     ) -> Result<TestResult, stack_graphs::CancellationError> {
         // build partial paths
         for file in self.graph.iter_files() {
-            partials.find_all_partial_paths_in_file(
+            partials.find_minimal_partial_paths_set_in_file(
                 &self.graph,
                 file,
                 &cancellation_flag,

--- a/tree-sitter-stack-graphs/tests/it/test.rs
+++ b/tree-sitter-stack-graphs/tests/it/test.rs
@@ -10,6 +10,8 @@ use pretty_assertions::assert_eq;
 use stack_graphs::arena::Handle;
 use stack_graphs::graph::File;
 use stack_graphs::graph::StackGraph;
+use stack_graphs::partial::PartialPaths;
+use stack_graphs::stitching::Database;
 use std::path::Path;
 use std::path::PathBuf;
 use tree_sitter_graph::Variables;
@@ -99,8 +101,10 @@ fn check_test(
         )
         .expect("Could not load stack graph");
     }
+    let mut partials = PartialPaths::new();
+    let mut db = Database::new();
     let results = test
-        .run(&NoCancellation)
+        .run(&mut partials, &mut db, &NoCancellation)
         .expect("should never be cancelled");
     assert_eq!(
         expected_successes,


### PR DESCRIPTION
This PR makes several changes to make partial path computation + path stitching the preferred and default method to do resolution. Several larger and smaller changes make this possible:

- Tests switched from using regular path search to partial path finding. Test assertions now use stitching.
- `PartialPaths::find_all_partial_paths_in_file` has been replaced by `PartialPaths::find_minimal_partial_paths_set_in_file`. The new method computes a much smaller set of partial paths.
- The `ForwardPartialPathStitcher::find_locally_complete_partial_paths` method replicates the old `PartialPaths::find_minimal_partial_paths_set_in_file` behavior by stitching the minimal set. This method is used in several places to control the transition from the old to the new method. For example, it is used in tests (which verifies that it implements the old behavior, and allows us to postpone the laborious task of adapting all tests), and in the C API so that its behavior doesn't change for now.
- The visualization now finds its paths by stitching partial paths, and partial path serialization has been implemented as well.
- We now verify that symbol scopes are of the correct node type (exported scope).

## Rough Memory Comaprison

To get an idea of the memory impact, I ran the following command from the base and the PR branch on [vscode sources](https://github.com/microsoft/vscode/releases/tag/1.74.3):

```
$ cargo run --features cli -- analyze -v --max-file-time 60 ~/src/microsoft/vscode/ --wait-at-start
```

I measured memory allocation with Instruments. In the pictures below the first 5 minutes of each run is selected. My impression is that the base version is a little slower, so it may have processed fewer files in those five minutes, but I didn't have a good way to measure. (I could run the processes to completion, but that is taking quite long, and there are occasional stops when the TSG file is incomplete.)

Before:

![memory usage before](https://user-images.githubusercontent.com/999073/216376691-59c24e22-d87c-43a5-ac1a-944957e7ea23.png)

After:

![memory usage after](https://user-images.githubusercontent.com/999073/216377047-31c87c55-b8ba-4579-8e66-f1fd943e50e9.png)

I highlighted the highest peak with the mouse, because no scales :/. Before, the highest peak is almost 4.5GB, and persisted over a longer time, while after the highest peaks are a little over 2GB are computed much faster as well.

## Possible follow-ups

- Change the partial path tests to test `PartialPaths::find_minimal_partial_paths_set_in_file` directly, or add tests for that.
- Return the minimal partial paths set from the C API.
- Precompute partial paths for the builtins only once, and share between tests.

## Prerequisites

- [x] #174
- [x] #176
- [ ] #183
- [ ] #178