### PR TITLE
Partial path improvements

### DIFF
--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -1006,6 +1006,26 @@ impl PartialSymbolStack {
         self.symbols
             .ensure_forwards(&mut partials.partial_symbol_stacks);
     }
+
+    /// Returns the largest value of any symbol stack variable in this partial symbol stack.
+    pub fn largest_symbol_stack_variable(&self) -> u32 {
+        self.variable
+            .into_option()
+            .map(SymbolStackVariable::as_u32)
+            .unwrap_or(0)
+    }
+
+    /// Returns the largest value of any scope stack variable in this partial symbol stack.
+    pub fn largest_scope_stack_variable(&self, partials: &PartialPaths) -> u32 {
+        // We don't have to check the postconditions, because it's not valid for a postcondition to
+        // refer to a variable that doesn't exist in the precondition.
+        self.iter_unordered(partials)
+            .filter_map(|symbol| symbol.scopes.into_option())
+            .filter_map(|scopes| scopes.variable.into_option())
+            .map(ScopeStackVariable::as_u32)
+            .max()
+            .unwrap_or(0)
+    }
 }
 
 impl DisplayWithPartialPaths for PartialSymbolStack {
@@ -1422,6 +1442,14 @@ impl PartialScopeStack {
     fn ensure_forwards(&mut self, partials: &mut PartialPaths) {
         self.scopes
             .ensure_forwards(&mut partials.partial_scope_stacks);
+    }
+
+    /// Returns the largest value of any scope stack variable in this partial scope stack.
+    pub fn largest_scope_stack_variable(&self) -> u32 {
+        self.variable
+            .into_option()
+            .map(ScopeStackVariable::as_u32)
+            .unwrap_or(0)
     }
 }
 
@@ -1906,39 +1934,27 @@ impl PartialPath {
         graph: &StackGraph,
         partials: &mut PartialPaths,
         node: Handle<Node>,
-    ) -> Result<PartialPath, PathResolutionError> {
+    ) -> PartialPath {
         let initial_symbol_stack = SymbolStackVariable::initial();
         let initial_scope_stack = ScopeStackVariable::initial();
-        let symbol_stack_precondition = PartialSymbolStack::from_variable(initial_symbol_stack);
+        let mut symbol_stack_precondition = PartialSymbolStack::from_variable(initial_symbol_stack);
         let mut symbol_stack_postcondition =
             PartialSymbolStack::from_variable(initial_symbol_stack);
         let mut scope_stack_precondition = PartialScopeStack::from_variable(initial_scope_stack);
         let mut scope_stack_postcondition = PartialScopeStack::from_variable(initial_scope_stack);
 
-        let inner_node = &graph[node];
-        if let Node::PushScopedSymbol(inner_node) = inner_node {
-            scope_stack_precondition = PartialScopeStack::empty();
-            scope_stack_postcondition = PartialScopeStack::empty();
-            let scope = graph
-                .node_for_id(inner_node.scope)
-                .ok_or(PathResolutionError::UnknownAttachedScope)?;
-            scope_stack_postcondition.push_front(partials, scope);
-            let initial_symbol = PartialScopedSymbol {
-                symbol: inner_node.symbol,
-                scopes: ControlledOption::some(scope_stack_postcondition),
-            };
-            symbol_stack_postcondition.push_front(partials, initial_symbol);
-        } else if let Node::PushSymbol(inner_node) = inner_node {
-            scope_stack_precondition = PartialScopeStack::empty();
-            scope_stack_postcondition = PartialScopeStack::empty();
-            let initial_symbol = PartialScopedSymbol {
-                symbol: inner_node.symbol,
-                scopes: ControlledOption::none(),
-            };
-            symbol_stack_postcondition.push_front(partials, initial_symbol);
-        }
+        graph[node]
+            .apply_to_partial_stacks(
+                graph,
+                partials,
+                &mut symbol_stack_precondition,
+                &mut scope_stack_precondition,
+                &mut symbol_stack_postcondition,
+                &mut scope_stack_postcondition,
+            )
+            .expect("");
 
-        Ok(PartialPath {
+        PartialPath {
             start_node: node,
             end_node: node,
             symbol_stack_precondition,
@@ -1946,7 +1962,7 @@ impl PartialPath {
             scope_stack_precondition,
             scope_stack_postcondition,
             edges: PartialPathEdgeList::empty(),
-        })
+        }
     }
 
     /// Returns whether one path shadows another.  Note that shadowing is not commutative — if path
@@ -2140,38 +2156,51 @@ impl PartialPath {
         // We don't have to check the postconditions, because it's not valid for a postcondition to
         // refer to a variable that doesn't exist in the precondition.
         self.symbol_stack_precondition
-            .variable
-            .into_option()
-            .map(SymbolStackVariable::as_u32)
-            .unwrap_or(0)
+            .largest_symbol_stack_variable()
     }
 
     /// Returns the largest value of any scope stack variable in this partial path.
     pub fn largest_scope_stack_variable(&self, partials: &PartialPaths) -> u32 {
+        Self::largest_scope_stack_variable_for_partial_stacks(
+            partials,
+            &self.symbol_stack_precondition,
+            &self.scope_stack_precondition,
+        )
+    }
+
+    fn largest_scope_stack_variable_for_partial_stacks(
+        partials: &PartialPaths,
+        symbol_stack_precondition: &PartialSymbolStack,
+        scope_stack_precondition: &PartialScopeStack,
+    ) -> u32 {
         // We don't have to check the postconditions, because it's not valid for a postcondition to
         // refer to a variable that doesn't exist in the precondition.
-        let symbol_stack_precondition_variables = self
-            .symbol_stack_precondition
-            .iter_unordered(partials)
-            .filter_map(|symbol| symbol.scopes.into_option())
-            .filter_map(|scopes| scopes.variable.into_option())
-            .map(ScopeStackVariable::as_u32);
-        let scope_stack_precondition_variables = self
-            .scope_stack_precondition
-            .variable
-            .into_option()
-            .map(ScopeStackVariable::as_u32);
-        std::iter::empty()
-            .chain(symbol_stack_precondition_variables)
-            .chain(scope_stack_precondition_variables)
-            .max()
-            .unwrap_or(0)
+        std::cmp::max(
+            symbol_stack_precondition.largest_scope_stack_variable(partials),
+            scope_stack_precondition.largest_scope_stack_variable(),
+        )
     }
 
     /// Returns a fresh scope stack variable that is not already used anywhere in this partial
     /// path.
     pub fn fresh_scope_stack_variable(&self, partials: &PartialPaths) -> ScopeStackVariable {
-        ScopeStackVariable::fresher_than(self.largest_scope_stack_variable(partials))
+        Self::fresh_scope_stack_variable_for_partial_stack(
+            partials,
+            &self.symbol_stack_precondition,
+            &self.scope_stack_precondition,
+        )
+    }
+
+    fn fresh_scope_stack_variable_for_partial_stack(
+        partials: &PartialPaths,
+        symbol_stack_precondition: &PartialSymbolStack,
+        scope_stack_precondition: &PartialScopeStack,
+    ) -> ScopeStackVariable {
+        ScopeStackVariable::fresher_than(Self::largest_scope_stack_variable_for_partial_stacks(
+            partials,
+            symbol_stack_precondition,
+            scope_stack_precondition,
+        ))
     }
 
     pub fn display<'a>(
@@ -2258,85 +2287,14 @@ impl PartialPath {
             return Err(PathResolutionError::IncorrectSourceNode);
         }
 
-        let sink = &graph[edge.sink];
-        if let Node::PushSymbol(sink) = sink {
-            // The symbol stack postcondition is our representation of the path's symbol stack.
-            // Pushing the symbol onto our postcondition indicates that using this partial path
-            // would push the symbol onto the path's symbol stack.
-            let sink_symbol = sink.symbol;
-            let postcondition_symbol = PartialScopedSymbol {
-                symbol: sink_symbol,
-                scopes: ControlledOption::none(),
-            };
-            self.symbol_stack_postcondition
-                .push_front(partials, postcondition_symbol);
-        } else if let Node::PushScopedSymbol(sink) = sink {
-            // The symbol stack postcondition is our representation of the path's symbol stack.
-            // Pushing the scoped symbol onto our postcondition indicates that using this partial
-            // path would push the scoped symbol onto the path's symbol stack.
-            let sink_symbol = sink.symbol;
-            let sink_scope = graph
-                .node_for_id(sink.scope)
-                .ok_or(PathResolutionError::UnknownAttachedScope)?;
-            let mut attached_scopes = self.scope_stack_postcondition;
-            attached_scopes.push_front(partials, sink_scope);
-            let postcondition_symbol = PartialScopedSymbol {
-                symbol: sink_symbol,
-                scopes: ControlledOption::some(attached_scopes),
-            };
-            self.symbol_stack_postcondition
-                .push_front(partials, postcondition_symbol);
-        } else if let Node::PopSymbol(sink) = sink {
-            // Ideally we want to pop sink's symbol off from top of the symbol stack postcondition.
-            if let Some(top) = self.symbol_stack_postcondition.pop_front(partials) {
-                if top.symbol != sink.symbol {
-                    return Err(PathResolutionError::IncorrectPoppedSymbol);
-                }
-                if top.scopes.is_some() {
-                    return Err(PathResolutionError::UnexpectedAttachedScopeList);
-                }
-            } else {
-                // If the symbol stack postcondition is empty, then we need to update the
-                // _precondition_ to indicate that the symbol stack needs to contain this symbol in
-                // order to successfully use this partial path.
-                let precondition_symbol = PartialScopedSymbol {
-                    symbol: sink.symbol,
-                    scopes: ControlledOption::none(),
-                };
-                self.symbol_stack_precondition
-                    .push_back(partials, precondition_symbol);
-            }
-        } else if let Node::PopScopedSymbol(sink) = sink {
-            // Ideally we want to pop sink's scoped symbol off from top of the symbol stack
-            // postcondition.
-            if let Some(top) = self.symbol_stack_postcondition.pop_front(partials) {
-                if top.symbol != sink.symbol {
-                    return Err(PathResolutionError::IncorrectPoppedSymbol);
-                }
-                let new_scope_stack = match top.scopes.into_option() {
-                    Some(scopes) => scopes,
-                    None => return Err(PathResolutionError::MissingAttachedScopeList),
-                };
-                self.scope_stack_postcondition = new_scope_stack;
-            } else {
-                // If the symbol stack postcondition is empty, then we need to update the
-                // _precondition_ to indicate that the symbol stack needs to contain this scoped
-                // symbol in order to successfully use this partial path.
-                let scope_stack_variable = self.fresh_scope_stack_variable(partials);
-                let precondition_symbol = PartialScopedSymbol {
-                    symbol: sink.symbol,
-                    scopes: ControlledOption::some(PartialScopeStack::from_variable(
-                        scope_stack_variable,
-                    )),
-                };
-                self.symbol_stack_precondition
-                    .push_back(partials, precondition_symbol);
-                self.scope_stack_postcondition =
-                    PartialScopeStack::from_variable(scope_stack_variable);
-            }
-        } else if let Node::DropScopes(_) = sink {
-            self.scope_stack_postcondition = PartialScopeStack::empty();
-        }
+        graph[edge.sink].apply_to_partial_stacks(
+            graph,
+            partials,
+            &mut self.symbol_stack_precondition,
+            &mut self.scope_stack_precondition,
+            &mut self.symbol_stack_postcondition,
+            &mut self.scope_stack_postcondition,
+        )?;
 
         self.end_node = edge.sink;
         self.edges.push_back(
@@ -2414,6 +2372,108 @@ impl PartialPath {
     }
 }
 
+impl Node {
+    fn apply_to_partial_stacks(
+        &self,
+        graph: &StackGraph,
+        partials: &mut PartialPaths,
+        symbol_stack_precondition: &mut PartialSymbolStack,
+        scope_stack_precondition: &mut PartialScopeStack,
+        symbol_stack_postcondition: &mut PartialSymbolStack,
+        scope_stack_postcondition: &mut PartialScopeStack,
+    ) -> Result<(), PathResolutionError> {
+        match self {
+            Self::DropScopes(_) => {
+                *scope_stack_postcondition = PartialScopeStack::empty();
+            }
+            Self::JumpTo(_) => {}
+            Self::PopScopedSymbol(sink) => {
+                // Ideally we want to pop sink's scoped symbol off from top of the symbol stack
+                // postcondition.
+                if let Some(top) = symbol_stack_postcondition.pop_front(partials) {
+                    if top.symbol != sink.symbol {
+                        return Err(PathResolutionError::IncorrectPoppedSymbol);
+                    }
+                    let new_scope_stack = match top.scopes.into_option() {
+                        Some(scopes) => scopes,
+                        None => return Err(PathResolutionError::MissingAttachedScopeList),
+                    };
+                    *scope_stack_postcondition = new_scope_stack;
+                } else {
+                    // If the symbol stack postcondition is empty, then we need to update the
+                    // _precondition_ to indicate that the symbol stack needs to contain this scoped
+                    // symbol in order to successfully use this partial path.
+                    let scope_stack_variable =
+                        PartialPath::fresh_scope_stack_variable_for_partial_stack(
+                            partials,
+                            symbol_stack_precondition,
+                            scope_stack_precondition,
+                        );
+                    let precondition_symbol = PartialScopedSymbol {
+                        symbol: sink.symbol,
+                        scopes: ControlledOption::some(PartialScopeStack::from_variable(
+                            scope_stack_variable,
+                        )),
+                    };
+                    symbol_stack_precondition.push_back(partials, precondition_symbol);
+                    *scope_stack_postcondition =
+                        PartialScopeStack::from_variable(scope_stack_variable);
+                }
+            }
+            Self::PopSymbol(sink) => {
+                // Ideally we want to pop sink's symbol off from top of the symbol stack postcondition.
+                if let Some(top) = symbol_stack_postcondition.pop_front(partials) {
+                    if top.symbol != sink.symbol {
+                        return Err(PathResolutionError::IncorrectPoppedSymbol);
+                    }
+                    if top.scopes.is_some() {
+                        return Err(PathResolutionError::UnexpectedAttachedScopeList);
+                    }
+                } else {
+                    // If the symbol stack postcondition is empty, then we need to update the
+                    // _precondition_ to indicate that the symbol stack needs to contain this symbol in
+                    // order to successfully use this partial path.
+                    let precondition_symbol = PartialScopedSymbol {
+                        symbol: sink.symbol,
+                        scopes: ControlledOption::none(),
+                    };
+                    symbol_stack_precondition.push_back(partials, precondition_symbol);
+                }
+            }
+            Self::PushScopedSymbol(sink) => {
+                // The symbol stack postcondition is our representation of the path's symbol stack.
+                // Pushing the scoped symbol onto our postcondition indicates that using this partial
+                // path would push the scoped symbol onto the path's symbol stack.
+                let sink_symbol = sink.symbol;
+                let sink_scope = graph
+                    .node_for_id(sink.scope)
+                    .ok_or(PathResolutionError::UnknownAttachedScope)?;
+                let mut attached_scopes = scope_stack_postcondition.clone();
+                attached_scopes.push_front(partials, sink_scope);
+                let postcondition_symbol = PartialScopedSymbol {
+                    symbol: sink_symbol,
+                    scopes: ControlledOption::some(attached_scopes),
+                };
+                symbol_stack_postcondition.push_front(partials, postcondition_symbol);
+            }
+            Self::PushSymbol(sink) => {
+                // The symbol stack postcondition is our representation of the path's symbol stack.
+                // Pushing the symbol onto our postcondition indicates that using this partial path
+                // would push the symbol onto the path's symbol stack.
+                let sink_symbol = sink.symbol;
+                let postcondition_symbol = PartialScopedSymbol {
+                    symbol: sink_symbol,
+                    scopes: ControlledOption::none(),
+                };
+                symbol_stack_postcondition.push_front(partials, postcondition_symbol);
+            }
+            Self::Root(_) => {}
+            Self::Scope(_) => {}
+        }
+        Ok(())
+    }
+}
+
 impl PartialPaths {
     /// Finds all partial paths in a file, calling the `visit` closure for each one.
     ///
@@ -2442,7 +2502,7 @@ impl PartialPaths {
     {
         let mut cycle_detector = CycleDetector::new();
         let mut queue = VecDeque::new();
-        queue.push_back(PartialPath::from_node(graph, self, StackGraph::root_node()).unwrap());
+        queue.push_back(PartialPath::from_node(graph, self, StackGraph::root_node()));
         queue.extend(
             graph
                 .nodes_for_file(file)
@@ -2452,7 +2512,7 @@ impl PartialPaths {
                     node @ Node::Scope(_) => node.is_exported_scope(),
                     _ => false,
                 })
-                .map(|node| PartialPath::from_node(graph, self, node).unwrap()),
+                .map(|node| PartialPath::from_node(graph, self, node)),
         );
         while let Some(path) = queue.pop_front() {
             cancellation_flag.check("finding partial paths in file")?;

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -2303,6 +2303,9 @@ impl PartialPath {
                 precedence: edge.precedence,
             },
         );
+
+        self.resolve(graph, partials)?;
+
         Ok(())
     }
 
@@ -2361,9 +2364,6 @@ impl PartialPath {
             // If there are errors adding this edge to the partial path, or resolving the resulting
             // partial path, just skip the edge — it's not a fatal error.
             if new_path.append(graph, partials, extension).is_err() {
-                continue;
-            }
-            if new_path.resolve(graph, partials).is_err() {
                 continue;
             }
             result.push(new_path);
@@ -2632,6 +2632,9 @@ impl Path {
             self.edges.push_back(paths, edge.into());
         }
         self.end_node = partial_path.end_node;
+
+        self.resolve(graph, paths)?;
+
         Ok(())
     }
 }
@@ -2755,6 +2758,9 @@ impl PartialPath {
             lhs.edges.push_back(partials, edge);
         }
         lhs.end_node = rhs.end_node;
+
+        lhs.resolve(graph, partials)?;
+
         Ok(())
     }
 }

--- a/stack-graphs/src/paths.rs
+++ b/stack-graphs/src/paths.rs
@@ -813,6 +813,9 @@ impl Path {
                 precedence: edge.precedence,
             },
         );
+
+        self.resolve(graph, paths)?;
+
         Ok(())
     }
 
@@ -858,9 +861,6 @@ impl Path {
             // If there are errors adding this edge to the path, or resolving the resulting path,
             // just skip the edge — it's not a fatal error.
             if new_path.append(graph, paths, extension).is_err() {
-                continue;
-            }
-            if new_path.resolve(graph, paths).is_err() {
                 continue;
             }
             result.push(new_path);

--- a/stack-graphs/src/stitching.rs
+++ b/stack-graphs/src/stitching.rs
@@ -585,11 +585,6 @@ impl PathStitcher {
                 copious_debugging!("        is invalid: {:?}", err);
                 continue;
             }
-            #[cfg_attr(not(feature = "copious-debugging"), allow(unused_variables))]
-            if let Err(err) = new_path.resolve(graph, paths) {
-                copious_debugging!("        cannot resolve: {:?}", err);
-                continue;
-            }
             copious_debugging!("        is {}", new_path.display(graph, paths));
             self.next_iteration.push_back(new_path);
         }
@@ -873,14 +868,6 @@ impl ForwardPartialPathStitcher {
                 }
                 if new_partial_path.start_node != partial_path.start_node {
                     copious_debugging!("        is invalid: slips off of starting node");
-                    continue;
-                }
-                if let Err(err) = new_partial_path.resolve(graph, partials) {
-                    copious_debugging!("        is invalid: cannot resolve: {:?}", err);
-                    continue;
-                }
-                if graph[new_partial_path.end_node].is_jump_to() {
-                    copious_debugging!("        is invalid: cannot resolve: ambiguous scope stack");
                     continue;
                 }
             }

--- a/stack-graphs/tests/it/c/can_find_local_nodes.rs
+++ b/stack-graphs/tests/it/c/can_find_local_nodes.rs
@@ -92,13 +92,7 @@ fn check_local_nodes(graph: &TestGraph, file: &str, expected_local_nodes: &[&str
 fn class_field_through_function_parameter() {
     let graph = test_graphs::class_field_through_function_parameter::new();
     check_local_nodes(&graph, "main.py", &[]);
-    check_local_nodes(
-        &graph,
-        "a.py",
-        &[
-            "[a.py(8) reference x]", //
-        ],
-    );
+    check_local_nodes(&graph, "a.py", &[]);
     check_local_nodes(&graph, "b.py", &[]);
 }
 

--- a/stack-graphs/tests/it/c/can_find_partial_paths_in_file.rs
+++ b/stack-graphs/tests/it/c/can_find_partial_paths_in_file.rs
@@ -146,20 +146,20 @@ fn class_field_through_function_parameter() {
             // definition of `__main__` module
             "<__main__,%1> ($1) [root] -> [main.py(0) definition __main__] <%1> ($1)",
             // reference to `a` in import statement
-            "<%1> () [main.py(17) reference a] -> [root] <a,%1> ()",
+            "<%1> ($1) [main.py(17) reference a] -> [root] <a,%1> ($1)",
             // `from a import *` means we can rewrite any lookup of `__main__.*` → `a.*`
             "<__main__.,%1> ($1) [root] -> [root] <a.,%1> ($1)",
             // reference to `b` in import statement
-            "<%1> () [main.py(15) reference b] -> [root] <b,%1> ()",
+            "<%1> ($1) [main.py(15) reference b] -> [root] <b,%1> ($1)",
             // `from b import *` means we can rewrite any lookup of `__main__.*` → `b.*`
             "<__main__.,%1> ($1) [root] -> [root] <b.,%1> ($1)",
             // we can look for every reference in either `a` or `b`
-            "<%1> () [main.py(9) reference A] -> [root] <a.A,%1> ()",
-            "<%1> () [main.py(9) reference A] -> [root] <b.A,%1> ()",
-            "<%1> () [main.py(10) reference bar] -> [root] <a.foo()/([main.py(7)]).bar,%1> ()",
-            "<%1> () [main.py(10) reference bar] -> [root] <b.foo()/([main.py(7)]).bar,%1> ()",
-            "<%1> () [main.py(13) reference foo] -> [root] <a.foo,%1> ()",
-            "<%1> () [main.py(13) reference foo] -> [root] <b.foo,%1> ()",
+            "<%1> ($1) [main.py(9) reference A] -> [root] <a.A,%1> ($1)",
+            "<%1> ($1) [main.py(9) reference A] -> [root] <b.A,%1> ($1)",
+            "<%1> ($1) [main.py(10) reference bar] -> [root] <a.foo()/([main.py(7)],$1).bar,%1> ($1)",
+            "<%1> ($1) [main.py(10) reference bar] -> [root] <b.foo()/([main.py(7)],$1).bar,%1> ($1)",
+            "<%1> ($1) [main.py(13) reference foo] -> [root] <a.foo,%1> ($1)",
+            "<%1> ($1) [main.py(13) reference foo] -> [root] <b.foo,%1> ($1)",
             // parameter 0 of function call is `A`, which we can look up in either `a` or `b`
             "<0,%1> ($1) [main.py(7) exported scope] -> [root] <a.A,%1> ($1)",
             "<0,%1> ($1) [main.py(7) exported scope] -> [root] <b.A,%1> ($1)",
@@ -173,8 +173,12 @@ fn class_field_through_function_parameter() {
             "<a,%1> ($1) [root] -> [a.py(0) definition a] <%1> ($1)",
             // definition of `foo` function
             "<a.foo,%1> ($1) [root] -> [a.py(5) definition foo] <%1> ($1)",
-            // reference to `x` in function body can resolve to formal parameter
-            "<%1> () [a.py(8) reference x] -> [a.py(14) definition x] <%1> ()",
+            // reference to `x` in function body can resolve to formal parameter, and may have passed in parameters...
+            "<%1> ($1) [a.py(8) reference x] -> [a.py(14) definition x] <%1> ()",
+            // ...which we can look up either the 0th actual positional parameter...
+            "<%1> ($1) [a.py(8) reference x] -> [jump to scope] <0,%1> ($1)",
+            // ...or the actual named parameter `x`
+            "<%1> ($1) [a.py(8) reference x] -> [jump to scope] <x,%1> ($1)",
             // result of function is `x`, which is passed in as a formal parameter...
             "<a.foo()/($2),%1> ($1) [root] -> [a.py(14) definition x] <%1> ()",
             // ...which we can look up either the 0th actual positional parameter...
@@ -209,11 +213,11 @@ fn cyclic_imports_python() {
             // definition of `__main__` module
             "<__main__,%1> ($1) [root] -> [main.py(0) definition __main__] <%1> ($1)",
             // reference to `a` in import statement
-            "<%1> () [main.py(8) reference a] -> [root] <a,%1> ()",
+            "<%1> ($1) [main.py(8) reference a] -> [root] <a,%1> ($1)",
             // `from a import *` means we can rewrite any lookup of `__main__.*` → `a.*`
             "<__main__.,%1> ($1) [root] -> [root] <a.,%1> ($1)",
             // reference to `foo` becomes `a.foo` because of import statement
-            "<%1> () [main.py(6) reference foo] -> [root] <a.foo,%1> ()",
+            "<%1> ($1) [main.py(6) reference foo] -> [root] <a.foo,%1> ($1)",
         ],
     );
     check_partial_paths_in_file(
@@ -223,7 +227,7 @@ fn cyclic_imports_python() {
             // definition of `a` module
             "<a,%1> ($1) [root] -> [a.py(0) definition a] <%1> ($1)",
             // reference to `b` in import statement
-            "<%1> () [a.py(6) reference b] -> [root] <b,%1> ()",
+            "<%1> ($1) [a.py(6) reference b] -> [root] <b,%1> ($1)",
             // `from b import *` means we can rewrite any lookup of `a.*` → `b.*`
             "<a.,%1> ($1) [root] -> [root] <b.,%1> ($1)",
         ],
@@ -235,7 +239,7 @@ fn cyclic_imports_python() {
             // definition of `b` module
             "<b,%1> ($1) [root] -> [b.py(0) definition b] <%1> ($1)",
             // reference to `a` in import statement
-            "<%1> () [b.py(8) reference a] -> [root] <a,%1> ()",
+            "<%1> ($1) [b.py(8) reference a] -> [root] <a,%1> ($1)",
             // `from a import *` means we can rewrite any lookup of `b.*` → `a.*`
             "<b.,%1> ($1) [root] -> [root] <a.,%1> ($1)",
             // definition of `foo`
@@ -254,16 +258,16 @@ fn cyclic_imports_rust() {
         // paths involving the root node.
         &[
             // reference to `a` in `main` function
-            "<%1> () [test.rs(103) reference a] -> [test.rs(201) definition a] <%1> ()",
+            "<%1> ($1) [test.rs(103) reference a] -> [test.rs(201) definition a] <%1> ($1)",
             // reference to `a` in `b` function
-            "<%1> () [test.rs(307) reference a] -> [test.rs(201) definition a] <%1> ()",
+            "<%1> ($1) [test.rs(307) reference a] -> [test.rs(201) definition a] <%1> ($1)",
             // reference to `b` in `a` function
-            "<%1> () [test.rs(206) reference b] -> [test.rs(301) definition b] <%1> ()",
+            "<%1> ($1) [test.rs(206) reference b] -> [test.rs(301) definition b] <%1> ($1)",
             // reference to `FOO` in `main` can resolve either to `a::BAR` or `b::FOO`
-            "<%1> () [test.rs(101) reference FOO] -> [test.rs(204) definition BAR] <%1> ()",
-            "<%1> () [test.rs(101) reference FOO] -> [test.rs(304) definition FOO] <%1> ()",
+            "<%1> ($1) [test.rs(101) reference FOO] -> [test.rs(204) definition BAR] <%1> ($1)",
+            "<%1> ($1) [test.rs(101) reference FOO] -> [test.rs(304) definition FOO] <%1> ($1)",
             // reference to `BAR` in `b` resolves _only_ to `a::BAR`
-            "<%1> () [test.rs(305) reference BAR] -> [test.rs(204) definition BAR] <%1> ()",
+            "<%1> ($1) [test.rs(305) reference BAR] -> [test.rs(204) definition BAR] <%1> ($1)",
         ],
     );
 }
@@ -278,11 +282,11 @@ fn sequenced_import_star() {
             // definition of `__main__` module
             "<__main__,%1> ($1) [root] -> [main.py(0) definition __main__] <%1> ($1)",
             // reference to `a` in import statement
-            "<%1> () [main.py(8) reference a] -> [root] <a,%1> ()",
+            "<%1> ($1) [main.py(8) reference a] -> [root] <a,%1> ($1)",
             // `from a import *` means we can rewrite any lookup of `__main__.*` → `a.*`
             "<__main__.,%1> ($1) [root] -> [root] <a.,%1> ($1)",
             // reference to `foo` becomes `a.foo` because of import statement
-            "<%1> () [main.py(6) reference foo] -> [root] <a.foo,%1> ()",
+            "<%1> ($1) [main.py(6) reference foo] -> [root] <a.foo,%1> ($1)",
         ],
     );
     check_partial_paths_in_file(
@@ -292,7 +296,7 @@ fn sequenced_import_star() {
             // definition of `a` module
             "<a,%1> ($1) [root] -> [a.py(0) definition a] <%1> ($1)",
             // reference to `b` in import statement
-            "<%1> () [a.py(6) reference b] -> [root] <b,%1> ()",
+            "<%1> ($1) [a.py(6) reference b] -> [root] <b,%1> ($1)",
             // `from b import *` means we can rewrite any lookup of `a.*` → `b.*`
             "<a.,%1> ($1) [root] -> [root] <b.,%1> ($1)",
         ],

--- a/stack-graphs/tests/it/c/can_jump_to_definition_with_phased_partial_path_stitching.rs
+++ b/stack-graphs/tests/it/c/can_jump_to_definition_with_phased_partial_path_stitching.rs
@@ -242,15 +242,15 @@ fn class_field_through_function_parameter() {
         "main.py",
         &[
             // reference to `a` in import statement
-            "<%1> () [main.py(17) reference a] -> [a.py(0) definition a] <%1> ()",
+            "<%1> ($1) [main.py(17) reference a] -> [a.py(0) definition a] <%1> ($1)",
             // reference to `b` in import statement
-            "<%1> () [main.py(15) reference b] -> [b.py(0) definition b] <%1> ()",
+            "<%1> ($1) [main.py(15) reference b] -> [b.py(0) definition b] <%1> ($1)",
             // reference to `foo` in function call resolves to function definition
-            "<%1> () [main.py(13) reference foo] -> [a.py(5) definition foo] <%1> ()",
+            "<%1> ($1) [main.py(13) reference foo] -> [a.py(5) definition foo] <%1> ($1)",
             // reference to `A` as function parameter resolves to class definition
-            "<%1> () [main.py(9) reference A] -> [b.py(5) definition A] <%1> ()",
+            "<%1> ($1) [main.py(9) reference A] -> [b.py(5) definition A] <%1> ($1)",
             // reference to `bar` on result flows through body of `foo` to find `A.bar`
-            "<%1> () [main.py(10) reference bar] -> [b.py(8) definition bar] <%1> ()",
+            "<%1> ($1) [main.py(10) reference bar] -> [b.py(8) definition bar] <%1> ($1)",
         ],
     );
     check_jump_to_definition(
@@ -258,7 +258,7 @@ fn class_field_through_function_parameter() {
         "a.py",
         &[
             // reference to `x` in function body resolves to formal parameter
-            "<%1> () [a.py(8) reference x] -> [a.py(14) definition x] <%1> ()",
+            "<%1> ($1) [a.py(8) reference x] -> [a.py(14) definition x] <%1> ()",
         ],
     );
     check_jump_to_definition(
@@ -278,9 +278,9 @@ fn cyclic_imports_python() {
         "main.py",
         &[
             // reference to `a` in import statement
-            "<%1> () [main.py(8) reference a] -> [a.py(0) definition a] <%1> ()",
+            "<%1> ($1) [main.py(8) reference a] -> [a.py(0) definition a] <%1> ($1)",
             // reference to `foo` resolves through intermediate file to find `b.foo`
-            "<%1> () [main.py(6) reference foo] -> [b.py(6) definition foo] <%1> ()",
+            "<%1> ($1) [main.py(6) reference foo] -> [b.py(6) definition foo] <%1> ($1)",
         ],
     );
     check_jump_to_definition(
@@ -288,7 +288,7 @@ fn cyclic_imports_python() {
         "a.py",
         &[
             // reference to `b` in import statement
-            "<%1> () [a.py(6) reference b] -> [b.py(0) definition b] <%1> ()",
+            "<%1> ($1) [a.py(6) reference b] -> [b.py(0) definition b] <%1> ($1)",
         ],
     );
     check_jump_to_definition(
@@ -296,7 +296,7 @@ fn cyclic_imports_python() {
         "b.py",
         &[
             // reference to `a` in import statement
-            "<%1> () [b.py(8) reference a] -> [a.py(0) definition a] <%1> ()",
+            "<%1> ($1) [b.py(8) reference a] -> [a.py(0) definition a] <%1> ($1)",
         ],
     );
 }
@@ -309,16 +309,16 @@ fn cyclic_imports_rust() {
         "test.rs",
         &[
             // reference to `a` in `a::FOO` resolves to module definition
-            "<%1> () [test.rs(103) reference a] -> [test.rs(201) definition a] <%1> ()",
+            "<%1> ($1) [test.rs(103) reference a] -> [test.rs(201) definition a] <%1> ($1)",
             // reference to `a::FOO` in `main` can resolve either to `a::BAR` or `b::FOO`
-            "<%1> () [test.rs(101) reference FOO] -> [test.rs(304) definition FOO] <%1> ()",
-            "<%1> () [test.rs(101) reference FOO] -> [test.rs(204) definition BAR] <%1> ()",
+            "<%1> ($1) [test.rs(101) reference FOO] -> [test.rs(304) definition FOO] <%1> ($1)",
+            "<%1> ($1) [test.rs(101) reference FOO] -> [test.rs(204) definition BAR] <%1> ($1)",
             // reference to `b` in use statement resolves to module definition
-            "<%1> () [test.rs(206) reference b] -> [test.rs(301) definition b] <%1> ()",
+            "<%1> ($1) [test.rs(206) reference b] -> [test.rs(301) definition b] <%1> ($1)",
             // reference to `a` in use statement resolves to module definition
-            "<%1> () [test.rs(307) reference a] -> [test.rs(201) definition a] <%1> ()",
+            "<%1> ($1) [test.rs(307) reference a] -> [test.rs(201) definition a] <%1> ($1)",
             // reference to `BAR` in module `b` can _only_ resolve to `a::BAR`
-            "<%1> () [test.rs(305) reference BAR] -> [test.rs(204) definition BAR] <%1> ()",
+            "<%1> ($1) [test.rs(305) reference BAR] -> [test.rs(204) definition BAR] <%1> ($1)",
         ],
     );
 }
@@ -331,9 +331,9 @@ fn sequenced_import_star() {
         "main.py",
         &[
             // reference to `a` in import statement
-            "<%1> () [main.py(8) reference a] -> [a.py(0) definition a] <%1> ()",
+            "<%1> ($1) [main.py(8) reference a] -> [a.py(0) definition a] <%1> ($1)",
             // reference to `foo` resolves through intermediate file to find `b.foo`
-            "<%1> () [main.py(6) reference foo] -> [b.py(5) definition foo] <%1> ()",
+            "<%1> ($1) [main.py(6) reference foo] -> [b.py(5) definition foo] <%1> ($1)",
         ],
     );
     check_jump_to_definition(
@@ -341,7 +341,7 @@ fn sequenced_import_star() {
         "a.py",
         &[
             // reference to `b` in import statement
-            "<%1> () [a.py(6) reference b] -> [b.py(0) definition b] <%1> ()",
+            "<%1> ($1) [a.py(6) reference b] -> [b.py(0) definition b] <%1> ($1)",
         ],
     );
     check_jump_to_definition(

--- a/stack-graphs/tests/it/can_find_local_nodes.rs
+++ b/stack-graphs/tests/it/can_find_local_nodes.rs
@@ -44,13 +44,7 @@ fn check_local_nodes(graph: &StackGraph, file: &str, expected_local_nodes: &[&st
 fn class_field_through_function_parameter() {
     let graph = test_graphs::class_field_through_function_parameter::new();
     check_local_nodes(&graph, "main.py", &[]);
-    check_local_nodes(
-        &graph,
-        "a.py",
-        &[
-            "[a.py(8) reference x]", //
-        ],
-    );
+    check_local_nodes(&graph, "a.py", &[]);
     check_local_nodes(&graph, "b.py", &[]);
 }
 

--- a/stack-graphs/tests/it/can_find_node_partial_paths_in_database.rs
+++ b/stack-graphs/tests/it/can_find_node_partial_paths_in_database.rs
@@ -55,14 +55,18 @@ fn class_field_through_function_parameter() {
         &mut graph,
         ("main.py", 10),
         &[
-            "<%1> () [main.py(10) reference bar] -> [root] <a.foo()/([main.py(7)]).bar,%1> ()",
-            "<%1> () [main.py(10) reference bar] -> [root] <b.foo()/([main.py(7)]).bar,%1> ()",
+            "<%1> ($1) [main.py(10) reference bar] -> [root] <a.foo()/([main.py(7)],$1).bar,%1> ($1)",
+            "<%1> ($1) [main.py(10) reference bar] -> [root] <b.foo()/([main.py(7)],$1).bar,%1> ($1)",
         ],
     );
     check_node_partial_paths(
         &mut graph,
         ("a.py", 8),
-        &["<%1> () [a.py(8) reference x] -> [a.py(14) definition x] <%1> ()"],
+        &[
+            "<%1> ($1) [a.py(8) reference x] -> [a.py(14) definition x] <%1> ()",
+            "<%1> ($1) [a.py(8) reference x] -> [jump to scope] <0,%1> ($1)",
+            "<%1> ($1) [a.py(8) reference x] -> [jump to scope] <x,%1> ($1)",
+        ],
     );
     // no references in b.py
 }
@@ -73,17 +77,17 @@ fn cyclic_imports_python() {
     check_node_partial_paths(
         &mut graph,
         ("main.py", 6),
-        &["<%1> () [main.py(6) reference foo] -> [root] <a.foo,%1> ()"],
+        &["<%1> ($1) [main.py(6) reference foo] -> [root] <a.foo,%1> ($1)"],
     );
     check_node_partial_paths(
         &mut graph,
         ("a.py", 6),
-        &["<%1> () [a.py(6) reference b] -> [root] <b,%1> ()"],
+        &["<%1> ($1) [a.py(6) reference b] -> [root] <b,%1> ($1)"],
     );
     check_node_partial_paths(
         &mut graph,
         ("b.py", 8),
-        &["<%1> () [b.py(8) reference a] -> [root] <a,%1> ()"],
+        &["<%1> ($1) [b.py(8) reference a] -> [root] <a,%1> ($1)"],
     );
 }
 
@@ -94,14 +98,14 @@ fn cyclic_imports_rust() {
         &mut graph,
         ("test.rs", 101),
         &[
-            "<%1> () [test.rs(101) reference FOO] -> [test.rs(204) definition BAR] <%1> ()",
-            "<%1> () [test.rs(101) reference FOO] -> [test.rs(304) definition FOO] <%1> ()",
+            "<%1> ($1) [test.rs(101) reference FOO] -> [test.rs(204) definition BAR] <%1> ($1)",
+            "<%1> ($1) [test.rs(101) reference FOO] -> [test.rs(304) definition FOO] <%1> ($1)",
         ],
     );
     check_node_partial_paths(
         &mut graph,
         ("test.rs", 305),
-        &["<%1> () [test.rs(305) reference BAR] -> [test.rs(204) definition BAR] <%1> ()"],
+        &["<%1> ($1) [test.rs(305) reference BAR] -> [test.rs(204) definition BAR] <%1> ($1)"],
     );
 }
 
@@ -111,12 +115,12 @@ fn sequenced_import_star() {
     check_node_partial_paths(
         &mut graph,
         ("main.py", 6),
-        &["<%1> () [main.py(6) reference foo] -> [root] <a.foo,%1> ()"],
+        &["<%1> ($1) [main.py(6) reference foo] -> [root] <a.foo,%1> ($1)"],
     );
     check_node_partial_paths(
         &mut graph,
         ("a.py", 6),
-        &["<%1> () [a.py(6) reference b] -> [root] <b,%1> ()"],
+        &["<%1> ($1) [a.py(6) reference b] -> [root] <b,%1> ($1)"],
     );
     // no references in b.py
 }

--- a/stack-graphs/tests/it/can_find_partial_paths_in_file.rs
+++ b/stack-graphs/tests/it/can_find_partial_paths_in_file.rs
@@ -40,20 +40,20 @@ fn class_field_through_function_parameter() {
             // definition of `__main__` module
             "<__main__,%1> ($1) [root] -> [main.py(0) definition __main__] <%1> ($1)",
             // reference to `a` in import statement
-            "<%1> () [main.py(17) reference a] -> [root] <a,%1> ()",
+            "<%1> ($1) [main.py(17) reference a] -> [root] <a,%1> ($1)",
             // `from a import *` means we can rewrite any lookup of `__main__.*` → `a.*`
             "<__main__.,%1> ($1) [root] -> [root] <a.,%1> ($1)",
             // reference to `b` in import statement
-            "<%1> () [main.py(15) reference b] -> [root] <b,%1> ()",
+            "<%1> ($1) [main.py(15) reference b] -> [root] <b,%1> ($1)",
             // `from b import *` means we can rewrite any lookup of `__main__.*` → `b.*`
             "<__main__.,%1> ($1) [root] -> [root] <b.,%1> ($1)",
             // we can look for every reference in either `a` or `b`
-            "<%1> () [main.py(9) reference A] -> [root] <a.A,%1> ()",
-            "<%1> () [main.py(9) reference A] -> [root] <b.A,%1> ()",
-            "<%1> () [main.py(10) reference bar] -> [root] <a.foo()/([main.py(7)]).bar,%1> ()",
-            "<%1> () [main.py(10) reference bar] -> [root] <b.foo()/([main.py(7)]).bar,%1> ()",
-            "<%1> () [main.py(13) reference foo] -> [root] <a.foo,%1> ()",
-            "<%1> () [main.py(13) reference foo] -> [root] <b.foo,%1> ()",
+            "<%1> ($1) [main.py(9) reference A] -> [root] <a.A,%1> ($1)",
+            "<%1> ($1) [main.py(9) reference A] -> [root] <b.A,%1> ($1)",
+            "<%1> ($1) [main.py(10) reference bar] -> [root] <a.foo()/([main.py(7)],$1).bar,%1> ($1)",
+            "<%1> ($1) [main.py(10) reference bar] -> [root] <b.foo()/([main.py(7)],$1).bar,%1> ($1)",
+            "<%1> ($1) [main.py(13) reference foo] -> [root] <a.foo,%1> ($1)",
+            "<%1> ($1) [main.py(13) reference foo] -> [root] <b.foo,%1> ($1)",
             // parameter 0 of function call is `A`, which we can look up in either `a` or `b`
             "<0,%1> ($1) [main.py(7) exported scope] -> [root] <a.A,%1> ($1)",
             "<0,%1> ($1) [main.py(7) exported scope] -> [root] <b.A,%1> ($1)",
@@ -67,8 +67,12 @@ fn class_field_through_function_parameter() {
             "<a,%1> ($1) [root] -> [a.py(0) definition a] <%1> ($1)",
             // definition of `foo` function
             "<a.foo,%1> ($1) [root] -> [a.py(5) definition foo] <%1> ($1)",
-            // reference to `x` in function body can resolve to formal parameter
-            "<%1> () [a.py(8) reference x] -> [a.py(14) definition x] <%1> ()",
+            // reference to `x` in function body can resolve to formal parameter, which might get formal parameters...
+            "<%1> ($1) [a.py(8) reference x] -> [a.py(14) definition x] <%1> ()",
+            // ...which we can look up either the 0th actual positional parameter...
+            "<%1> ($1) [a.py(8) reference x] -> [jump to scope] <0,%1> ($1)",
+            // ...or the actual named parameter `x`
+            "<%1> ($1) [a.py(8) reference x] -> [jump to scope] <x,%1> ($1)",
             // result of function is `x`, which is passed in as a formal parameter...
             "<a.foo()/($2),%1> ($1) [root] -> [a.py(14) definition x] <%1> ()",
             // ...which we can look up either the 0th actual positional parameter...
@@ -103,11 +107,11 @@ fn cyclic_imports_python() {
             // definition of `__main__` module
             "<__main__,%1> ($1) [root] -> [main.py(0) definition __main__] <%1> ($1)",
             // reference to `a` in import statement
-            "<%1> () [main.py(8) reference a] -> [root] <a,%1> ()",
+            "<%1> ($1) [main.py(8) reference a] -> [root] <a,%1> ($1)",
             // `from a import *` means we can rewrite any lookup of `__main__.*` → `a.*`
             "<__main__.,%1> ($1) [root] -> [root] <a.,%1> ($1)",
             // reference to `foo` becomes `a.foo` because of import statement
-            "<%1> () [main.py(6) reference foo] -> [root] <a.foo,%1> ()",
+            "<%1> ($1) [main.py(6) reference foo] -> [root] <a.foo,%1> ($1)",
         ],
     );
     check_partial_paths_in_file(
@@ -117,7 +121,7 @@ fn cyclic_imports_python() {
             // definition of `a` module
             "<a,%1> ($1) [root] -> [a.py(0) definition a] <%1> ($1)",
             // reference to `b` in import statement
-            "<%1> () [a.py(6) reference b] -> [root] <b,%1> ()",
+            "<%1> ($1) [a.py(6) reference b] -> [root] <b,%1> ($1)",
             // `from b import *` means we can rewrite any lookup of `a.*` → `b.*`
             "<a.,%1> ($1) [root] -> [root] <b.,%1> ($1)",
         ],
@@ -129,7 +133,7 @@ fn cyclic_imports_python() {
             // definition of `b` module
             "<b,%1> ($1) [root] -> [b.py(0) definition b] <%1> ($1)",
             // reference to `a` in import statement
-            "<%1> () [b.py(8) reference a] -> [root] <a,%1> ()",
+            "<%1> ($1) [b.py(8) reference a] -> [root] <a,%1> ($1)",
             // `from a import *` means we can rewrite any lookup of `b.*` → `a.*`
             "<b.,%1> ($1) [root] -> [root] <a.,%1> ($1)",
             // definition of `foo`
@@ -148,16 +152,16 @@ fn cyclic_imports_rust() {
         // paths involving the root node.
         &[
             // reference to `a` in `main` function
-            "<%1> () [test.rs(103) reference a] -> [test.rs(201) definition a] <%1> ()",
+            "<%1> ($1) [test.rs(103) reference a] -> [test.rs(201) definition a] <%1> ($1)",
             // reference to `a` in `b` function
-            "<%1> () [test.rs(307) reference a] -> [test.rs(201) definition a] <%1> ()",
+            "<%1> ($1) [test.rs(307) reference a] -> [test.rs(201) definition a] <%1> ($1)",
             // reference to `b` in `a` function
-            "<%1> () [test.rs(206) reference b] -> [test.rs(301) definition b] <%1> ()",
+            "<%1> ($1) [test.rs(206) reference b] -> [test.rs(301) definition b] <%1> ($1)",
             // reference to `FOO` in `main` can resolve either to `a::BAR` or `b::FOO`
-            "<%1> () [test.rs(101) reference FOO] -> [test.rs(204) definition BAR] <%1> ()",
-            "<%1> () [test.rs(101) reference FOO] -> [test.rs(304) definition FOO] <%1> ()",
+            "<%1> ($1) [test.rs(101) reference FOO] -> [test.rs(204) definition BAR] <%1> ($1)",
+            "<%1> ($1) [test.rs(101) reference FOO] -> [test.rs(304) definition FOO] <%1> ($1)",
             // reference to `BAR` in `b` resolves _only_ to `a::BAR`
-            "<%1> () [test.rs(305) reference BAR] -> [test.rs(204) definition BAR] <%1> ()",
+            "<%1> ($1) [test.rs(305) reference BAR] -> [test.rs(204) definition BAR] <%1> ($1)",
         ],
     );
 }
@@ -172,11 +176,11 @@ fn sequenced_import_star() {
             // definition of `__main__` module
             "<__main__,%1> ($1) [root] -> [main.py(0) definition __main__] <%1> ($1)",
             // reference to `a` in import statement
-            "<%1> () [main.py(8) reference a] -> [root] <a,%1> ()",
+            "<%1> ($1) [main.py(8) reference a] -> [root] <a,%1> ($1)",
             // `from a import *` means we can rewrite any lookup of `__main__.*` → `a.*`
             "<__main__.,%1> ($1) [root] -> [root] <a.,%1> ($1)",
             // reference to `foo` becomes `a.foo` because of import statement
-            "<%1> () [main.py(6) reference foo] -> [root] <a.foo,%1> ()",
+            "<%1> ($1) [main.py(6) reference foo] -> [root] <a.foo,%1> ($1)",
         ],
     );
     check_partial_paths_in_file(
@@ -186,7 +190,7 @@ fn sequenced_import_star() {
             // definition of `a` module
             "<a,%1> ($1) [root] -> [a.py(0) definition a] <%1> ($1)",
             // reference to `b` in import statement
-            "<%1> () [a.py(6) reference b] -> [root] <b,%1> ()",
+            "<%1> ($1) [a.py(6) reference b] -> [root] <b,%1> ($1)",
             // `from b import *` means we can rewrite any lookup of `a.*` → `b.*`
             "<a.,%1> ($1) [root] -> [root] <b.,%1> ($1)",
         ],

--- a/stack-graphs/tests/it/can_jump_to_definition_with_forward_partial_path_stitching.rs
+++ b/stack-graphs/tests/it/can_jump_to_definition_with_forward_partial_path_stitching.rs
@@ -64,17 +64,17 @@ fn class_field_through_function_parameter() {
         &graph,
         &[
             // reference to `a` in import statement
-            "<%1> () [main.py(17) reference a] -> [a.py(0) definition a] <%1> ()",
+            "<%1> ($1) [main.py(17) reference a] -> [a.py(0) definition a] <%1> ($1)",
             // reference to `b` in import statement
-            "<%1> () [main.py(15) reference b] -> [b.py(0) definition b] <%1> ()",
+            "<%1> ($1) [main.py(15) reference b] -> [b.py(0) definition b] <%1> ($1)",
             // reference to `foo` in function call resolves to function definition
-            "<%1> () [main.py(13) reference foo] -> [a.py(5) definition foo] <%1> ()",
+            "<%1> ($1) [main.py(13) reference foo] -> [a.py(5) definition foo] <%1> ($1)",
             // reference to `A` as function parameter resolves to class definition
-            "<%1> () [main.py(9) reference A] -> [b.py(5) definition A] <%1> ()",
+            "<%1> ($1) [main.py(9) reference A] -> [b.py(5) definition A] <%1> ($1)",
             // reference to `bar` on result flows through body of `foo` to find `A.bar`
-            "<%1> () [main.py(10) reference bar] -> [b.py(8) definition bar] <%1> ()",
+            "<%1> ($1) [main.py(10) reference bar] -> [b.py(8) definition bar] <%1> ($1)",
             // reference to `x` in function body resolves to formal parameter
-            "<%1> () [a.py(8) reference x] -> [a.py(14) definition x] <%1> ()",
+            "<%1> ($1) [a.py(8) reference x] -> [a.py(14) definition x] <%1> ()",
         ],
     );
 }
@@ -86,13 +86,13 @@ fn cyclic_imports_python() {
         &graph,
         &[
             // reference to `a` in import statement
-            "<%1> () [main.py(8) reference a] -> [a.py(0) definition a] <%1> ()",
+            "<%1> ($1) [main.py(8) reference a] -> [a.py(0) definition a] <%1> ($1)",
             // reference to `foo` resolves through intermediate file to find `b.foo`
-            "<%1> () [main.py(6) reference foo] -> [b.py(6) definition foo] <%1> ()",
+            "<%1> ($1) [main.py(6) reference foo] -> [b.py(6) definition foo] <%1> ($1)",
             // reference to `b` in import statement
-            "<%1> () [a.py(6) reference b] -> [b.py(0) definition b] <%1> ()",
+            "<%1> ($1) [a.py(6) reference b] -> [b.py(0) definition b] <%1> ($1)",
             // reference to `a` in import statement
-            "<%1> () [b.py(8) reference a] -> [a.py(0) definition a] <%1> ()",
+            "<%1> ($1) [b.py(8) reference a] -> [a.py(0) definition a] <%1> ($1)",
         ],
     );
 }
@@ -104,16 +104,16 @@ fn cyclic_imports_rust() {
         &graph,
         &[
             // reference to `a` in `a::FOO` resolves to module definition
-            "<%1> () [test.rs(103) reference a] -> [test.rs(201) definition a] <%1> ()",
+            "<%1> ($1) [test.rs(103) reference a] -> [test.rs(201) definition a] <%1> ($1)",
             // reference to `a::FOO` in `main` can resolve either to `a::BAR` or `b::FOO`
-            "<%1> () [test.rs(101) reference FOO] -> [test.rs(304) definition FOO] <%1> ()",
-            "<%1> () [test.rs(101) reference FOO] -> [test.rs(204) definition BAR] <%1> ()",
+            "<%1> ($1) [test.rs(101) reference FOO] -> [test.rs(304) definition FOO] <%1> ($1)",
+            "<%1> ($1) [test.rs(101) reference FOO] -> [test.rs(204) definition BAR] <%1> ($1)",
             // reference to `b` in use statement resolves to module definition
-            "<%1> () [test.rs(206) reference b] -> [test.rs(301) definition b] <%1> ()",
+            "<%1> ($1) [test.rs(206) reference b] -> [test.rs(301) definition b] <%1> ($1)",
             // reference to `a` in use statement resolves to module definition
-            "<%1> () [test.rs(307) reference a] -> [test.rs(201) definition a] <%1> ()",
+            "<%1> ($1) [test.rs(307) reference a] -> [test.rs(201) definition a] <%1> ($1)",
             // reference to `BAR` in module `b` can _only_ resolve to `a::BAR`
-            "<%1> () [test.rs(305) reference BAR] -> [test.rs(204) definition BAR] <%1> ()",
+            "<%1> ($1) [test.rs(305) reference BAR] -> [test.rs(204) definition BAR] <%1> ($1)",
         ],
     );
 }
@@ -125,11 +125,11 @@ fn sequenced_import_star() {
         &graph,
         &[
             // reference to `a` in import statement
-            "<%1> () [main.py(8) reference a] -> [a.py(0) definition a] <%1> ()",
+            "<%1> ($1) [main.py(8) reference a] -> [a.py(0) definition a] <%1> ($1)",
             // reference to `foo` resolves through intermediate file to find `b.foo`
-            "<%1> () [main.py(6) reference foo] -> [b.py(5) definition foo] <%1> ()",
+            "<%1> ($1) [main.py(6) reference foo] -> [b.py(5) definition foo] <%1> ($1)",
             // reference to `b` in import statement
-            "<%1> () [a.py(6) reference b] -> [b.py(0) definition b] <%1> ()",
+            "<%1> ($1) [a.py(6) reference b] -> [b.py(0) definition b] <%1> ($1)",
         ],
     );
 }

--- a/stack-graphs/tests/it/partial.rs
+++ b/stack-graphs/tests/it/partial.rs
@@ -7,6 +7,7 @@
 
 use controlled_option::ControlledOption;
 use stack_graphs::arena::Handle;
+use stack_graphs::graph::Edge;
 use stack_graphs::graph::Node;
 use stack_graphs::graph::NodeID;
 use stack_graphs::graph::StackGraph;
@@ -26,6 +27,7 @@ use stack_graphs::stitching::Database;
 type NiceSymbolStack<'a> = (&'a [NiceScopedSymbol<'a>], Option<SymbolStackVariable>);
 type NiceScopedSymbol<'a> = (&'a str, Option<NiceScopeStack<'a>>);
 type NiceScopeStack<'a> = (&'a [u32], Option<ScopeStackVariable>);
+type NicePartialPath<'a> = &'a [Handle<Node>];
 
 fn create_symbol_stack(
     graph: &mut StackGraph,
@@ -562,4 +564,180 @@ fn can_create_partial_path_from_node() {
         scope_node,
         "<%1> ($1) [test(5) scope] -> [test(5) scope] <%1> ($1)",
     );
+}
+
+#[test]
+fn can_concatenate_partial_paths() -> Result<(), PathResolutionError> {
+    let mut graph = StackGraph::new();
+    let file = graph.add_file("test").expect("");
+
+    let scope0_id = graph.new_node_id(file);
+    let scope0 = graph.add_scope_node(scope0_id, false).unwrap();
+
+    let scope1_id = graph.new_node_id(file);
+    let scope1 = graph.add_scope_node(scope1_id, false).unwrap();
+
+    let foo = graph.add_symbol("foo");
+    let foo_ref_id = graph.new_node_id(file);
+    let foo_ref = graph.add_push_symbol_node(foo_ref_id, foo, false).unwrap();
+    let foo_def_id = graph.new_node_id(file);
+    let foo_def = graph.add_pop_symbol_node(foo_def_id, foo, false).unwrap();
+
+    let bar = graph.add_symbol("bar");
+    let bar_ref_id = graph.new_node_id(file);
+    let bar_ref = graph.add_push_symbol_node(bar_ref_id, bar, false).unwrap();
+    let bar_def_id = graph.new_node_id(file);
+    let bar_def = graph.add_pop_symbol_node(bar_def_id, bar, false).unwrap();
+
+    let exported_scope_id = graph.new_node_id(file);
+    graph.add_scope_node(exported_scope_id, true);
+    let baz = graph.add_symbol("baz");
+    let baz_ref_id = graph.new_node_id(file);
+    let baz_ref = graph
+        .add_push_scoped_symbol_node(baz_ref_id, baz, exported_scope_id, false)
+        .unwrap();
+    let baz_def_id = graph.new_node_id(file);
+    let baz_def = graph
+        .add_pop_scoped_symbol_node(baz_def_id, baz, false)
+        .unwrap();
+
+    let drop_scopes_id = graph.new_node_id(file);
+    let drop_scopes = graph.add_drop_scopes_node(drop_scopes_id).unwrap();
+
+    fn run(
+        graph: &StackGraph,
+        left: NicePartialPath,
+        right: NicePartialPath,
+        expected: &str,
+    ) -> Result<(), PathResolutionError> {
+        let mut g = StackGraph::new();
+        g.add_from_graph(graph).expect("");
+
+        let mut ps = PartialPaths::new();
+
+        let mut lns = left.iter();
+        let mut prev = lns.next().unwrap();
+        let mut l = PartialPath::from_node(&g, &mut ps, *prev);
+        for next in lns {
+            g.add_edge(*prev, *next, 0);
+            l.append(
+                &g,
+                &mut ps,
+                Edge {
+                    source: *prev,
+                    sink: *next,
+                    precedence: 0,
+                },
+            )
+            .expect("");
+            prev = next;
+        }
+
+        let mut rns = right.iter();
+        let mut prev = rns.next().unwrap();
+        let mut r = PartialPath::from_node(&g, &mut ps, *prev);
+        for next in rns {
+            g.add_edge(*prev, *next, 0);
+            r.append(
+                &g,
+                &mut ps,
+                Edge {
+                    source: *prev,
+                    sink: *next,
+                    precedence: 0,
+                },
+            )
+            .expect("");
+            prev = next;
+        }
+
+        r.ensure_no_overlapping_variables(&mut ps, &l);
+        l.concatenate(&g, &mut ps, &r)?;
+        let actual = l.display(&g, &mut ps).to_string();
+        assert_eq!(actual, expected);
+
+        Ok(())
+    }
+
+    fn verify(graph: &StackGraph, left: NicePartialPath, right: NicePartialPath, expected: &str) {
+        run(graph, left, right, expected).expect("");
+    }
+
+    fn verify_not(graph: &StackGraph, left: NicePartialPath, right: NicePartialPath) {
+        run(graph, left, right, "").expect_err("");
+    }
+
+    verify(
+        &graph,
+        &[scope0],
+        &[scope0],
+        "<%1> ($1) [test(0) scope] -> [test(0) scope] <%1> ($1)",
+    );
+
+    verify_not(&graph, &[scope0], &[scope1]);
+
+    verify(
+        &graph,
+        &[foo_ref, scope0],
+        &[scope0, foo_def],
+        "<%1> ($1) [test(2) push foo] -> [test(3) pop foo] <%1> ($1)",
+    );
+
+    verify(
+        &graph,
+        &[foo_ref, scope0],
+        &[scope0, scope1],
+        "<%1> ($1) [test(2) push foo] -> [test(1) scope] <foo,%1> ($1)",
+    );
+
+    verify(
+        &graph,
+        &[scope0, scope1],
+        &[scope1, foo_ref],
+        "<%1> ($1) [test(0) scope] -> [test(2) push foo] <foo,%1> ($1)",
+    );
+
+    verify(
+        &graph,
+        &[foo_def, scope0],
+        &[scope0, bar_ref],
+        "<foo,%1> ($1) [test(3) pop foo] -> [test(4) push bar] <bar,%1> ($1)",
+    );
+
+    verify(
+        &graph,
+        &[foo_ref, scope0, foo_def],
+        &[foo_def, scope1, bar_ref],
+        "<%1> ($1) [test(2) push foo] -> [test(4) push bar] <bar,%1> ($1)",
+    );
+
+    verify(
+        &graph,
+        &[foo_def, scope0, bar_ref],
+        &[bar_ref, scope1, bar_def],
+        "<foo,%1> ($1) [test(3) pop foo] -> [test(5) pop bar] <%1> ($1)",
+    );
+
+    verify(
+        &graph,
+        &[baz_ref, scope0, baz_def],
+        &[baz_def, scope1, bar_ref],
+        "<%1> ($1) [test(7) push scoped baz test(6)] -> [test(4) push bar] <bar,%1> ([test(6)],$1)",
+    );
+
+    verify(
+        &graph,
+        &[foo_def, scope0, baz_ref],
+        &[baz_ref, scope1, baz_def],
+        "<foo,%1> ($1) [test(3) pop foo] -> [test(8) pop scoped baz] <%1> ([test(6)],$1)",
+    );
+
+    verify(
+        &graph,
+        &[scope0, drop_scopes],
+        &[drop_scopes, scope1],
+        "<%1> ($1) [test(0) scope] -> [test(1) scope] <%1> ()",
+    );
+
+    Ok(())
 }

--- a/stack-graphs/tests/it/partial.rs
+++ b/stack-graphs/tests/it/partial.rs
@@ -571,6 +571,8 @@ fn can_concatenate_partial_paths() -> Result<(), PathResolutionError> {
     let mut graph = StackGraph::new();
     let file = graph.add_file("test").expect("");
 
+    let jump_to_scope_node = StackGraph::jump_to_node();
+
     let scope0_id = graph.new_node_id(file);
     let scope0 = graph.add_scope_node(scope0_id, false).unwrap();
 
@@ -737,6 +739,26 @@ fn can_concatenate_partial_paths() -> Result<(), PathResolutionError> {
         &[scope0, drop_scopes],
         &[drop_scopes, scope1],
         "<%1> ($1) [test(0) scope] -> [test(1) scope] <%1> ()",
+    );
+
+    verify_not(
+        &graph,
+        &[scope0, drop_scopes, scope1],
+        &[scope1, jump_to_scope_node],
+    );
+
+    verify(
+        &graph,
+        &[baz_def, scope0],
+        &[scope0, jump_to_scope_node],
+        "<baz/($2),%1> ($1) [test(8) pop scoped baz] -> [jump to scope] <%1> ($2)",
+    );
+
+    verify(
+        &graph,
+        &[baz_ref, scope0],
+        &[scope0, jump_to_scope_node],
+        "<%1> ($1) [test(7) push scoped baz test(6)] -> [jump to scope] <baz/([test(6)],$1),%1> ($1)",
     );
 
     Ok(())


### PR DESCRIPTION
Partial path code is incomplete or broken in several ways:
1. Lifting nodes to partial paths was incorrect for several node types
2. Path concatenation is incorrect for certain connecting nodes (the node shared between left & right)

This PR fixes these and adds test as well.

Re 1. I've addressed this be refactoring the existing code for `PartialPath::append` so that the logic to apply a node to a set of pre- and postcondition stacks can be used independently of a partial path as well. The `PartialPath::from_node` now creates some default stack sand simply uses that logic. This also reduces some duplication that existed between `from_node` and `append`.

Re 2. This was a fun one, that surfaced when I experimented with different partial path finding strategies. I noticed that stitching partial paths that joined on a pop or push node didn't work correctly. The reason was these operate on the stack, and the effect of the stack operation was reflected both in the postcondition and the precondition. I've added code that undoes the effect on one of the paths being joined.

Additionally all methods that extend paths (such as `append` or `concatentate`) now call resolve as part of the extension. In other words, extension will fail if resolving is not possible. `resolve` was already called right after paths were extended in most places, but it is easy to forget and there didn't seem to be cases where extending a path without attempting to resolve it made sense.

## Prerequisites

- [x] #174
- [x] #176
- [ ] #183