### PR TITLE
Set global variables for Java tssg

### DIFF
--- a/languages/tree-sitter-stack-graphs-java/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-java/rust/lib.rs
@@ -10,6 +10,11 @@ pub const STACK_GRAPHS_BUILTINS_CONFIG: &str = include_str!("../src/builtins.cfg
 /// The stack graphs builtins source for this language
 pub const STACK_GRAPHS_BUILTINS_SOURCE: &str = include_str!("../src/builtins.java");
 
+/// The name of the file path global variable
+pub const FILE_PATH_VAR: &str = "FILE_PATH";
+/// The name of the project name global variable
+pub const PROJECT_NAME_VAR: &str = "PROJECT_NAME";
+
 pub fn language_configuration(cancellation_flag: &dyn CancellationFlag) -> LanguageConfiguration {
     LanguageConfiguration::from_tsg_str(
         tree_sitter_java::language(),

--- a/languages/tree-sitter-stack-graphs-java/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-java/src/stack-graphs.tsg
@@ -1,9 +1,11 @@
 ;;;;;;;;;;;;;;;;;;;
 ;; Global Variables
 
-global FILE_PATH
-global ROOT_NODE
+global FILE_PATH           ; project relative path of this file
+global PROJECT_NAME = ""   ; project name, used to isolate different projects in the same stack graph
+
 global JUMP_TO_SCOPE_NODE
+global ROOT_NODE
 
 ;;;;;;;;;;;;;;;;;;;;;;;
 ;; Attribute Shorthands


### PR DESCRIPTION
Adds `PROJECT_NAME_VAR` and `FILE_PATH_VAR` to the Java rust lib.