### PR TITLE
Update Java tssg crate README path

### DIFF
--- a/languages/tree-sitter-stack-graphs-java/Cargo.toml
+++ b/languages/tree-sitter-stack-graphs-java/Cargo.toml
@@ -6,7 +6,7 @@ description = "Stack graphs for the Java programming language"
 homepage = "https://github.com/github/stack-graphs/tree/main/stack-graphs/languages/tree-sitter-stack-graphs-java"
 repository = "https://github.com/github/stack-graphs"
 license = "MIT OR Apache-2.0"
-readme = "languages/tree-sitter-stack-graphs-java/README.md"
+readme = "README.md"
 edition = "2021"
 
 authors = [


### PR DESCRIPTION
Updates the path for the README in the Java tssg Cargo.toml file to reflect the location relative to the Cargo.toml file. Fixes the issue in the latest crate publish run [here](https://github.com/github/stack-graphs/actions/runs/4176778494/jobs/7233513470).

This should be the last iteration of changes for publishing this crate - I ran `cargo publish --dry-run` locally and was able to remedy the issue with this change.