### PR TITLE
Non-terminating path finding with current definition of `is_productive`

### DIFF
--- a/stack-graphs/Cargo.toml
+++ b/stack-graphs/Cargo.toml
@@ -24,6 +24,7 @@ test = false
 bitvec = "1.0"
 controlled-option = "0.4"
 either = "1.6"
+enumset = "1.0"
 fxhash = "0.2"
 itertools = "0.10"
 libc = "0.2"

--- a/stack-graphs/src/cycles.rs
+++ b/stack-graphs/src/cycles.rs
@@ -216,14 +216,14 @@ impl<A: Appendable + Clone> AppendingCycleDetector<A> {
             // build prefix path -- prefix starts at end_node, because this is a cycle
             let mut prefix_path = PartialPath::from_node(graph, partials, end_node);
             while let Some(appendage) = prefix_appendages.pop_front(appendables) {
-                prefix_path.resolve_to(graph, partials, appendage.start_node(ctx))?;
+                prefix_path.resolve_to_node(graph, partials, appendage.start_node(ctx))?;
                 appendage.append_to(graph, partials, ctx, &mut prefix_path)?;
             }
 
             // build cyclic path
             let cyclic_path = maybe_cyclic_path
                 .unwrap_or_else(|| PartialPath::from_node(graph, partials, end_node));
-            prefix_path.resolve_to(graph, partials, cyclic_path.start_node)?;
+            prefix_path.resolve_to_node(graph, partials, cyclic_path.start_node)?;
             prefix_path.ensure_no_overlapping_variables(partials, &cyclic_path);
             prefix_path.concatenate(graph, partials, &cyclic_path)?;
             if let Some(cyclicity) = prefix_path.is_cyclic(graph, partials) {

--- a/stack-graphs/src/cycles.rs
+++ b/stack-graphs/src/cycles.rs
@@ -31,6 +31,7 @@
 
 use std::collections::HashMap;
 
+use enumset::EnumSet;
 use smallvec::SmallVec;
 
 use crate::arena::Handle;
@@ -186,8 +187,8 @@ impl<A: Appendable + Clone> AppendingCycleDetector<A> {
         partials: &mut PartialPaths,
         ctx: &mut A::Ctx,
         appendables: &mut Appendables<A>,
-    ) -> Result<Vec<Cyclicity>, PathResolutionError> {
-        let mut cycles = Vec::new();
+    ) -> Result<EnumSet<Cyclicity>, PathResolutionError> {
+        let mut cycles = EnumSet::new();
 
         let end_node = match self.appendages.clone().pop_front(appendables) {
             Some(appendage) => appendage.end_node(ctx),
@@ -227,7 +228,7 @@ impl<A: Appendable + Clone> AppendingCycleDetector<A> {
             prefix_path.ensure_no_overlapping_variables(partials, &cyclic_path);
             prefix_path.concatenate(graph, partials, &cyclic_path)?;
             if let Some(cyclicity) = prefix_path.is_cyclic(graph, partials) {
-                cycles.push(cyclicity);
+                cycles |= cyclicity;
             }
             maybe_cyclic_path = Some(prefix_path);
         }

--- a/stack-graphs/src/cycles.rs
+++ b/stack-graphs/src/cycles.rs
@@ -178,18 +178,20 @@ impl<A: Appendable + Clone> AppendingCycleDetector<A> {
         self.appendages.push_front(appendables, appendage);
     }
 
+    /// Tests if the path is cyclic. Returns a vector indicating the kind of cycles that were found.
+    /// If appending or concatenating all fragments succeeds, this function will never raise and error.
     pub fn is_cyclic(
         &self,
         graph: &StackGraph,
         partials: &mut PartialPaths,
         ctx: &mut A::Ctx,
         appendables: &mut Appendables<A>,
-    ) -> Vec<Cyclicity> {
+    ) -> Result<Vec<Cyclicity>, PathResolutionError> {
         let mut cycles = Vec::new();
 
         let end_node = match self.appendages.clone().pop_front(appendables) {
             Some(appendage) => appendage.end_node(ctx),
-            None => return cycles,
+            None => return Ok(cycles),
         };
 
         let mut maybe_cyclic_path = None;
@@ -207,31 +209,23 @@ impl<A: Appendable + Clone> AppendingCycleDetector<A> {
                             break;
                         }
                     }
-                    None => return cycles,
+                    None => return Ok(cycles),
                 }
             }
 
             // build prefix path -- prefix starts at end_node, because this is a cycle
             let mut prefix_path = PartialPath::from_node(graph, partials, end_node);
             while let Some(appendage) = prefix_appendages.pop_front(appendables) {
-                prefix_path
-                    .resolve_to(graph, partials, appendage.start_node(ctx))
-                    .expect("resolving cycle prefix path failed");
-                appendage
-                    .append_to(graph, partials, ctx, &mut prefix_path)
-                    .expect("appending cycle prefix path failed");
+                prefix_path.resolve_to(graph, partials, appendage.start_node(ctx))?;
+                appendage.append_to(graph, partials, ctx, &mut prefix_path)?;
             }
 
             // build cyclic path
             let cyclic_path = maybe_cyclic_path
                 .unwrap_or_else(|| PartialPath::from_node(graph, partials, end_node));
-            prefix_path
-                .resolve_to(graph, partials, cyclic_path.start_node)
-                .expect("resolving cyclic path failed");
+            prefix_path.resolve_to(graph, partials, cyclic_path.start_node)?;
             prefix_path.ensure_no_overlapping_variables(partials, &cyclic_path);
-            prefix_path
-                .concatenate(graph, partials, &cyclic_path)
-                .expect("concatenating cyclic path failed ");
+            prefix_path.concatenate(graph, partials, &cyclic_path)?;
             if let Some(cyclicity) = prefix_path.is_cyclic(graph, partials) {
                 cycles.push(cyclicity);
             }

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -40,6 +40,7 @@ use std::num::NonZeroU32;
 
 use controlled_option::ControlledOption;
 use controlled_option::Niche;
+use enumset::EnumSetType;
 use smallvec::SmallVec;
 
 use crate::arena::Deque;
@@ -2229,7 +2230,7 @@ impl PartialPath {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Debug, EnumSetType)]
 pub enum Cyclicity {
     /// The path can be freely concatenated to itself.
     Free,

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -2743,6 +2743,7 @@ impl PartialPaths {
                 }
             } else if !path_cycle_detector
                 .is_cyclic(graph, self, &mut (), &mut edges)
+                .expect("cyclic test failed when finding partial paths")
                 .is_empty()
             {
                 copious_debugging!("    * cycle");

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -2440,15 +2440,6 @@ impl PartialPath {
             .apply_partial_bindings(partials, &scope_bindings)
             .unwrap();
 
-        self.symbol_stack_postcondition = self
-            .symbol_stack_postcondition
-            .apply_partial_bindings(partials, &symbol_bindings, &scope_bindings)
-            .unwrap();
-        self.scope_stack_postcondition = self
-            .scope_stack_postcondition
-            .apply_partial_bindings(partials, &scope_bindings)
-            .unwrap();
-
         self.end_node = node;
 
         Ok(())

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -2371,15 +2371,15 @@ impl PartialPath {
             },
         );
 
-        self.resolve(graph, partials)?;
+        self.resolve_from_postcondition(graph, partials)?;
 
         Ok(())
     }
 
-    /// Attempts to resolve any _jump to scope_ node at the end of a partial path.  If the partial
-    /// path does not end in a _jump to scope_ node, we do nothing.  If it does, and we cannot
-    /// resolve it, then we return an error describing why.
-    pub fn resolve(
+    /// Attempts to resolve any _jump to scope_ node at the end of a partial path from the postcondition
+    /// scope stack.  If the partial path does not end in a _jump to scope_ node, we do nothing.  If it
+    /// does, and we cannot resolve it, then we return an error describing why.
+    pub fn resolve_from_postcondition(
         &mut self,
         graph: &StackGraph,
         partials: &mut PartialPaths,
@@ -2405,10 +2405,11 @@ impl PartialPath {
         Ok(())
     }
 
-    /// Attempts to resolve any _jump to scope_ node at the end of a partial path to the given node.
-    /// If the partial path does not end in a _jump to scope_ node, we do nothing.  If it does, and we
-    /// cannot resolve it, then we return an error describing why.
-    pub fn resolve_to(
+    /// Resolve any _jump to scope_ node at the end of a partial path to the given node, updating the
+    /// precondition to include the given node.  If the partial path does not end in a _jump to scope_
+    /// node, we do nothing.  If it does, and we cannot resolve it, then we return an error describing
+    /// why.
+    pub fn resolve_to_node(
         &mut self,
         graph: &StackGraph,
         partials: &mut PartialPaths,
@@ -2971,7 +2972,7 @@ impl PartialPath {
         }
         lhs.end_node = rhs.end_node;
 
-        lhs.resolve(graph, partials)?;
+        lhs.resolve_from_postcondition(graph, partials)?;
 
         Ok(())
     }

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -2378,10 +2378,22 @@ impl PartialPath {
         if !graph[self.end_node].is_jump_to() {
             return Ok(());
         }
-        if self.scope_stack_postcondition.contains_scopes() {
-            return Err(PathResolutionError::ScopeStackUnsatisfied); // this path was not properly resolved
-        }
-        self.scope_stack_precondition.push_back(partials, node);
+        let scope_variable = match self.scope_stack_postcondition.variable() {
+            Some(scope_variable) => scope_variable,
+            None => return Err(PathResolutionError::ScopeStackUnsatisfied),
+        };
+        let mut scope_stack = PartialScopeStack::from_variable(scope_variable);
+        scope_stack.push_front(partials, node);
+        let mut scope_bindings = PartialScopeStackBindings::new();
+        scope_bindings
+            .add(partials, scope_variable, scope_stack)
+            .unwrap();
+        self.scope_stack_precondition
+            .apply_partial_bindings(partials, &scope_bindings)
+            .unwrap();
+        self.scope_stack_postcondition
+            .apply_partial_bindings(partials, &scope_bindings)
+            .unwrap();
         self.end_node = node;
         Ok(())
     }
@@ -2561,9 +2573,7 @@ impl Node {
         scope_stack: &mut PartialScopeStack,
     ) {
         match self {
-            Node::DropScopes(_) => {
-                *scope_stack = PartialScopeStack::empty();
-            }
+            Node::DropScopes(_) => {}
             Node::JumpTo(_) => {}
             Node::PopScopedSymbol(node) => {
                 let symbol = symbol_stack

--- a/stack-graphs/src/paths.rs
+++ b/stack-graphs/src/paths.rs
@@ -26,7 +26,7 @@ use crate::arena::DequeArena;
 use crate::arena::Handle;
 use crate::arena::List;
 use crate::arena::ListArena;
-use crate::cycles::Appendages;
+use crate::cycles::Appendables;
 use crate::cycles::AppendingCycleDetector;
 use crate::cycles::SimilarPathDetector;
 use crate::graph::Edge;
@@ -875,7 +875,7 @@ impl Path {
         &self,
         graph: &StackGraph,
         paths: &mut Paths,
-        edges: &mut Appendages<Edge>,
+        edges: &mut Appendables<Edge>,
         path_cycle_detector: AppendingCycleDetector<Edge>,
         result: &mut R,
     ) {
@@ -924,7 +924,7 @@ impl Paths {
             })
             .collect::<VecDeque<_>>();
         let mut partials = PartialPaths::new();
-        let mut edges = Appendages::new();
+        let mut edges = Appendables::new();
         while let Some((path, path_cycle_detector)) = queue.pop_front() {
             cancellation_flag.check("finding paths")?;
             if !similar_path_detector_detector
@@ -936,6 +936,7 @@ impl Paths {
             }
             if !path_cycle_detector
                 .is_cyclic(graph, &mut partials, &mut (), &mut edges)
+                .expect("cyclic test failed when finding paths")
                 .into_iter()
                 .all(|c| c == Cyclicity::StrengthensPrecondition)
             {

--- a/stack-graphs/src/stitching.rs
+++ b/stack-graphs/src/stitching.rs
@@ -121,6 +121,8 @@ impl Database {
 
         // If the partial path starts at the root node, index it by its symbol stack precondition.
         if graph[start_node].is_root() {
+            // The join node is root, so there's no need to use half-open symbol stacks here, as we
+            // do for [`PartialPath::concatenate`][].
             let key = SymbolStackKey::from_partial_symbol_stack(
                 partials,
                 self,
@@ -587,6 +589,8 @@ impl PathStitcher {
         copious_debugging!("--> Candidate path {}", path.display(graph, paths));
         self.candidate_paths.clear();
         if graph[path.end_node].is_root() {
+            // The join node is root, so there's no need to use half-open symbol stacks here, as we
+            // do for [`PartialPath::concatenate`][].
             let key = SymbolStackKey::from_symbol_stack(paths, db, path.symbol_stack);
             db.find_candidate_partial_paths_from_root(
                 graph,
@@ -923,6 +927,8 @@ impl ForwardPartialPathStitcher {
     ) -> usize {
         self.candidate_partial_paths.clear();
         if graph[partial_path.end_node].is_root() {
+            // The join node is root, so there's no need to use half-open symbol stacks here, as we
+            // do for [`PartialPath::concatenate`][].
             let key = SymbolStackKey::from_partial_symbol_stack(
                 partials,
                 db,

--- a/stack-graphs/src/stitching.rs
+++ b/stack-graphs/src/stitching.rs
@@ -482,7 +482,7 @@ pub struct PathStitcher {
         VecDeque<Path>,
         VecDeque<AppendingCycleDetector<OwnedOrDatabasePath>>,
     ),
-    appended_paths: Appendages<OwnedOrDatabasePath>,
+    appended_paths: Appendables<OwnedOrDatabasePath>,
     cycle_detector: SimilarPathDetector<Path>,
     max_work_per_phase: usize,
     #[cfg(feature = "copious-debugging")]
@@ -517,7 +517,7 @@ impl PathStitcher {
             copious_debugging!("    Initial node {}", node.display(graph));
             db.find_candidate_partial_paths_from_node(graph, partials, node, &mut candidate_paths);
         }
-        let mut appended_paths = Appendages::new();
+        let mut appended_paths = Appendables::new();
         let next_iteration = candidate_paths
             .iter()
             .filter_map(|partial_path| {
@@ -620,8 +620,9 @@ impl PathStitcher {
                 continue;
             }
             new_cycle_detector.append(&mut self.appended_paths, extension.into());
-            let cycles =
-                new_cycle_detector.is_cyclic(graph, partials, db, &mut self.appended_paths);
+            let cycles = new_cycle_detector
+                .is_cyclic(graph, partials, db, &mut self.appended_paths)
+                .expect("cyclic test failed when stitching paths");
             if !cycles
                 .into_iter()
                 .all(|c| c == Cyclicity::StrengthensPrecondition)
@@ -963,8 +964,9 @@ impl ForwardPartialPathStitcher {
                     continue;
                 }
                 new_cycle_detector.append(&mut self.appended_paths, extension.into());
-                let cycles =
-                    new_cycle_detector.is_cyclic(graph, partials, db, &mut self.appended_paths);
+                let cycles = new_cycle_detector
+                    .is_cyclic(graph, partials, db, &mut self.appended_paths)
+                    .expect("cyclic test failed when stitching partial paths");
                 if !cycles
                     .into_iter()
                     .all(|c| c == Cyclicity::StrengthensPrecondition)

--- a/stack-graphs/src/stitching.rs
+++ b/stack-graphs/src/stitching.rs
@@ -54,6 +54,7 @@ use crate::cycles::SimilarPathDetector;
 use crate::graph::Node;
 use crate::graph::StackGraph;
 use crate::graph::Symbol;
+use crate::partial::Cyclicity;
 use crate::partial::PartialPath;
 use crate::partial::PartialPaths;
 use crate::partial::PartialSymbolStack;
@@ -931,15 +932,12 @@ impl ForwardPartialPathStitcher {
                     copious_debugging!("        is invalid: {:?}", err);
                     continue;
                 }
-                if new_cycle_detector
-                    .append(
-                        graph,
-                        partials,
-                        db,
-                        &mut self.appended_paths,
-                        extension.into(),
-                    )
-                    .is_err()
+                new_cycle_detector.append(&mut self.appended_paths, extension.into());
+                let cycles =
+                    new_cycle_detector.is_cyclic(graph, partials, db, &mut self.appended_paths);
+                if !cycles
+                    .into_iter()
+                    .all(|c| c == Cyclicity::StrengthensPrecondition)
                 {
                     copious_debugging!("        is invalid: cyclic");
                     continue;

--- a/stack-graphs/tests/it/c/can_jump_to_definition_with_phased_partial_path_stitching.rs
+++ b/stack-graphs/tests/it/c/can_jump_to_definition_with_phased_partial_path_stitching.rs
@@ -242,15 +242,15 @@ fn class_field_through_function_parameter() {
         "main.py",
         &[
             // reference to `a` in import statement
-            "<%1> ($1) [main.py(17) reference a] -> [a.py(0) definition a] <%1> ($1)",
+            "<> () [main.py(17) reference a] -> [a.py(0) definition a] <> ()",
             // reference to `b` in import statement
-            "<%1> ($1) [main.py(15) reference b] -> [b.py(0) definition b] <%1> ($1)",
+            "<> () [main.py(15) reference b] -> [b.py(0) definition b] <> ()",
             // reference to `foo` in function call resolves to function definition
-            "<%1> ($1) [main.py(13) reference foo] -> [a.py(5) definition foo] <%1> ($1)",
+            "<> () [main.py(13) reference foo] -> [a.py(5) definition foo] <> ()",
             // reference to `A` as function parameter resolves to class definition
-            "<%1> ($1) [main.py(9) reference A] -> [b.py(5) definition A] <%1> ($1)",
+            "<> () [main.py(9) reference A] -> [b.py(5) definition A] <> ()",
             // reference to `bar` on result flows through body of `foo` to find `A.bar`
-            "<%1> ($1) [main.py(10) reference bar] -> [b.py(8) definition bar] <%1> ($1)",
+            "<> () [main.py(10) reference bar] -> [b.py(8) definition bar] <> ()",
         ],
     );
     check_jump_to_definition(
@@ -258,7 +258,7 @@ fn class_field_through_function_parameter() {
         "a.py",
         &[
             // reference to `x` in function body resolves to formal parameter
-            "<%1> ($1) [a.py(8) reference x] -> [a.py(14) definition x] <%1> ()",
+            "<> () [a.py(8) reference x] -> [a.py(14) definition x] <> ()",
         ],
     );
     check_jump_to_definition(
@@ -278,9 +278,9 @@ fn cyclic_imports_python() {
         "main.py",
         &[
             // reference to `a` in import statement
-            "<%1> ($1) [main.py(8) reference a] -> [a.py(0) definition a] <%1> ($1)",
+            "<> () [main.py(8) reference a] -> [a.py(0) definition a] <> ()",
             // reference to `foo` resolves through intermediate file to find `b.foo`
-            "<%1> ($1) [main.py(6) reference foo] -> [b.py(6) definition foo] <%1> ($1)",
+            "<> () [main.py(6) reference foo] -> [b.py(6) definition foo] <> ()",
         ],
     );
     check_jump_to_definition(
@@ -288,7 +288,7 @@ fn cyclic_imports_python() {
         "a.py",
         &[
             // reference to `b` in import statement
-            "<%1> ($1) [a.py(6) reference b] -> [b.py(0) definition b] <%1> ($1)",
+            "<> () [a.py(6) reference b] -> [b.py(0) definition b] <> ()",
         ],
     );
     check_jump_to_definition(
@@ -296,7 +296,7 @@ fn cyclic_imports_python() {
         "b.py",
         &[
             // reference to `a` in import statement
-            "<%1> ($1) [b.py(8) reference a] -> [a.py(0) definition a] <%1> ($1)",
+            "<> () [b.py(8) reference a] -> [a.py(0) definition a] <> ()",
         ],
     );
 }
@@ -309,16 +309,16 @@ fn cyclic_imports_rust() {
         "test.rs",
         &[
             // reference to `a` in `a::FOO` resolves to module definition
-            "<%1> ($1) [test.rs(103) reference a] -> [test.rs(201) definition a] <%1> ($1)",
+            "<> () [test.rs(103) reference a] -> [test.rs(201) definition a] <> ()",
             // reference to `a::FOO` in `main` can resolve either to `a::BAR` or `b::FOO`
-            "<%1> ($1) [test.rs(101) reference FOO] -> [test.rs(304) definition FOO] <%1> ($1)",
-            "<%1> ($1) [test.rs(101) reference FOO] -> [test.rs(204) definition BAR] <%1> ($1)",
+            "<> () [test.rs(101) reference FOO] -> [test.rs(304) definition FOO] <> ()",
+            "<> () [test.rs(101) reference FOO] -> [test.rs(204) definition BAR] <> ()",
             // reference to `b` in use statement resolves to module definition
-            "<%1> ($1) [test.rs(206) reference b] -> [test.rs(301) definition b] <%1> ($1)",
+            "<> () [test.rs(206) reference b] -> [test.rs(301) definition b] <> ()",
             // reference to `a` in use statement resolves to module definition
-            "<%1> ($1) [test.rs(307) reference a] -> [test.rs(201) definition a] <%1> ($1)",
+            "<> () [test.rs(307) reference a] -> [test.rs(201) definition a] <> ()",
             // reference to `BAR` in module `b` can _only_ resolve to `a::BAR`
-            "<%1> ($1) [test.rs(305) reference BAR] -> [test.rs(204) definition BAR] <%1> ($1)",
+            "<> () [test.rs(305) reference BAR] -> [test.rs(204) definition BAR] <> ()",
         ],
     );
 }
@@ -331,9 +331,9 @@ fn sequenced_import_star() {
         "main.py",
         &[
             // reference to `a` in import statement
-            "<%1> ($1) [main.py(8) reference a] -> [a.py(0) definition a] <%1> ($1)",
+            "<> () [main.py(8) reference a] -> [a.py(0) definition a] <> ()",
             // reference to `foo` resolves through intermediate file to find `b.foo`
-            "<%1> ($1) [main.py(6) reference foo] -> [b.py(5) definition foo] <%1> ($1)",
+            "<> () [main.py(6) reference foo] -> [b.py(5) definition foo] <> ()",
         ],
     );
     check_jump_to_definition(
@@ -341,7 +341,7 @@ fn sequenced_import_star() {
         "a.py",
         &[
             // reference to `b` in import statement
-            "<%1> ($1) [a.py(6) reference b] -> [b.py(0) definition b] <%1> ($1)",
+            "<> () [a.py(6) reference b] -> [b.py(0) definition b] <> ()",
         ],
     );
     check_jump_to_definition(

--- a/stack-graphs/tests/it/can_jump_to_definition_with_forward_partial_path_stitching.rs
+++ b/stack-graphs/tests/it/can_jump_to_definition_with_forward_partial_path_stitching.rs
@@ -68,17 +68,17 @@ fn class_field_through_function_parameter() {
         &graph,
         &[
             // reference to `a` in import statement
-            "<%1> ($1) [main.py(17) reference a] -> [a.py(0) definition a] <%1> ($1)",
+            "<> () [main.py(17) reference a] -> [a.py(0) definition a] <> ()",
             // reference to `b` in import statement
-            "<%1> ($1) [main.py(15) reference b] -> [b.py(0) definition b] <%1> ($1)",
+            "<> () [main.py(15) reference b] -> [b.py(0) definition b] <> ()",
             // reference to `foo` in function call resolves to function definition
-            "<%1> ($1) [main.py(13) reference foo] -> [a.py(5) definition foo] <%1> ($1)",
+            "<> () [main.py(13) reference foo] -> [a.py(5) definition foo] <> ()",
             // reference to `A` as function parameter resolves to class definition
-            "<%1> ($1) [main.py(9) reference A] -> [b.py(5) definition A] <%1> ($1)",
+            "<> () [main.py(9) reference A] -> [b.py(5) definition A] <> ()",
             // reference to `bar` on result flows through body of `foo` to find `A.bar`
-            "<%1> ($1) [main.py(10) reference bar] -> [b.py(8) definition bar] <%1> ($1)",
+            "<> () [main.py(10) reference bar] -> [b.py(8) definition bar] <> ()",
             // reference to `x` in function body resolves to formal parameter
-            "<%1> ($1) [a.py(8) reference x] -> [a.py(14) definition x] <%1> ()",
+            "<> () [a.py(8) reference x] -> [a.py(14) definition x] <> ()",
         ],
     );
 }
@@ -90,13 +90,13 @@ fn cyclic_imports_python() {
         &graph,
         &[
             // reference to `a` in import statement
-            "<%1> ($1) [main.py(8) reference a] -> [a.py(0) definition a] <%1> ($1)",
+            "<> () [main.py(8) reference a] -> [a.py(0) definition a] <> ()",
             // reference to `foo` resolves through intermediate file to find `b.foo`
-            "<%1> ($1) [main.py(6) reference foo] -> [b.py(6) definition foo] <%1> ($1)",
+            "<> () [main.py(6) reference foo] -> [b.py(6) definition foo] <> ()",
             // reference to `b` in import statement
-            "<%1> ($1) [a.py(6) reference b] -> [b.py(0) definition b] <%1> ($1)",
+            "<> () [a.py(6) reference b] -> [b.py(0) definition b] <> ()",
             // reference to `a` in import statement
-            "<%1> ($1) [b.py(8) reference a] -> [a.py(0) definition a] <%1> ($1)",
+            "<> () [b.py(8) reference a] -> [a.py(0) definition a] <> ()",
         ],
     );
 }
@@ -108,16 +108,16 @@ fn cyclic_imports_rust() {
         &graph,
         &[
             // reference to `a` in `a::FOO` resolves to module definition
-            "<%1> ($1) [test.rs(103) reference a] -> [test.rs(201) definition a] <%1> ($1)",
+            "<> () [test.rs(103) reference a] -> [test.rs(201) definition a] <> ()",
             // reference to `a::FOO` in `main` can resolve either to `a::BAR` or `b::FOO`
-            "<%1> ($1) [test.rs(101) reference FOO] -> [test.rs(304) definition FOO] <%1> ($1)",
-            "<%1> ($1) [test.rs(101) reference FOO] -> [test.rs(204) definition BAR] <%1> ($1)",
+            "<> () [test.rs(101) reference FOO] -> [test.rs(304) definition FOO] <> ()",
+            "<> () [test.rs(101) reference FOO] -> [test.rs(204) definition BAR] <> ()",
             // reference to `b` in use statement resolves to module definition
-            "<%1> ($1) [test.rs(206) reference b] -> [test.rs(301) definition b] <%1> ($1)",
+            "<> () [test.rs(206) reference b] -> [test.rs(301) definition b] <> ()",
             // reference to `a` in use statement resolves to module definition
-            "<%1> ($1) [test.rs(307) reference a] -> [test.rs(201) definition a] <%1> ($1)",
+            "<> () [test.rs(307) reference a] -> [test.rs(201) definition a] <> ()",
             // reference to `BAR` in module `b` can _only_ resolve to `a::BAR`
-            "<%1> ($1) [test.rs(305) reference BAR] -> [test.rs(204) definition BAR] <%1> ($1)",
+            "<> () [test.rs(305) reference BAR] -> [test.rs(204) definition BAR] <> ()",
         ],
     );
 }
@@ -129,11 +129,11 @@ fn sequenced_import_star() {
         &graph,
         &[
             // reference to `a` in import statement
-            "<%1> ($1) [main.py(8) reference a] -> [a.py(0) definition a] <%1> ($1)",
+            "<> () [main.py(8) reference a] -> [a.py(0) definition a] <> ()",
             // reference to `foo` resolves through intermediate file to find `b.foo`
-            "<%1> ($1) [main.py(6) reference foo] -> [b.py(5) definition foo] <%1> ($1)",
+            "<> () [main.py(6) reference foo] -> [b.py(5) definition foo] <> ()",
             // reference to `b` in import statement
-            "<%1> ($1) [a.py(6) reference b] -> [b.py(0) definition b] <%1> ($1)",
+            "<> () [a.py(6) reference b] -> [b.py(0) definition b] <> ()",
         ],
     );
 }

--- a/stack-graphs/tests/it/cycles.rs
+++ b/stack-graphs/tests/it/cycles.rs
@@ -177,12 +177,14 @@ fn finding_simple_identity_cycle_is_detected() {
             cd.append(&mut edges, *edge);
             assert!(cd
                 .is_cyclic(&graph, &mut partials, ctx, &mut edges)
+                .unwrap()
                 .is_empty());
         }
         cd.append(&mut edges, edge(foo_def, r, 0));
         assert_eq!(
             vec![Cyclicity::StrengthensPostcondition],
             cd.is_cyclic(&graph, &mut partials, ctx, &mut edges)
+                .unwrap()
         );
     }
 
@@ -227,6 +229,7 @@ fn stitching_simple_identity_cycle_is_detected() {
         assert_eq!(
             vec![Cyclicity::StrengthensPostcondition],
             cd.is_cyclic(&graph, &mut partials, &mut db, &mut paths)
+                .unwrap()
         );
     }
 }
@@ -267,12 +270,14 @@ fn finding_composite_identity_cycle_is_detected() {
             cd.append(&mut edges, *edge);
             assert!(cd
                 .is_cyclic(&graph, &mut partials, ctx, &mut edges)
+                .unwrap()
                 .is_empty());
         }
         cd.append(&mut edges, edge(bar_ref, s, 0));
         assert_eq!(
             vec![Cyclicity::StrengthensPostcondition],
             cd.is_cyclic(&graph, &mut partials, ctx, &mut edges)
+                .unwrap()
         );
     }
 
@@ -320,6 +325,7 @@ fn stitching_composite_identity_cycle_is_detected() {
         assert_eq!(
             vec![Cyclicity::StrengthensPostcondition],
             cd.is_cyclic(&graph, &mut partials, &mut db, &mut paths)
+                .unwrap()
         );
     }
 }

--- a/stack-graphs/tests/it/cycles.rs
+++ b/stack-graphs/tests/it/cycles.rs
@@ -5,6 +5,7 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+use enumset::enum_set;
 use stack_graphs::cycles::Appendables;
 use stack_graphs::cycles::AppendingCycleDetector;
 use stack_graphs::graph::StackGraph;
@@ -182,7 +183,7 @@ fn finding_simple_identity_cycle_is_detected() {
         }
         cd.append(&mut edges, edge(foo_def, r, 0));
         assert_eq!(
-            vec![Cyclicity::StrengthensPostcondition],
+            enum_set![Cyclicity::StrengthensPostcondition],
             cd.is_cyclic(&graph, &mut partials, ctx, &mut edges)
                 .unwrap()
         );
@@ -227,7 +228,7 @@ fn stitching_simple_identity_cycle_is_detected() {
             AppendingCycleDetector::from(&mut paths, p0.into());
         cd.append(&mut paths, p1.into());
         assert_eq!(
-            vec![Cyclicity::StrengthensPostcondition],
+            enum_set![Cyclicity::StrengthensPostcondition],
             cd.is_cyclic(&graph, &mut partials, &mut db, &mut paths)
                 .unwrap()
         );
@@ -275,7 +276,7 @@ fn finding_composite_identity_cycle_is_detected() {
         }
         cd.append(&mut edges, edge(bar_ref, s, 0));
         assert_eq!(
-            vec![Cyclicity::StrengthensPostcondition],
+            enum_set![Cyclicity::StrengthensPostcondition],
             cd.is_cyclic(&graph, &mut partials, ctx, &mut edges)
                 .unwrap()
         );
@@ -323,7 +324,7 @@ fn stitching_composite_identity_cycle_is_detected() {
             AppendingCycleDetector::from(&mut paths, p0.into());
         cd.append(&mut paths, p1.into());
         assert_eq!(
-            vec![Cyclicity::StrengthensPostcondition],
+            enum_set![Cyclicity::StrengthensPostcondition],
             cd.is_cyclic(&graph, &mut partials, &mut db, &mut paths)
                 .unwrap()
         );

--- a/stack-graphs/tests/it/json.rs
+++ b/stack-graphs/tests/it/json.rs
@@ -484,7 +484,7 @@ fn can_serialize_graph() {
             ]
         }
     );
-    assert_eq!(actual, expected);
+    assert_eq!(expected, actual);
 }
 
 #[test]
@@ -1808,7 +1808,7 @@ fn can_serialize_paths() {
             }
         ]
     );
-    assert_eq!(actual, expected);
+    assert_eq!(expected, actual);
 }
 
 #[test]
@@ -2107,5 +2107,5 @@ fn can_serialize_partial_paths() {
             }
         ]
     );
-    assert_eq!(actual, expected);
+    assert_eq!(expected, actual);
 }

--- a/stack-graphs/tests/it/partial.rs
+++ b/stack-graphs/tests/it/partial.rs
@@ -517,41 +517,18 @@ fn can_create_partial_path_from_node() {
 fn can_append_partial_paths() -> Result<(), PathResolutionError> {
     let mut graph = StackGraph::new();
     let file = graph.add_file("test").expect("");
-
     let jump_to_scope_node = StackGraph::jump_to_node();
-
-    let scope0_id = graph.new_node_id(file);
-    let scope0 = graph.add_scope_node(scope0_id, false).unwrap();
-
-    let scope1_id = graph.new_node_id(file);
-    let scope1 = graph.add_scope_node(scope1_id, false).unwrap();
-
-    let foo = graph.add_symbol("foo");
-    let foo_ref_id = graph.new_node_id(file);
-    let foo_ref = graph.add_push_symbol_node(foo_ref_id, foo, false).unwrap();
-    let foo_def_id = graph.new_node_id(file);
-    let foo_def = graph.add_pop_symbol_node(foo_def_id, foo, false).unwrap();
-
-    let bar = graph.add_symbol("bar");
-    let bar_ref_id = graph.new_node_id(file);
-    let bar_ref = graph.add_push_symbol_node(bar_ref_id, bar, false).unwrap();
-    let bar_def_id = graph.new_node_id(file);
-    let bar_def = graph.add_pop_symbol_node(bar_def_id, bar, false).unwrap();
-
-    let exported_scope_id = graph.new_node_id(file);
-    graph.add_scope_node(exported_scope_id, true);
-    let baz = graph.add_symbol("baz");
-    let baz_ref_id = graph.new_node_id(file);
-    let baz_ref = graph
-        .add_push_scoped_symbol_node(baz_ref_id, baz, exported_scope_id, false)
-        .unwrap();
-    let baz_def_id = graph.new_node_id(file);
-    let baz_def = graph
-        .add_pop_scoped_symbol_node(baz_def_id, baz, false)
-        .unwrap();
-
-    let drop_scopes_id = graph.new_node_id(file);
-    let drop_scopes = graph.add_drop_scopes_node(drop_scopes_id).unwrap();
+    let scope0 = create_scope_node(&mut graph, file, false);
+    let scope1 = create_scope_node(&mut graph, file, false);
+    let foo_ref = create_push_symbol_node(&mut graph, file, "foo", false);
+    let foo_def = create_pop_symbol_node(&mut graph, file, "foo", false);
+    let bar_ref = create_push_symbol_node(&mut graph, file, "bar", false);
+    let bar_def = create_pop_symbol_node(&mut graph, file, "bar", false);
+    let exported_scope = create_scope_node(&mut graph, file, true);
+    let exported_scope_id = graph[exported_scope].id();
+    let baz_ref = create_push_scoped_symbol_node(&mut graph, file, "baz", exported_scope_id, false);
+    let baz_def = create_pop_scoped_symbol_node(&mut graph, file, "baz", false);
+    let drop_scopes = create_drop_scopes_node(&mut graph, file);
 
     fn run(
         graph: &StackGraph,

--- a/stack-graphs/tests/it/partial.rs
+++ b/stack-graphs/tests/it/partial.rs
@@ -675,5 +675,23 @@ fn can_append_partial_paths() -> Result<(), PathResolutionError> {
         "<%1> ($1) [test(7) push scoped baz test(6)] -> [jump to scope] <baz/([test(6)],$1),%1> ($1)",
     );
 
+    // verify that without stack variables in the precondition, the precondition cannot grow because of concatenation
+    {
+        let left = &[scope0];
+        let right = &[scope0, bar_def];
+
+        let mut g = StackGraph::new();
+        g.add_from_graph(&graph).expect("");
+
+        let mut ps = PartialPaths::new();
+        let mut l = create_partial_path_and_edges(&mut g, &mut ps, left).expect("");
+        l.eliminate_precondition_stack_variables(&mut ps);
+        let mut r = create_partial_path_and_edges(&mut g, &mut ps, right).expect("");
+
+        r.ensure_no_overlapping_variables(&mut ps, &l);
+        let result = l.concatenate(&g, &mut ps, &r);
+        result.expect_err("");
+    }
+
     Ok(())
 }

--- a/stack-graphs/tests/it/partial.rs
+++ b/stack-graphs/tests/it/partial.rs
@@ -62,7 +62,7 @@ fn can_apply_offset_to_partial_symbol_stacks() {
         let with_offset =
             stack.with_offset(&mut partials, symbol_variable_offset, scope_variable_offset);
         let actual = with_offset.display(&graph, &mut partials).to_string();
-        assert_eq!(actual, expected);
+        assert_eq!(expected, actual);
     }
 
     verify((&[], None), 0, 0, "");
@@ -128,11 +128,11 @@ fn can_unify_partial_symbol_stacks() -> Result<(), PathResolutionError> {
             &mut scope_bindings,
         )?;
         let unified = unified.display(&graph, &mut partials).to_string();
-        assert_eq!(unified, expected_unification);
+        assert_eq!(expected_unification, unified);
         let symbol_bindings = symbol_bindings.display(&graph, &mut partials).to_string();
-        assert_eq!(symbol_bindings, expected_symbol_bindings);
+        assert_eq!(expected_symbol_bindings, symbol_bindings);
         let scope_bindings = scope_bindings.display(&graph, &mut partials).to_string();
-        assert_eq!(scope_bindings, expected_scope_bindings);
+        assert_eq!(expected_scope_bindings, scope_bindings);
         Ok(())
     }
 
@@ -339,9 +339,9 @@ fn can_unify_partial_scope_stacks() -> Result<(), PathResolutionError> {
         let mut bindings = PartialScopeStackBindings::new();
         let unified = lhs.unify(&mut partials, rhs, &mut bindings)?;
         let unified = unified.display(&graph, &mut partials).to_string();
-        assert_eq!(unified, expected_unification);
+        assert_eq!(expected_unification, unified);
         let bindings = bindings.display(&graph, &mut partials).to_string();
-        assert_eq!(bindings, expected_bindings);
+        assert_eq!(expected_bindings, bindings);
         Ok(())
     }
 
@@ -465,7 +465,7 @@ fn can_create_partial_path_from_node() {
         let mut partials = PartialPaths::new();
         let path = PartialPath::from_node(graph, &mut partials, node);
         let actual = path.display(&graph, &mut partials).to_string();
-        assert_eq!(actual, expected);
+        assert_eq!(expected, actual);
     }
 
     verify(
@@ -570,7 +570,7 @@ fn can_append_partial_paths() -> Result<(), PathResolutionError> {
         r.ensure_no_overlapping_variables(&mut ps, &l);
         l.concatenate(&g, &mut ps, &r)?;
         let actual = l.display(&g, &mut ps).to_string();
-        assert_eq!(actual, expected);
+        assert_eq!(expected, actual);
 
         Ok(())
     }

--- a/stack-graphs/tests/it/util.rs
+++ b/stack-graphs/tests/it/util.rs
@@ -26,6 +26,11 @@ pub(crate) type NiceScopedSymbol<'a> = (&'a str, Option<NiceScopeStack<'a>>);
 pub(crate) type NiceScopeStack<'a> = (&'a [u32], Option<ScopeStackVariable>);
 pub(crate) type NicePartialPath<'a> = &'a [Handle<Node>];
 
+pub(crate) fn create_drop_scopes_node(graph: &mut StackGraph, file: Handle<File>) -> Handle<Node> {
+    let id = graph.new_node_id(file);
+    graph.add_drop_scopes_node(id).unwrap()
+}
+
 pub(crate) fn create_scope_node(
     graph: &mut StackGraph,
     file: Handle<File>,
@@ -48,6 +53,20 @@ pub(crate) fn create_push_symbol_node(
         .unwrap()
 }
 
+pub(crate) fn create_push_scoped_symbol_node(
+    graph: &mut StackGraph,
+    file: Handle<File>,
+    symbol: &str,
+    scope: NodeID,
+    is_reference: bool,
+) -> Handle<Node> {
+    let id = graph.new_node_id(file);
+    let symbol = graph.add_symbol(symbol);
+    graph
+        .add_push_scoped_symbol_node(id, symbol, scope, is_reference)
+        .unwrap()
+}
+
 pub(crate) fn create_pop_symbol_node(
     graph: &mut StackGraph,
     file: Handle<File>,
@@ -58,6 +77,19 @@ pub(crate) fn create_pop_symbol_node(
     let symbol = graph.add_symbol(symbol);
     graph
         .add_pop_symbol_node(id, symbol, is_definition)
+        .unwrap()
+}
+
+pub(crate) fn create_pop_scoped_symbol_node(
+    graph: &mut StackGraph,
+    file: Handle<File>,
+    symbol: &str,
+    is_definition: bool,
+) -> Handle<Node> {
+    let id = graph.new_node_id(file);
+    let symbol = graph.add_symbol(symbol);
+    graph
+        .add_pop_scoped_symbol_node(id, symbol, is_definition)
         .unwrap()
 }
 


### PR DESCRIPTION
When testing https://github.com/github/stack-graphs/pull/193#issuecomment-1442133780, it turned out that the condition for cyclicity was incorrect. In particular, depending on the kind of path construction that happened, we need a different condition.

The old condition allowed cycles with compatible stacks if the precondition was strengthened, that is, when following the cycle consumes symbols from the stack _before_ the cycle. The idea is that eventually those symbols will all be consumed, ensuring termination. However, this is not true when constructing paths that allow their precondition to grow, such as `find_minimal_patial_path_set` does. In those cases, the cycle can be followed arbitrarily many times. In cases where the precondition is fixed, such as when finding complete paths, it is perfectly safe to use such cycles though.

This PR addresses this by (i) allowing different conditions depending on the caller, and (ii) allow keeping cyclic paths in the minimal path set in some condition, but not extend them further.

1. The old `is_productive` method is replaced by `is_cyclic`, which returns details on how the path is cyclic. Is the cycle free (stack remains the same), does it strengthen the precondition (consume symbols from the stack), or does it strengthen the postcondition (add symbols to the stack).

2. The `find_minimal_partial_path_set` method allows cycles that strengthen the precondition, but won't extend them. This means cycles that consume symbols _and start and end in end points_, are added to the set, because the are useful and safe when resolving complete paths. The `find_all_complete_paths` method also allows cycles that strengthen the precondition, but also extends them, since it constructs paths that are closed on the left side, so termination is guaranteed.

## PR stack

- [x] #206 
- [x] #207
- [ ] #193
- [ ] #204 ⬅️
- [ ] #205 