### PR TITLE
Add CLI flag to query analysis result

### DIFF
--- a/stack-graphs/src/assert.rs
+++ b/stack-graphs/src/assert.rs
@@ -72,6 +72,22 @@ impl AssertionSource {
                     .unwrap_or(false)
         })
     }
+
+    pub fn display<'a>(&'a self, graph: &'a StackGraph) -> impl std::fmt::Display + 'a {
+        struct Displayer<'a>(&'a AssertionSource, &'a StackGraph);
+        impl std::fmt::Display for Displayer<'_> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(
+                    f,
+                    "{}:{}:{}",
+                    self.1[self.0.file],
+                    self.0.position.line + 1,
+                    self.0.position.column.grapheme_offset + 1
+                )
+            }
+        }
+        Displayer(self, graph)
+    }
 }
 
 /// Target line of an assertion

--- a/stack-graphs/src/assert.rs
+++ b/stack-graphs/src/assert.rs
@@ -47,7 +47,7 @@ pub struct AssertionSource {
 }
 
 impl AssertionSource {
-    fn definitions_iter<'a>(
+    pub fn definitions_iter<'a>(
         &'a self,
         graph: &'a StackGraph,
     ) -> impl Iterator<Item = Handle<Node>> + 'a {
@@ -60,7 +60,7 @@ impl AssertionSource {
         })
     }
 
-    fn references_iter<'a>(
+    pub fn references_iter<'a>(
         &'a self,
         graph: &'a StackGraph,
     ) -> impl Iterator<Item = Handle<Node>> + 'a {

--- a/tree-sitter-stack-graphs/src/cli/analyze.rs
+++ b/tree-sitter-stack-graphs/src/cli/analyze.rs
@@ -82,9 +82,8 @@ pub struct AnalyzeArgs {
     /// Query definitions for the references at the given position. The position
     /// must be given in the format SOURCE_PATH:LINE:COLUMN.
     #[clap(
-        long = "definitions",
+        long = "definition",
         short = 'd',
-        visible_alias = "definition",
         value_name = "POSITION",
         parse(try_from_str)
     )]

--- a/tree-sitter-stack-graphs/src/cli/util.rs
+++ b/tree-sitter-stack-graphs/src/cli/util.rs
@@ -7,6 +7,10 @@
 
 use anyhow::anyhow;
 use colored::Colorize;
+use lsp_positions::PositionedSubstring;
+use lsp_positions::SpanCalculator;
+use stack_graphs::assert::AssertionSource;
+use stack_graphs::graph::StackGraph;
 use std::ffi::OsStr;
 use std::ffi::OsString;
 use std::io::Write;
@@ -115,7 +119,7 @@ impl PathSpec {
 }
 
 impl std::str::FromStr for PathSpec {
-    type Err = clap::Error;
+    type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self { spec: s.into() })
     }
@@ -124,6 +128,88 @@ impl std::str::FromStr for PathSpec {
 impl From<&str> for PathSpec {
     fn from(s: &str) -> Self {
         Self { spec: s.into() }
+    }
+}
+
+#[derive(Clone, Debug)]
+/// A source position.
+pub struct SourcePosition {
+    /// File path
+    pub path: PathBuf,
+    /// Position line (0-based)
+    pub line: usize,
+    /// Position column (0-based)
+    pub column: usize,
+}
+
+impl SourcePosition {
+    pub fn to_assertion_source<'a>(
+        &self,
+        graph: &StackGraph,
+        lines: impl Iterator<Item = PositionedSubstring<'a>>,
+        span_calculator: &mut SpanCalculator,
+    ) -> anyhow::Result<AssertionSource> {
+        let file = match graph.get_file(&self.path.to_string_lossy()) {
+            Some(file) => file,
+            None => return Err(anyhow!("")),
+        };
+        let (line_no, line) = match lines.enumerate().nth(self.line) {
+            Some(result) => result,
+            None => return Err(anyhow!("Missing line {}", self.line + 1)),
+        };
+        let position =
+            span_calculator.for_line_and_grapheme(line_no, line.utf8_bounds.start, self.column);
+        Ok(AssertionSource { file, position })
+    }
+}
+
+impl std::fmt::Display for SourcePosition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}:{}:{}",
+            self.path.display(),
+            self.line + 1,
+            self.column + 1
+        )
+    }
+}
+
+impl std::str::FromStr for SourcePosition {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut values = s.split(':');
+        let path = match values.next() {
+            Some(path) => PathBuf::from(path),
+            None => return Err(anyhow!("Missing path")),
+        };
+        let line = match values.next() {
+            Some(line) => {
+                let line = usize::from_str(line)
+                    .map_err(|_| anyhow!("Expected line number, got {}", line))?;
+                if line == 0 {
+                    return Err(anyhow!("Line numbers are 1-based, got 0"));
+                }
+                line - 1
+            }
+            None => return Err(anyhow!("Missing line number")),
+        };
+        let column = match values.next() {
+            Some(column) => {
+                let column = usize::from_str(column)
+                    .map_err(|_| anyhow!("Expected column number, got {}", column))?;
+                if column == 0 {
+                    return Err(anyhow!("column numbers are 1-based, got 0"));
+                }
+                column - 1
+            }
+            None => return Err(anyhow!("Missing column number")),
+        };
+        if values.next().is_some() {
+            return Err(anyhow!("Found unexpected components"));
+        }
+        Ok(Self { path, line, column })
     }
 }
 


### PR DESCRIPTION
Until we support (de)serialization, the result of `analyze` only exist during its execution.  This PR adds a `--definition` flag to the `analyze` command that, after analysis, runs a query on the result of analysis.  This is useful for debugging against external code bases.

Eventually we want to persist analysis results and have a separate `query` command. Then this flag will probably be removed.

## PR stack

- [ ] #230
- [ ] #213 ⬅️