### PR TITLE
Updates to `analyze` (and `test`)

### DIFF
--- a/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
@@ -2732,7 +2732,7 @@ if none @is_async {
 }
 
 
-;; Variables
+;; Variables / Identifiers
 
 ; x;
 
@@ -2742,6 +2742,8 @@ if none @is_async {
   (for_in_statement ["var" "let" "const"]?@is_def left:(identifier)@name)
   (assignment_expression left:(identifier)@name)
   (augmented_assignment_expression left:(identifier)@name)
+  (asserts (identifier)@name)
+  (type_predicate name:(identifier)@name)
   ; FIXME type_query has its own restricted expression production
   ;       we need to do this for every (identifier) inside a type query
   ;       this cannot be expressed, so we manually unroll three levels here
@@ -2789,6 +2791,8 @@ if none @is_def {
   (for_in_statement ["var" "let" "const"]?@is_def left:(identifier)@name)
   (assignment_expression left:(identifier)@name)
   (augmented_assignment_expression left:(identifier)@name)
+  (asserts (identifier)@name)
+  (type_predicate name:(identifier)@name)
   ; FIXME type_query has its own restricted expression production
   (type_query (identifier)@name)
   (type_query (member_expression object:(identifier)@name))
@@ -4972,9 +4976,6 @@ if none @is_acc {
 )@asserts {
   ; propagate lexical scope
   edge @type.lexical_scope -> @asserts.lexical_scope
-
-  ; type is type of inner
-  edge @asserts.type -> @type.type
 }
 
 
@@ -5119,9 +5120,8 @@ if none @is_acc {
   (_)@type
 )@type_pred {
   ; propagate lexical scope
+  edge @name.lexical_scope -> @type_pred.lexical_scope
   edge @type.lexical_scope -> @type_pred.lexical_scope
-
-  ; FIXME name is a expression reference
 }
 
 

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/asserts-condition.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/asserts-condition.ts
@@ -1,0 +1,7 @@
+function assert(
+    condition: any,
+): asserts condition {
+//         ^ defined: 2
+}
+
+export {}

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/asserts-type.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/asserts-type.ts
@@ -1,0 +1,7 @@
+function assertIsString(
+    val: any
+): asserts val is string {
+//         ^ defined: 2
+}
+
+export {}

--- a/tree-sitter-stack-graphs/CHANGELOG.md
+++ b/tree-sitter-stack-graphs/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `--show-ignored` flag of the `test` command has been renamed to `--show-skipped`. Only explicitly skipped test files (with a `.skip` extension) will be shown. Other unsupported files are, such as generated HTML files, are never shown.
 - The `--hide-passing` flag of the `test` command has been renamed to the more common `--quiet`/`-q`.
 - The output of the `test` command has changed to print the test name before the test result, so that it clear which test is currently running.
+- The output of the `test` and `analyze` commands has changed in debug builds to include the run time per file.
+- The `--hide-failure-errors` has been renamed to the more general `--hide-error-details`. The new flag is supported by the `test` and `analyze` commands.
+- The files in directory arguments are now processed in filename order.
 
 ## v0.6.0 -- 2023-01-13
 

--- a/tree-sitter-stack-graphs/src/cli/analyze.rs
+++ b/tree-sitter-stack-graphs/src/cli/analyze.rs
@@ -98,6 +98,7 @@ impl AnalyzeArgs {
                 let source_root = source_path;
                 for source_entry in WalkDir::new(source_root)
                     .follow_links(true)
+                    .sort_by_file_name()
                     .into_iter()
                     .filter_map(|e| e.ok())
                     .filter(|e| e.file_type().is_file())

--- a/tree-sitter-stack-graphs/src/cli/analyze.rs
+++ b/tree-sitter-stack-graphs/src/cli/analyze.rs
@@ -59,6 +59,10 @@ pub struct AnalyzeArgs {
     #[clap(long, short = 'v')]
     pub verbose: bool,
 
+    /// Hide failure error details.
+    #[clap(long)]
+    pub hide_error_details: bool,
+
     /// Maximum runtime per file in seconds.
     #[clap(
         long,
@@ -78,6 +82,7 @@ impl AnalyzeArgs {
             source_paths,
             continue_from: None,
             verbose: false,
+            hide_error_details: false,
             max_file_time: None,
             wait_at_start: false,
         }
@@ -203,7 +208,9 @@ impl AnalyzeArgs {
             Err(LoadError::ParseErrors(parse_errors)) => {
                 let parse_error = map_parse_errors(source_path, &parse_errors, &source, "");
                 file_status.error("parsing failed")?;
-                eprintln!("{}", parse_error);
+                if !self.hide_error_details {
+                    println!("{}", parse_error);
+                }
                 return Ok(());
             }
             Err(LoadError::Cancelled(_)) => {

--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -90,7 +90,7 @@ pub struct TestArgs {
 
     /// Hide failure error details.
     #[clap(long)]
-    pub hide_failure_errors: bool,
+    pub hide_error_details: bool,
 
     /// Show skipped files in output.
     #[clap(long)]
@@ -153,7 +153,7 @@ impl TestArgs {
         Self {
             test_paths,
             quiet: false,
-            hide_failure_errors: false,
+            hide_error_details: false,
             show_skipped: false,
             save_graph: None,
             save_paths: None,
@@ -336,7 +336,7 @@ impl TestArgs {
                 result.count(),
             ))?;
         }
-        if !success && !self.hide_failure_errors {
+        if !success && !self.hide_error_details {
             for failure in result.failures_iter() {
                 println!("{}", failure);
             }

--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -169,6 +169,7 @@ impl TestArgs {
                 let test_root = test_path;
                 for test_entry in WalkDir::new(test_root)
                     .follow_links(true)
+                    .sort_by_file_name()
                     .into_iter()
                     .filter_map(|e| e.ok())
                     .filter(|e| e.file_type().is_file())


### PR DESCRIPTION
Some small updates to the `analyze` command and the TypeScript TSG:

- A few syntax cases were added in the TSG, as well as corresponding tests.
- Output of `test` and `analyze` in debug builds includes the runtime per file.
- The `--hide-failure-errors` flag was renamed to the more descriptive `--hide-error-details`, which is now supported by the `test` and `analyze` commands.
- Files in directory arguments (e.g. when `test/` is passed) are now processed in filename order.