### PR TITLE
Add action for Java tssg releases

### DIFF
--- a/.github/workflows/publish-tree-sitter-stack-graphs-java.yml
+++ b/.github/workflows/publish-tree-sitter-stack-graphs-java.yml
@@ -1,0 +1,45 @@
+name: Publish tree-sitter-stack-graphs-java release
+
+on:
+  push:
+    tags:
+      - tree-sitter-stack-graphs-java-v*
+
+jobs:
+  publish-crate:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      CARGO_INCREMENTAL: 0
+      CRATE_DIR: './languages/tree-sitter-stack-graphs-java'
+    steps:
+      - name: Install Rust environment
+        uses: hecrj/setup-rust-action@v1
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      # TODO Verify the crate version matches the tag
+      - name: Test crate
+        run: cargo test --all-features
+        working-directory: ${{ env.CRATE_DIR }}
+      - name: Verify publish crate
+        run: cargo publish --dry-run
+        working-directory: ${{ env.CRATE_DIR }}
+      - name: Publish crate
+        run: cargo publish
+        working-directory: ${{ env.CRATE_DIR }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+  create-release:
+    needs: publish-crate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Create GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          body: |
+            Find more info on all releases at https://crates.io/crates/tree-sitter-stack-graphs-java.
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a new release action for our Java tssg crate. This action is based on other release actions in this repo.

It will run on tag push, so I plan to exercise this action when I push up the tag `tree-sitter-stack-graphs-java-v0.1.0`, which will include all the changes linked [here](https://github.com/github/stack-graphs/compare/tree-sitter-stack-graphs-typescript-v0.1.0...main).