### PR TITLE
Do not require scope stack linearity

### DIFF
--- a/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
@@ -5847,26 +5847,6 @@ if none @is_acc {
   ;
   attr (@gen_decl.type_abs) pop_scoped_symbol = "<>"
   edge @gen_decl.type_abs -> @gen_decl.generic_inner_type
-
-  ; FIXME   This edge enables resolving to a member while dropping the type
-  ;       application from the scope stack. This is necessary to be able to
-  ;       resolve to a member inside a generic type without consuming its type.
-  ;       Consuming the type results in either DROP or JUMP. Resolving just to
-  ;       the field does not consume the scope on the scope stack, and is not
-  ;       considered a complete path.
-  ;         I think this is an example where a semantics that allows a non-
-  ;       empty scope stack, but not symbol stack, makes more sense than re-
-  ;       quiring the complete consumption of it. One of the effects of the strict
-  ;       semantics is that an intermediate path may not resolve on its own, but does
-  ;       resolve in the context of another path.
-  ;         An example can be found in the test `types/generic-interface.ts`, where
-  ;       in the expression `x.f.v`, the reference `.f` does not resolve on its own,
-  ;       while the reference `.v`, which depend on being able to resolve `.f` does
-  ;       resolve fine.
-  edge @gen_decl.type_abs -> @gen_decl.drop_type_abs
-  ;
-  attr (@gen_decl.drop_type_abs) type = "drop_scopes"
-  edge @gen_decl.drop_type_abs -> @gen_decl.generic_inner_type
 }
 
 ;; Attributes defined on generic applications

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -1818,9 +1818,7 @@ impl PartialPath {
     /// Returns whether a partial path represents the end of a name binding from a reference to a
     /// definition.
     pub fn ends_at_definition(&self, graph: &StackGraph) -> bool {
-        graph[self.end_node].is_definition()
-            && self.symbol_stack_postcondition.can_match_empty()
-            && self.scope_stack_postcondition.can_match_empty()
+        graph[self.end_node].is_definition() && self.symbol_stack_postcondition.can_match_empty()
     }
 
     /// A _complete_ partial path represents a full name binding that resolves a reference to a


### PR DESCRIPTION
Currently, a path's scope stack postcondition must be empty for the path to be considered complete. This means arguments to function or type applications _must_ be used before a path can become complete. This condition is in my opinion too strict.

An example of a situation that doesn't work well with this behavior is the following:

```typescript
class A<T> {
    m(): T;
}
function test(a: A<{ i: number }>) {
    a.m().i;
//    ^ defined: 2
}
```

The reference to `m` is not resolved, because the type argument `string` is still on the scope stack. The reference to `i` resolves fine again, because the type argument has been consumed by then.

I think removing the linearity restriction is the right thing to do here. The effect of the change is limited to precisely these situations. This is also visible from the TypeScript tests. After removing the work-around for `generic-interfaces.ts`, this test now succeeds and no other tests changed behavior.
