### PR TITLE
Specify tree-sitter-java crate version

### DIFF
--- a/languages/tree-sitter-stack-graphs-java/Cargo.toml
+++ b/languages/tree-sitter-stack-graphs-java/Cargo.toml
@@ -37,4 +37,4 @@ harness = false # need to provide own main function to handle running tests
 anyhow = "1.0"
 clap = "3"
 tree-sitter-stack-graphs = { version = "~0.6.0", path = "../../tree-sitter-stack-graphs", features=["cli"] }
-tree-sitter-java = { git = "http://github.com/tree-sitter/tree-sitter-java", rev="09d650def6cdf7f479f4b78f595e9ef5b58ce31e" }
+tree-sitter-java = { version = "~0.20.0" }


### PR DESCRIPTION
Updates the `tree-sitter-java` crate to the latest version, 0.20.0. 😄 
This explicit specification of a version is required for publishing the `tree-sitter-stack-graphs-java` crate, as noted in the failed run [here](https://github.com/github/stack-graphs/actions/runs/4148507907/jobs/7176561630#step:5:14).