### PR TITLE
Add analyze flags (and small TSG fixes)

### DIFF
--- a/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
@@ -234,11 +234,11 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
 
   ; import builtins
   node builtins_ref__ns
-  attr (builtins_ref__ns) symbol_reference = "%Proj"
+  attr (builtins_ref__ns) push_symbol = "%Proj"
   edge builtins_ref__ns -> ROOT_NODE
   ;
   node builtins_ref
-  attr (builtins_ref) symbol_reference = "<builtins>"
+  attr (builtins_ref) push_symbol = "<builtins>"
   edge builtins_ref -> builtins_ref__ns
   ;
   edge @prog.lexical_scope -> builtins_ref

--- a/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
@@ -86,14 +86,12 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
   node @comment.aliased_type
   node @comment.applied_type
   node @comment.arg
-  node @comment.arg_index
   node @comment.args
   node @comment.async_type
   node @comment.await_type
   node @comment.callable
   node @comment.coargs
   node @comment.cocallable
-  node @comment.comp_index
   node @comment.coparam
   node @comment.coparams
   node @comment.cotype
@@ -435,6 +433,7 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
     (generator_function_declaration)
     (hash_bang_line)
     (if_statement)
+    (import_alias)
     (import_statement)
     (interface_declaration)
     (internal_module)
@@ -5292,18 +5291,21 @@ if none @is_acc {
 ;   (_)@element_type
 ; )@type
 
-(array_type
-  (_)@element_type
-)@type {
+(array_type)@type {
   node @type.indexable
-
-  ; propagate lexical scope
-  edge @element_type.lexical_scope -> @type.lexical_scope
 
   ; type is indexable element type
   edge @type.type -> @type.indexable
   ;
   attr (@type.indexable) pop_symbol = "[]"
+}
+
+(array_type
+  (_)@element_type
+)@type {
+  ; propagate lexical scope
+  edge @element_type.lexical_scope -> @type.lexical_scope
+
   edge @type.indexable -> @element_type.type
 }
 

--- a/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
@@ -5266,6 +5266,7 @@ if none @is_acc {
 
 (type_arguments)@type_args {
   node @type_args.type_args
+  attr (@type_args.type_args) is_exported
 }
 
 (type_arguments
@@ -5900,6 +5901,7 @@ if none @is_acc {
 ]@gen_expr {
   node @gen_expr.type_app
   node @gen_expr.inferred_type_args
+  attr (@gen_expr.inferred_type_args) is_exported
 
   ; push inferred type arguments
   edge @gen_expr.applied_type -> @gen_expr.type_app
@@ -6118,6 +6120,7 @@ if none @is_acc {
   node @async.async_type__type_app
   node @async.async_type__type_arg
   node @async.async_type__type_args
+  attr (@async.async_type__type_args) is_exported
   node @async.async_type__promise_ref
   node @async.async_type__promise_ref__ns
   node @async.await_type

--- a/tree-sitter-stack-graphs/src/cli/analyze.rs
+++ b/tree-sitter-stack-graphs/src/cli/analyze.rs
@@ -133,7 +133,7 @@ impl AnalyzeArgs {
         seen_mark: &mut bool,
     ) -> anyhow::Result<()> {
         self.analyze_file(source_root, source_path, loader, seen_mark)
-            .with_context(|| format!("Error analyzing file {}", source_path.display()))
+            .with_context(|| format!("Error analyzing file {}. To continue analysis from this file later, add: --continue-from {}", source_path.display(), source_path.display()))
     }
 
     fn analyze_file(

--- a/tree-sitter-stack-graphs/src/cli/analyze.rs
+++ b/tree-sitter-stack-graphs/src/cli/analyze.rs
@@ -13,6 +13,7 @@ use stack_graphs::graph::StackGraph;
 use stack_graphs::partial::PartialPaths;
 use stack_graphs::stitching::Database;
 use std::collections::HashMap;
+use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -45,6 +46,16 @@ pub struct AnalyzeArgs {
     )]
     pub source_paths: Vec<PathBuf>,
 
+    /// Continue analysis from the given file
+    #[clap(
+        long,
+        value_name = "SOURCE_PATH",
+        value_hint = ValueHint::AnyPath,
+        parse(from_os_str),
+        validator_os = path_exists,
+    )]
+    pub continue_from: Option<PathBuf>,
+
     #[clap(long, short = 'v')]
     pub verbose: bool,
 
@@ -55,18 +66,28 @@ pub struct AnalyzeArgs {
         parse(try_from_str = duration_from_seconds_str),
     )]
     pub max_file_time: Option<Duration>,
+
+    /// Wait for user input before starting analysis. Useful for profiling.
+    #[clap(long)]
+    pub wait_at_start: bool,
 }
 
 impl AnalyzeArgs {
     pub fn new(source_paths: Vec<PathBuf>) -> Self {
         Self {
             source_paths,
+            continue_from: None,
             verbose: false,
             max_file_time: None,
+            wait_at_start: false,
         }
     }
 
     pub fn run(&self, loader: &mut Loader) -> anyhow::Result<()> {
+        if self.wait_at_start {
+            self.wait_for_input()?;
+        }
+        let mut seen_mark = false;
         for source_path in &self.source_paths {
             if source_path.is_dir() {
                 let source_root = source_path;
@@ -77,13 +98,29 @@ impl AnalyzeArgs {
                     .filter(|e| e.file_type().is_file())
                 {
                     let source_path = source_entry.path();
-                    self.analyze_file_with_context(source_root, source_path, loader)?;
+                    self.analyze_file_with_context(
+                        source_root,
+                        source_path,
+                        loader,
+                        &mut seen_mark,
+                    )?;
                 }
             } else {
                 let source_root = source_path.parent().unwrap();
-                self.analyze_file_with_context(source_root, source_path, loader)?;
+                if self.skip(source_path, &mut seen_mark) {
+                    continue;
+                }
+                self.analyze_file_with_context(source_root, source_path, loader, &mut seen_mark)?;
             }
         }
+        Ok(())
+    }
+
+    fn wait_for_input(&self) -> anyhow::Result<()> {
+        print!("<press ENTER to continue>");
+        std::io::stdout().flush()?;
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input)?;
         Ok(())
     }
 
@@ -93,8 +130,9 @@ impl AnalyzeArgs {
         source_root: &Path,
         source_path: &Path,
         loader: &mut Loader,
+        seen_mark: &mut bool,
     ) -> anyhow::Result<()> {
-        self.analyze_file(source_root, source_path, loader)
+        self.analyze_file(source_root, source_path, loader, seen_mark)
             .with_context(|| format!("Error analyzing file {}", source_path.display()))
     }
 
@@ -103,8 +141,14 @@ impl AnalyzeArgs {
         source_root: &Path,
         source_path: &Path,
         loader: &mut Loader,
+        seen_mark: &mut bool,
     ) -> anyhow::Result<()> {
         let mut file_status = FileStatusLogger::new(source_path, self.verbose);
+
+        if self.skip(source_path, seen_mark) {
+            file_status.info("skipped")?;
+            return Ok(());
+        }
 
         let mut file_reader = FileReader::new();
         let lc = match loader.load_for_file(source_path, &mut file_reader, &NoCancellation) {
@@ -191,5 +235,20 @@ impl AnalyzeArgs {
 
         file_status.ok("success")?;
         Ok(())
+    }
+
+    fn skip(&self, path: &Path, seen_mark: &mut bool) -> bool {
+        if *seen_mark {
+            false
+        } else if let Some(mark) = &self.continue_from {
+            if path != mark {
+                true
+            } else {
+                *seen_mark = true;
+                false
+            }
+        } else {
+            false
+        }
     }
 }

--- a/tree-sitter-stack-graphs/src/cli/util.rs
+++ b/tree-sitter-stack-graphs/src/cli/util.rs
@@ -189,6 +189,13 @@ impl<'a> FileStatusLogger<'a> {
         Ok(())
     }
 
+    pub fn info(&mut self, status: &str) -> Result<(), anyhow::Error> {
+        self.print_path(true)?;
+        println!("{}", status.dimmed());
+        self.path_logged = false;
+        Ok(())
+    }
+
     pub fn warn(&mut self, status: &str) -> Result<(), anyhow::Error> {
         self.print_path(true)?;
         println!("{}", status.yellow());


### PR DESCRIPTION
- Add analyze flags to aid debugging and profiling
- Add flag suggestion to error message
- Use regular symbol pushes for project and buitlins
- Mark symbols scopes as exported
- Fix missing or duplicate scoped variables
