### PR TITLE
Generate Cargo projects with `init`

### DIFF
--- a/languages/tree-sitter-stack-graphs-typescript/README.md
+++ b/languages/tree-sitter-stack-graphs-typescript/README.md
@@ -42,6 +42,8 @@ The project is organized as follows:
 - Builtins sources and configuration are defined in `src/builtins.ts` and `builtins.cfg` respectively.
 - Tests are put into the `test` directory.
 
+### Building and Running Tests
+
 Build the project by running:
 
 ``` sh
@@ -70,10 +72,15 @@ Sources are formatted using the standard Rust formatted, which is applied by run
 $ cargo fmt
 ```
 
-The stack graph rules are written in [tree-sitter-graph][], which provides a VSCode
-extension for syntax highlighting.
+### Writing TSG
+
+The stack graph rules are written in [tree-sitter-graph][]. Checkout the [examples][],
+which contain self-contained TSG rules for specific language features. A VSCode
+[extension][] is available that provides syntax highlighting for TSG files.
 
 [tree-sitter-graph]: https://github.com/tree-sitter/tree-sitter-graph
+[examples]: https://github.com/github/stack-graphs/blob/main/tree-sitter-stack-graphs/examples/
+[extension]: https://marketplace.visualstudio.com/items?itemName=tree-sitter.tree-sitter-graph
 
 Parse and test a single file by executing the following commands:
 
@@ -82,8 +89,7 @@ $ cargo run --features cli -- parse FILES...
 $ cargo run --features cli -- test TESTFILES...
 ```
 
-Additional flags can be passed to these commands as well. For example, to generate
-a visualization for the test, execute:
+Generate a visualization to debug failing tests by passing the `-V` flag:
 
 ``` sh
 $ cargo run --features cli -- test -V TESTFILES...

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -45,9 +45,9 @@ dialoguer = { version = "0.10", optional = true }
 env_logger = { version = "0.9", optional = true }
 indoc = { version = "1.0", optional = true }
 itertools = "0.10"
-lazy_static = "1.4"
 log = "0.4"
 lsp-positions = { version="0.3", path="../lsp-positions" }
+once_cell = "1"
 pathdiff = { version = "0.2.1", optional = true }
 regex = "1"
 rust-ini = "0.18"

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -22,10 +22,22 @@ name = "tree-sitter-stack-graphs"
 required-features = ["cli"]
 
 [features]
-cli = ["clap", "colored", "dialoguer", "env_logger", "indoc", "pathdiff", "stack-graphs/json", "tree-sitter-config", "walkdir"]
+cli = [
+  "chrono",
+  "clap",
+  "colored",
+  "dialoguer",
+  "env_logger",
+  "indoc",
+  "pathdiff",
+  "stack-graphs/json",
+  "tree-sitter-config",
+  "walkdir"
+]
 
 [dependencies]
 anyhow = "1.0"
+chrono = { version = "0.4", optional = true }
 clap = { version = "3", optional = true, features=["derive"] }
 colored = { version = "2.0", optional = true }
 controlled-option = ">=0.4"

--- a/tree-sitter-stack-graphs/README.md
+++ b/tree-sitter-stack-graphs/README.md
@@ -39,7 +39,22 @@ Alternatively, the program can be invoked via NPM as follows:
 $ npx tree-sitter-stack-graphs
 ```
 
-Check out our [examples](https://github.com/github/stack-graphs/blob/main/tree-sitter-stack-graphs/examples/) for more details on how to work with the CLI.
+## Getting Started
+
+Starting a new project to develop stack graph definitions for your favourite language
+is as easy as running the `init` command:
+
+``` sh
+$ tree-sitter-stack-graphs init PROJECT_DIR
+```
+
+Answer the questions to provide information about the language, the grammar dependency, and
+the project and hit `Generate` to generate the new project. Check out `PROJECT_DIR/README.md`
+to find out how to start developing.
+
+Also check out our [examples][] for more details on how to work with the CLI.
+
+[examples]: https://github.com/github/stack-graphs/blob/main/tree-sitter-stack-graphs/examples/
 
 ## Development
 

--- a/tree-sitter-stack-graphs/src/cli/init.rs
+++ b/tree-sitter-stack-graphs/src/cli/init.rs
@@ -14,7 +14,7 @@ use dialoguer::Select;
 use dialoguer::Validator;
 use indoc::printdoc;
 use indoc::writedoc;
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use regex::Regex;
 use std::fs;
 use std::fs::File;
@@ -31,12 +31,12 @@ mod license;
 
 const TSSG_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-lazy_static! {
-    static ref VALID_CRATE_NAME: Regex = Regex::new(r"^[a-zA-Z_-][a-zA-Z0-9_-]*$").unwrap();
-    static ref VALID_CRATE_VERSION: Regex = Regex::new(r"^[0-9]+\.[0-9]+\.[0-9]+$").unwrap();
-    static ref VALID_DEPENDENCY_VERSION: Regex =
-        Regex::new(r"^[~^]?[0-9]+(\.[0-9]+(\.[0-9]+)?)?$").unwrap();
-}
+static VALID_CRATE_NAME: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^[a-zA-Z_-][a-zA-Z0-9_-]*$").unwrap());
+static VALID_CRATE_VERSION: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^[0-9]+\.[0-9]+\.[0-9]+$").unwrap());
+static VALID_DEPENDENCY_VERSION: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^[~^]?[0-9]+(\.[0-9]+(\.[0-9]+)?)?$").unwrap());
 
 /// Initialize project
 #[derive(Args)]

--- a/tree-sitter-stack-graphs/src/cli/init.rs
+++ b/tree-sitter-stack-graphs/src/cli/init.rs
@@ -308,12 +308,13 @@ impl ProjectSettings {
 
             [rustup]: https://rustup.rs/
 
-
             The project is organized as follows:
 
             - The stack graph rules are defined in `src/stack-graphs.tsg`.
             - Builtins sources and configuration are defined in `src/builtins.{}` and `builtins.cfg` respectively.
             - Tests are put into the `test` directory.
+
+            ### Building and Running Tests
 
             Build the project by running:
 
@@ -341,9 +342,15 @@ impl ProjectSettings {
             $ cargo fmt
             ```
 
-            The stack graph rules are written in [tree-sitter-graph][], which provides a VSCode extension for syntax highlighting.
+            ### Writing TSG
+
+            The stack graph rules are written in [tree-sitter-graph][]. Checkout the [examples][],
+            which contain self-contained TSG rules for specific language features. A VSCode
+            [extension][] is available that provides syntax highlighting for TSG files.
 
             [tree-sitter-graph]: https://github.com/tree-sitter/tree-sitter-graph
+            [examples]: https://github.com/github/stack-graphs/blob/main/tree-sitter-stack-graphs/examples/
+            [extension]: https://marketplace.visualstudio.com/items?itemName=tree-sitter.tree-sitter-graph
 
             Parse and test a single file by executing the following commands:
 
@@ -352,7 +359,7 @@ impl ProjectSettings {
             $ cargo run --features cli -- test TESTFILES...
             ```
 
-            Additional flags can be passed to these commands as well. For example, to generate a visualization for the test, execute:
+            Generate a visualization to debug failing tests by passing the `-V` flag:
 
             ``` sh
             $ cargo run --features cli -- test -V TESTFILES...

--- a/tree-sitter-stack-graphs/src/cli/init/license.rs
+++ b/tree-sitter-stack-graphs/src/cli/init/license.rs
@@ -1,0 +1,389 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2023, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use indoc::writedoc;
+use std::fs::File;
+use std::io::Write;
+
+pub type WriteLicenseHeader = fn(&mut File, i32, &str, &str) -> std::io::Result<()>;
+pub type WriteLicenseText = fn(&mut File, i32, &str) -> std::io::Result<()>;
+
+pub const DEFAULT_LICENSES: &[(&str, WriteLicenseHeader, WriteLicenseText)] = &[
+    ("APACHE-2.0", write_apache2_header, write_apache2_text),
+    ("BSD-2-Clause", write_empty_header, write_bsd2_text),
+    ("BSD-3-Clause", write_empty_header, write_bsd3_text),
+    ("ISC", write_empty_header, write_isc_text),
+    ("MIT", write_empty_header, write_mit_text),
+];
+pub const OTHER_LICENSE: usize = DEFAULT_LICENSES.len();
+pub const NO_LICENSE: usize = OTHER_LICENSE + 1;
+
+// Return an index into DEFAULT_LICENSES, OTHER_LICENSE, or NO_LICENSE.
+pub fn lookup_license(name: &str) -> usize {
+    DEFAULT_LICENSES
+        .iter()
+        .position(|l| l.0 == name)
+        .unwrap_or_else(|| {
+            if name.is_empty() {
+                NO_LICENSE
+            } else {
+                OTHER_LICENSE
+            }
+        })
+}
+
+fn write_empty_header(
+    _file: &mut File,
+    _year: i32,
+    _author: &str,
+    _prefix: &str,
+) -> std::io::Result<()> {
+    Ok(())
+}
+
+fn write_apache2_header(
+    file: &mut File,
+    year: i32,
+    author: &str,
+    prefix: &str,
+) -> std::io::Result<()> {
+    writedoc! {file, r####"
+        {}Copyright {} {}
+        {}
+        {}Licensed under the Apache License, Version 2.0 (the "License");
+        {}you may not use this file except in compliance with the License.
+        {}You may obtain a copy of the License at
+        {}
+        {}    http://www.apache.org/licenses/LICENSE-2.0
+        {}
+        {}Unless required by applicable law or agreed to in writing, software
+        {}distributed under the License is distributed on an "AS IS" BASIS,
+        {}WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        {}See the License for the specific language governing permissions and
+        {}limitations under the License.
+
+        "####,
+        prefix, year, author,
+        prefix, prefix, prefix, prefix, prefix, prefix, prefix, prefix, prefix, prefix, prefix, prefix,
+    }
+}
+
+fn write_apache2_text(file: &mut File, _year: i32, _author: &str) -> std::io::Result<()> {
+    writedoc! {file, r####"
+
+                                      Apache License
+                                Version 2.0, January 2004
+                             http://www.apache.org/licenses/
+
+        TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+        1. Definitions.
+
+           "License" shall mean the terms and conditions for use, reproduction,
+           and distribution as defined by Sections 1 through 9 of this document.
+
+           "Licensor" shall mean the copyright owner or entity authorized by
+           the copyright owner that is granting the License.
+
+           "Legal Entity" shall mean the union of the acting entity and all
+           other entities that control, are controlled by, or are under common
+           control with that entity. For the purposes of this definition,
+           "control" means (i) the power, direct or indirect, to cause the
+           direction or management of such entity, whether by contract or
+           otherwise, or (ii) ownership of fifty percent (50%) or more of the
+           outstanding shares, or (iii) beneficial ownership of such entity.
+
+           "You" (or "Your") shall mean an individual or Legal Entity
+           exercising permissions granted by this License.
+
+           "Source" form shall mean the preferred form for making modifications,
+           including but not limited to software source code, documentation
+           source, and configuration files.
+
+           "Object" form shall mean any form resulting from mechanical
+           transformation or translation of a Source form, including but
+           not limited to compiled object code, generated documentation,
+           and conversions to other media types.
+
+           "Work" shall mean the work of authorship, whether in Source or
+           Object form, made available under the License, as indicated by a
+           copyright notice that is included in or attached to the work
+           (an example is provided in the Appendix below).
+
+           "Derivative Works" shall mean any work, whether in Source or Object
+           form, that is based on (or derived from) the Work and for which the
+           editorial revisions, annotations, elaborations, or other modifications
+           represent, as a whole, an original work of authorship. For the purposes
+           of this License, Derivative Works shall not include works that remain
+           separable from, or merely link (or bind by name) to the interfaces of,
+           the Work and Derivative Works thereof.
+
+           "Contribution" shall mean any work of authorship, including
+           the original version of the Work and any modifications or additions
+           to that Work or Derivative Works thereof, that is intentionally
+           submitted to Licensor for inclusion in the Work by the copyright owner
+           or by an individual or Legal Entity authorized to submit on behalf of
+           the copyright owner. For the purposes of this definition, "submitted"
+           means any form of electronic, verbal, or written communication sent
+           to the Licensor or its representatives, including but not limited to
+           communication on electronic mailing lists, source code control systems,
+           and issue tracking systems that are managed by, or on behalf of, the
+           Licensor for the purpose of discussing and improving the Work, but
+           excluding communication that is conspicuously marked or otherwise
+           designated in writing by the copyright owner as "Not a Contribution."
+
+           "Contributor" shall mean Licensor and any individual or Legal Entity
+           on behalf of whom a Contribution has been received by Licensor and
+           subsequently incorporated within the Work.
+
+        2. Grant of Copyright License. Subject to the terms and conditions of
+           this License, each Contributor hereby grants to You a perpetual,
+           worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+           copyright license to reproduce, prepare Derivative Works of,
+           publicly display, publicly perform, sublicense, and distribute the
+           Work and such Derivative Works in Source or Object form.
+
+        3. Grant of Patent License. Subject to the terms and conditions of
+           this License, each Contributor hereby grants to You a perpetual,
+           worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+           (except as stated in this section) patent license to make, have made,
+           use, offer to sell, sell, import, and otherwise transfer the Work,
+           where such license applies only to those patent claims licensable
+           by such Contributor that are necessarily infringed by their
+           Contribution(s) alone or by combination of their Contribution(s)
+           with the Work to which such Contribution(s) was submitted. If You
+           institute patent litigation against any entity (including a
+           cross-claim or counterclaim in a lawsuit) alleging that the Work
+           or a Contribution incorporated within the Work constitutes direct
+           or contributory patent infringement, then any patent licenses
+           granted to You under this License for that Work shall terminate
+           as of the date such litigation is filed.
+
+        4. Redistribution. You may reproduce and distribute copies of the
+           Work or Derivative Works thereof in any medium, with or without
+           modifications, and in Source or Object form, provided that You
+           meet the following conditions:
+
+           (a) You must give any other recipients of the Work or
+               Derivative Works a copy of this License; and
+
+           (b) You must cause any modified files to carry prominent notices
+               stating that You changed the files; and
+
+           (c) You must retain, in the Source form of any Derivative Works
+               that You distribute, all copyright, patent, trademark, and
+               attribution notices from the Source form of the Work,
+               excluding those notices that do not pertain to any part of
+               the Derivative Works; and
+
+           (d) If the Work includes a "NOTICE" text file as part of its
+               distribution, then any Derivative Works that You distribute must
+               include a readable copy of the attribution notices contained
+               within such NOTICE file, excluding those notices that do not
+               pertain to any part of the Derivative Works, in at least one
+               of the following places: within a NOTICE text file distributed
+               as part of the Derivative Works; within the Source form or
+               documentation, if provided along with the Derivative Works; or,
+               within a display generated by the Derivative Works, if and
+               wherever such third-party notices normally appear. The contents
+               of the NOTICE file are for informational purposes only and
+               do not modify the License. You may add Your own attribution
+               notices within Derivative Works that You distribute, alongside
+               or as an addendum to the NOTICE text from the Work, provided
+               that such additional attribution notices cannot be construed
+               as modifying the License.
+
+           You may add Your own copyright statement to Your modifications and
+           may provide additional or different license terms and conditions
+           for use, reproduction, or distribution of Your modifications, or
+           for any such Derivative Works as a whole, provided Your use,
+           reproduction, and distribution of the Work otherwise complies with
+           the conditions stated in this License.
+
+        5. Submission of Contributions. Unless You explicitly state otherwise,
+           any Contribution intentionally submitted for inclusion in the Work
+           by You to the Licensor shall be under the terms and conditions of
+           this License, without any additional terms or conditions.
+           Notwithstanding the above, nothing herein shall supersede or modify
+           the terms of any separate license agreement you may have executed
+           with Licensor regarding such Contributions.
+
+        6. Trademarks. This License does not grant permission to use the trade
+           names, trademarks, service marks, or product names of the Licensor,
+           except as required for reasonable and customary use in describing the
+           origin of the Work and reproducing the content of the NOTICE file.
+
+        7. Disclaimer of Warranty. Unless required by applicable law or
+           agreed to in writing, Licensor provides the Work (and each
+           Contributor provides its Contributions) on an "AS IS" BASIS,
+           WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+           implied, including, without limitation, any warranties or conditions
+           of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+           PARTICULAR PURPOSE. You are solely responsible for determining the
+           appropriateness of using or redistributing the Work and assume any
+           risks associated with Your exercise of permissions under this License.
+
+        8. Limitation of Liability. In no event and under no legal theory,
+           whether in tort (including negligence), contract, or otherwise,
+           unless required by applicable law (such as deliberate and grossly
+           negligent acts) or agreed to in writing, shall any Contributor be
+           liable to You for damages, including any direct, indirect, special,
+           incidental, or consequential damages of any character arising as a
+           result of this License or out of the use or inability to use the
+           Work (including but not limited to damages for loss of goodwill,
+           work stoppage, computer failure or malfunction, or any and all
+           other commercial damages or losses), even if such Contributor
+           has been advised of the possibility of such damages.
+
+        9. Accepting Warranty or Additional Liability. While redistributing
+           the Work or Derivative Works thereof, You may choose to offer,
+           and charge a fee for, acceptance of support, warranty, indemnity,
+           or other liability obligations and/or rights consistent with this
+           License. However, in accepting such obligations, You may act only
+           on Your own behalf and on Your sole responsibility, not on behalf
+           of any other Contributor, and only if You agree to indemnify,
+           defend, and hold each Contributor harmless for any liability
+           incurred by, or claims asserted against, such Contributor by reason
+           of your accepting any such warranty or additional liability.
+
+        END OF TERMS AND CONDITIONS
+
+        APPENDIX: How to apply the Apache License to your work.
+
+           To apply the Apache License to your work, attach the following
+           boilerplate notice, with the fields enclosed by brackets "[]"
+           replaced with your own identifying information. (Don't include
+           the brackets!)  The text should be enclosed in the appropriate
+           comment syntax for the file format. We also recommend that a
+           file or class name and description of purpose be included on the
+           same "printed page" as the copyright notice for easier
+           identification within third-party archives.
+
+        Copyright [yyyy] [name of copyright owner]
+
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+        "####
+    }
+}
+
+fn write_bsd2_text(file: &mut File, year: i32, author: &str) -> std::io::Result<()> {
+    writedoc! {file, r####"
+        Copyright {} {}
+
+        Redistribution and use in source and binary forms, with or without
+        modification, are permitted provided that the following conditions are met:
+
+        1. Redistributions of source code must retain the above copyright notice,
+        this list of conditions and the following disclaimer.
+
+        2. Redistributions in binary form must reproduce the above copyright notice,
+        this list of conditions and the following disclaimer in the documentation
+        and/or other materials provided with the distribution.
+
+        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+        AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+        IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+        DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+        FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+        DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+        SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+        CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+        OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+        USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+        "####,
+        year, author,
+    }
+}
+
+fn write_bsd3_text(file: &mut File, year: i32, author: &str) -> std::io::Result<()> {
+    writedoc! {file, r####"
+        Copyright {} {}
+
+        Redistribution and use in source and binary forms, with or without
+        modification, are permitted provided that the following conditions are met:
+
+        1. Redistributions of source code must retain the above copyright notice,
+        this list of conditions and the following disclaimer.
+
+        2. Redistributions in binary form must reproduce the above copyright notice,
+        this list of conditions and the following disclaimer in the documentation
+        and/or other materials provided with the distribution.
+
+        3. Neither the name of the copyright holder nor the names of its contributors
+        may be used to endorse or promote products derived from this software without
+        specific prior written permission.
+
+        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+        AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+        IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+        DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+        FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+        DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+        SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+        CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+        OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+        USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+        "####,
+        year, author,
+    }
+}
+
+fn write_isc_text(file: &mut File, year: i32, author: &str) -> std::io::Result<()> {
+    writedoc! {file, r####"
+        Copyright {} {}
+
+        Permission to use, copy, modify, and/or distribute this software for any
+        purpose with or without fee is hereby granted, provided that the above
+        copyright notice and this permission notice appear in all copies.
+
+        THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+        REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+        AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+        INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+        LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+        OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+        PERFORMANCE OF THIS SOFTWARE.
+        "####,
+        year, author,
+    }
+}
+
+fn write_mit_text(file: &mut File, year: i32, author: &str) -> std::io::Result<()> {
+    writedoc! {file, r####"
+        Copyright {} {}
+
+        Permission is hereby granted, free of charge, to any person obtaining a
+        copy of this software and associated documentation files (the "Software"),
+        to deal in the Software without restriction, including without limitation the
+        rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+        sell copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be included in
+        all copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+        THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+        THE SOFTWARE.
+        "####,
+        year, author,
+    }
+}

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -309,8 +309,8 @@
 //! ```
 
 use controlled_option::ControlledOption;
-use lazy_static::lazy_static;
 use lsp_positions::SpanCalculator;
+use once_cell::sync::Lazy;
 use stack_graphs::arena::Handle;
 use stack_graphs::graph::File;
 use stack_graphs::graph::Node;
@@ -368,19 +368,16 @@ static SYMBOL_ATTR: &'static str = "symbol";
 static TYPE_ATTR: &'static str = "type";
 
 // Expected attributes per node type
-lazy_static! {
-    static ref DROP_SCOPES_ATTRS: HashSet<&'static str> = HashSet::from([TYPE_ATTR]);
-    static ref POP_SCOPED_SYMBOL_ATTRS: HashSet<&'static str> =
-        HashSet::from([TYPE_ATTR, SYMBOL_ATTR, IS_DEFINITION_ATTR]);
-    static ref POP_SYMBOL_ATTRS: HashSet<&'static str> =
-        HashSet::from([TYPE_ATTR, SYMBOL_ATTR, IS_DEFINITION_ATTR]);
-    static ref PUSH_SCOPED_SYMBOL_ATTRS: HashSet<&'static str> =
-        HashSet::from([TYPE_ATTR, SYMBOL_ATTR, SCOPE_ATTR, IS_REFERENCE_ATTR]);
-    static ref PUSH_SYMBOL_ATTRS: HashSet<&'static str> =
-        HashSet::from([TYPE_ATTR, SYMBOL_ATTR, IS_REFERENCE_ATTR]);
-    static ref SCOPE_ATTRS: HashSet<&'static str> =
-        HashSet::from([TYPE_ATTR, IS_EXPORTED_ATTR, IS_ENDPOINT_ATTR]);
-}
+static POP_SCOPED_SYMBOL_ATTRS: Lazy<HashSet<&'static str>> =
+    Lazy::new(|| HashSet::from([TYPE_ATTR, SYMBOL_ATTR, IS_DEFINITION_ATTR]));
+static POP_SYMBOL_ATTRS: Lazy<HashSet<&'static str>> =
+    Lazy::new(|| HashSet::from([TYPE_ATTR, SYMBOL_ATTR, IS_DEFINITION_ATTR]));
+static PUSH_SCOPED_SYMBOL_ATTRS: Lazy<HashSet<&'static str>> =
+    Lazy::new(|| HashSet::from([TYPE_ATTR, SYMBOL_ATTR, SCOPE_ATTR, IS_REFERENCE_ATTR]));
+static PUSH_SYMBOL_ATTRS: Lazy<HashSet<&'static str>> =
+    Lazy::new(|| HashSet::from([TYPE_ATTR, SYMBOL_ATTR, IS_REFERENCE_ATTR]));
+static SCOPE_ATTRS: Lazy<HashSet<&'static str>> =
+    Lazy::new(|| HashSet::from([TYPE_ATTR, IS_EXPORTED_ATTR, IS_ENDPOINT_ATTR]));
 
 // Edge attribute names
 static PRECEDENCE_ATTR: &'static str = "precedence";

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -9,7 +9,7 @@
 
 use ini::Ini;
 use itertools::Itertools;
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use regex::Regex;
 use stack_graphs::graph::StackGraph;
 use std::collections::HashMap;
@@ -29,12 +29,10 @@ use crate::CancellationFlag;
 use crate::FileAnalyzer;
 use crate::StackGraphLanguage;
 
-lazy_static! {
-    pub static ref DEFAULT_TSG_PATHS: Vec<LoadPath> =
-        vec![LoadPath::Grammar("queries/stack-graphs".into())];
-    pub static ref DEFAULT_BUILTINS_PATHS: Vec<LoadPath> =
-        vec![LoadPath::Grammar("queries/builtins".into())];
-}
+pub static DEFAULT_TSG_PATHS: Lazy<Vec<LoadPath>> =
+    Lazy::new(|| vec![LoadPath::Grammar("queries/stack-graphs".into())]);
+pub static DEFAULT_BUILTINS_PATHS: Lazy<Vec<LoadPath>> =
+    Lazy::new(|| vec![LoadPath::Grammar("queries/builtins".into())]);
 
 /// Data type that holds all information to recognize and analyze files for a language
 pub struct LanguageConfiguration {

--- a/tree-sitter-stack-graphs/src/test.rs
+++ b/tree-sitter-stack-graphs/src/test.rs
@@ -58,10 +58,10 @@
 //! Any content before the first fragment header of the file is ignored, and will not be part of the test.
 
 use itertools::Itertools;
-use lazy_static::lazy_static;
 use lsp_positions::Position;
 use lsp_positions::PositionedSubstring;
 use lsp_positions::SpanCalculator;
+use once_cell::sync::Lazy;
 use regex::Regex;
 use stack_graphs::arena::Handle;
 use stack_graphs::assert::Assertion;
@@ -85,15 +85,14 @@ const DEFINED: &'static str = "defined";
 const DEFINES: &'static str = "defines";
 const REFERS: &'static str = "refers";
 
-lazy_static! {
-    static ref PATH_REGEX: Regex = Regex::new(r#"---\s*path:\s*([^\s]+)\s*---"#).unwrap();
-    static ref GLOBAL_REGEX: Regex =
-        Regex::new(r#"---\s*global:\s*([^\s]+)=([^\s]+)\s*---"#).unwrap();
-    static ref ASSERTION_REGEX: Regex =
-        Regex::new(r#"(\^)\s*(\w+):\s*([^\s,]+(?:\s*,\s*[^\s,]+)*)?"#).unwrap();
-    static ref LINE_NUMBER_REGEX: Regex = Regex::new(r#"\d+"#).unwrap();
-    static ref NAME_REGEX: Regex = Regex::new(r#"[^\s,]+"#).unwrap();
-}
+static PATH_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r#"---\s*path:\s*([^\s]+)\s*---"#).unwrap());
+static GLOBAL_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r#"---\s*global:\s*([^\s]+)=([^\s]+)\s*---"#).unwrap());
+static ASSERTION_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r#"(\^)\s*(\w+):\s*([^\s,]+(?:\s*,\s*[^\s,]+)*)?"#).unwrap());
+static LINE_NUMBER_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r#"\d+"#).unwrap());
+static NAME_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r#"[^\s,]+"#).unwrap());
 
 /// An error that can occur while parsing tests
 #[derive(Debug, Error)]

--- a/tree-sitter-stack-graphs/tests/it/loader.rs
+++ b/tree-sitter-stack-graphs/tests/it/loader.rs
@@ -5,7 +5,7 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use pretty_assertions::assert_eq;
 use stack_graphs::graph::StackGraph;
 use std::path::PathBuf;
@@ -15,13 +15,13 @@ use tree_sitter_stack_graphs::loader::Loader;
 use tree_sitter_stack_graphs::NoCancellation;
 use tree_sitter_stack_graphs::StackGraphLanguage;
 
-lazy_static! {
-    static ref PATH: PathBuf = PathBuf::from("test.py");
-    static ref TSG: String = r#"
+static PATH: Lazy<PathBuf> = Lazy::new(|| PathBuf::from("test.py"));
+static TSG: Lazy<String> = Lazy::new(|| {
+    r#"
       (module) {}
     "#
-    .to_string();
-}
+    .to_string()
+});
 
 #[test]
 fn can_load_from_provided_language_configuration() {

--- a/tree-sitter-stack-graphs/tests/it/test.rs
+++ b/tree-sitter-stack-graphs/tests/it/test.rs
@@ -5,7 +5,7 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use pretty_assertions::assert_eq;
 use stack_graphs::arena::Handle;
 use stack_graphs::graph::File;
@@ -18,9 +18,9 @@ use tree_sitter_stack_graphs::LoadError;
 use tree_sitter_stack_graphs::NoCancellation;
 use tree_sitter_stack_graphs::StackGraphLanguage;
 
-lazy_static! {
-    static ref PATH: PathBuf = PathBuf::from("test.py");
-    static ref TSG: String = r#"
+static PATH: Lazy<PathBuf> = Lazy::new(|| PathBuf::from("test.py"));
+static TSG: Lazy<String> = Lazy::new(|| {
+    r#"
       global ROOT_NODE
       (module) @mod {
           node @mod.lexical_in
@@ -50,11 +50,15 @@ lazy_static! {
           attr (@name.ref) type = "push_symbol", symbol = (source-text @name), source_node = @name, is_reference
           edge @name.ref -> @stmt.lexical_in
       }
-    "#.to_string();
-    static ref TSG_WITH_PKG: String = r#"
+    "#.to_string()
+});
+static TSG_WITH_PKG: Lazy<String> = Lazy::new(|| {
+    r#"
       global PKG
-    "#.to_string() + &TSG;
-}
+    "#
+    .to_string()
+        + &TSG
+});
 
 fn build_stack_graph_into(
     graph: &mut StackGraph,


### PR DESCRIPTION
The `init` command generates NPM based projects. Recently we have switched
over to using Cargo and Rust instead. This PR changes the `init` command
to generate Cargo projects instead of NPM projects.

I have chosen not to keep the NPM project generation around. The Cargo
setup is much cleaner. The NPM package will remain supported for the
time being, so it would be possible for NPM based projects to integrate
stack graphs, but they'll have to set it up manually.

The console interaction was also improved a little. Input values can now
be revised instead of only having the option to generate or cancel at the
end of the input cycle.

Fixes #175.

## Demo


https://user-images.githubusercontent.com/999073/216321666-6557dbf2-d979-4d7e-814b-9570d188ed31.mov

