### PR TITLE
Replace chrono dependency by time

### DIFF
--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -23,7 +23,6 @@ required-features = ["cli"]
 
 [features]
 cli = [
-  "chrono",
   "clap",
   "colored",
   "dialoguer",
@@ -31,13 +30,13 @@ cli = [
   "indoc",
   "pathdiff",
   "stack-graphs/json",
+  "time",
   "tree-sitter-config",
   "walkdir"
 ]
 
 [dependencies]
 anyhow = "1.0"
-chrono = { version = "0.4", optional = true }
 clap = { version = "3", optional = true, features=["derive"] }
 colored = { version = "2.0", optional = true }
 controlled-option = ">=0.4"
@@ -53,6 +52,7 @@ regex = "1"
 rust-ini = "0.18"
 stack-graphs = { version="0.10", path="../stack-graphs" }
 thiserror = "1.0"
+time = { version = "0.3", optional = true }
 tree-sitter = ">= 0.19"
 tree-sitter-config = { version = "0.19", optional = true }
 tree-sitter-graph = "0.7"

--- a/tree-sitter-stack-graphs/src/cli/init.rs
+++ b/tree-sitter-stack-graphs/src/cli/init.rs
@@ -6,7 +6,6 @@
 // ------------------------------------------------------------------------------------------------
 
 use anyhow::anyhow;
-use chrono::Datelike;
 use clap::Args;
 use clap::ValueHint;
 use dialoguer::Input;
@@ -21,6 +20,7 @@ use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
+use time::OffsetDateTime;
 
 use self::license::lookup_license;
 use self::license::DEFAULT_LICENSES;
@@ -445,7 +445,7 @@ impl ProjectSettings {
             NO_LICENSE | OTHER_LICENSE => {}
             selected => {
                 let mut file = File::create(project_path.join("LICENSE"))?;
-                let year = chrono::Utc::now().year();
+                let year = OffsetDateTime::now_utc().year();
                 let author = self.license_author();
                 (DEFAULT_LICENSES[selected].2)(&mut file, year, &author)?;
             }
@@ -457,7 +457,7 @@ impl ProjectSettings {
         match lookup_license(&self.license) {
             NO_LICENSE | OTHER_LICENSE => {}
             selected => {
-                let year = chrono::Utc::now().year();
+                let year = OffsetDateTime::now_utc().year();
                 let author = self.license_author();
                 (DEFAULT_LICENSES[selected].1)(file, year, &author, prefix)?;
             }


### PR DESCRIPTION
The `tree-sitter-stack-graphs` crate depends on `chrono` to get the current year in the CLI. Latest `chrono` version has a vulnerability, but there's no release yet that fixes this. [Online comments](https://github.com/chronotope/chrono/issues/602#issuecomment-1436548077) suggest that the `chrono` project has trouble with maintainance and getting to new releases.

This PR removes the `chrono` dependency and replaces it with `time`, which sees releases more often. Much of `time` is also behind feature flags, so we pull in less code as well.
