### PR TITLE
Deduplicate stacks

### DIFF
--- a/stack-graphs/src/arena.rs
+++ b/stack-graphs/src/arena.rs
@@ -204,6 +204,10 @@ pub trait Arena<T> {
 
     /// Returns the number of instances stored in this arena.
     fn len(&self) -> usize;
+
+    /// Returns whether the values associated with the arena are equal, if this can be determined from the
+    /// handles alone. Otherwise, no value is returned.
+    fn try_equals(&self, lhs: Handle<T>, rhs: Handle<T>) -> Option<bool>;
 }
 
 /// Manages the life cycle of instances of type `T`.  You can allocate new instances of `T` from
@@ -260,6 +264,11 @@ impl<T> Arena<T> for VecArena<T> {
     #[inline(always)]
     fn len(&self) -> usize {
         self.items.len()
+    }
+
+    #[inline]
+    fn try_equals(&self, _lhs: Handle<T>, _rhs: Handle<T>) -> Option<bool> {
+        None
     }
 }
 
@@ -319,6 +328,11 @@ where
     #[inline(always)]
     fn len(&self) -> usize {
         self.arena.len()
+    }
+
+    #[inline]
+    fn try_equals(&self, lhs: Handle<T>, rhs: Handle<T>) -> Option<bool> {
+        Some(lhs == rhs)
     }
 }
 
@@ -672,6 +686,9 @@ where
     T: Eq,
 {
     pub fn equals(self, arena: &impl ListArena<T>, other: List<T>) -> bool {
+        if let Some(equals) = arena.try_equals(self.cells, other.cells) {
+            return equals;
+        }
         self.equals_with(arena, other, |a, b| *a == *b)
     }
 }
@@ -987,6 +1004,9 @@ where
     T: Eq,
 {
     pub fn equals(self, arena: &impl ReversibleListArena<T>, other: ReversibleList<T>) -> bool {
+        if let Some(equals) = arena.try_equals(self.cells, other.cells) {
+            return equals;
+        }
         self.equals_with(arena, other, |a, b| *a == *b)
     }
 }

--- a/stack-graphs/src/arena.rs
+++ b/stack-graphs/src/arena.rs
@@ -716,16 +716,12 @@ pub struct ReversibleListCell<T> {
     reversed: Cell<Option<Handle<ReversibleListCell<T>>>>,
 }
 
-// An arena that's used to manage `ReversibleList<T>` instances.
-//
-// (Note that the arena doesn't store `ReversibleList<T>` itself; it stores the
-// `ReversibleListCell<T>`s that the lists are made of.)
 pub type ReversibleListArena<T> = VecArena<ReversibleListCell<T>>;
 
 impl<T> ReversibleList<T> {
-    /// Creates a new `ReversibleListArena` that will manage lists of this type.
+    /// Creates a new arena that will manage lists of this type.
     pub fn new_arena() -> ReversibleListArena<T> {
-        ReversibleListArena::new()
+        VecArena::new()
     }
 
     /// Returns whether this list is empty.
@@ -765,12 +761,11 @@ impl<T> ReversibleList<T> {
         self.cells = cell.tail;
         Some(&cell.head)
     }
+}
 
+impl<'a, T: 'a> ReversibleList<T> {
     /// Returns an iterator over the elements of this list.
-    pub fn iter<'a>(
-        mut self,
-        arena: &'a ReversibleListArena<T>,
-    ) -> impl Iterator<Item = &'a T> + 'a {
+    pub fn iter(mut self, arena: &'a ReversibleListArena<T>) -> impl Iterator<Item = &'a T> + 'a {
         std::iter::from_fn(move || self.pop_front(arena))
     }
 }
@@ -997,7 +992,7 @@ pub type DequeArena<T> = ReversibleListArena<T>;
 impl<T> Deque<T> {
     /// Creates a new `DequeArena` that will manage deques of this type.
     pub fn new_arena() -> DequeArena<T> {
-        ReversibleList::new_arena()
+        VecArena::new()
     }
 
     /// Returns whether this deque is empty.

--- a/stack-graphs/src/c.rs
+++ b/stack-graphs/src/c.rs
@@ -14,6 +14,7 @@ use std::sync::atomic::AtomicUsize;
 
 use libc::c_char;
 
+use crate::arena::Arena;
 use crate::arena::Handle;
 use crate::graph::File;
 use crate::graph::InternedString;

--- a/stack-graphs/src/cycles.rs
+++ b/stack-graphs/src/cycles.rs
@@ -35,7 +35,8 @@ use std::collections::HashMap;
 
 use crate::arena::Handle;
 use crate::arena::List;
-use crate::arena::ListArena;
+use crate::arena::ListCell;
+use crate::arena::VecArena;
 use crate::graph::Edge;
 use crate::graph::Node;
 use crate::graph::StackGraph;
@@ -148,7 +149,7 @@ pub struct AppendingCycleDetector<A> {
     appendages: List<A>,
 }
 
-pub type Appendables<A> = ListArena<A>;
+pub type Appendables<A> = VecArena<ListCell<A>>;
 
 impl<A: Appendable + Clone> AppendingCycleDetector<A> {
     pub fn new() -> Self {

--- a/stack-graphs/src/graph.rs
+++ b/stack-graphs/src/graph.rs
@@ -63,6 +63,7 @@ use smallvec::SmallVec;
 use crate::arena::Arena;
 use crate::arena::Handle;
 use crate::arena::SupplementalArena;
+use crate::arena::VecArena;
 
 //-------------------------------------------------------------------------------------------------
 // String content
@@ -1401,13 +1402,13 @@ impl StackGraph {
 /// Contains all of the nodes and edges that make up a stack graph.
 pub struct StackGraph {
     interned_strings: InternedStringArena,
-    pub(crate) symbols: Arena<Symbol>,
+    pub(crate) symbols: VecArena<Symbol>,
     symbol_handles: FxHashMap<&'static str, Handle<Symbol>>,
-    pub(crate) strings: Arena<InternedString>,
+    pub(crate) strings: VecArena<InternedString>,
     string_handles: FxHashMap<&'static str, Handle<InternedString>>,
-    pub(crate) files: Arena<File>,
+    pub(crate) files: VecArena<File>,
     file_handles: FxHashMap<&'static str, Handle<File>>,
-    pub(crate) nodes: Arena<Node>,
+    pub(crate) nodes: VecArena<Node>,
     pub(crate) source_info: SupplementalArena<Node, SourceInfo>,
     node_id_handles: NodeIDHandles,
     outgoing_edges: SupplementalArena<Node, SmallVec<[OutgoingEdge; 8]>>,
@@ -1573,17 +1574,17 @@ impl StackGraph {
 
 impl Default for StackGraph {
     fn default() -> StackGraph {
-        let mut nodes = Arena::new();
+        let mut nodes = VecArena::new();
         nodes.add(RootNode::new().into());
         nodes.add(JumpToNode::new().into());
 
         StackGraph {
             interned_strings: InternedStringArena::new(),
-            symbols: Arena::new(),
+            symbols: VecArena::new(),
             symbol_handles: FxHashMap::default(),
-            strings: Arena::new(),
+            strings: VecArena::new(),
             string_handles: FxHashMap::default(),
-            files: Arena::new(),
+            files: VecArena::new(),
             file_handles: FxHashMap::default(),
             nodes,
             source_info: SupplementalArena::new(),

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -158,8 +158,8 @@ where
 
 /// Represents an unknown list of scoped symbols.
 #[repr(transparent)]
-#[derive(Clone, Copy, Debug, Eq, Hash, Niche, Ord, PartialEq, PartialOrd)]
-pub struct SymbolStackVariable(#[niche] NonZeroU32);
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct SymbolStackVariable(NonZeroU32);
 
 impl SymbolStackVariable {
     pub fn new(variable: u32) -> Option<SymbolStackVariable> {
@@ -218,13 +218,37 @@ impl TryFrom<u32> for SymbolStackVariable {
     }
 }
 
+impl Niche for SymbolStackVariable {
+    type Output = u32;
+
+    #[inline]
+    fn none() -> Self::Output {
+        0
+    }
+
+    #[inline]
+    fn is_none(value: &Self::Output) -> bool {
+        *value == 0
+    }
+
+    #[inline]
+    fn into_some(value: Self) -> Self::Output {
+        value.as_u32()
+    }
+
+    #[inline]
+    fn from_some(value: Self::Output) -> Self {
+        Self(unsafe { NonZeroU32::new_unchecked(value) })
+    }
+}
+
 //-------------------------------------------------------------------------------------------------
 // Scope stack variables
 
 /// Represents an unknown list of exported scopes.
 #[repr(transparent)]
-#[derive(Clone, Copy, Debug, Eq, Hash, Niche, Ord, PartialEq, PartialOrd)]
-pub struct ScopeStackVariable(#[niche] NonZeroU32);
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ScopeStackVariable(NonZeroU32);
 
 impl ScopeStackVariable {
     pub fn new(variable: u32) -> Option<ScopeStackVariable> {
@@ -286,6 +310,30 @@ impl TryFrom<u32> for ScopeStackVariable {
     fn try_from(value: u32) -> Result<ScopeStackVariable, ()> {
         let value = NonZeroU32::new(value).ok_or(())?;
         Ok(ScopeStackVariable(value))
+    }
+}
+
+impl Niche for ScopeStackVariable {
+    type Output = u32;
+
+    #[inline]
+    fn none() -> Self::Output {
+        0
+    }
+
+    #[inline]
+    fn is_none(value: &Self::Output) -> bool {
+        *value == 0
+    }
+
+    #[inline]
+    fn into_some(value: Self) -> Self::Output {
+        value.as_u32()
+    }
+
+    #[inline]
+    fn from_some(value: Self::Output) -> Self {
+        Self(unsafe { NonZeroU32::new_unchecked(value) })
     }
 }
 
@@ -855,7 +903,7 @@ impl DisplayWithPartialPaths for PartialSymbolStack {
 /// A pattern that might match against a scope stack.  Consists of a (possibly empty) list of
 /// exported scopes, along with an optional scope stack variable.
 #[repr(C)]
-#[derive(Clone, Copy, Niche)]
+#[derive(Clone, Copy, Eq, Hash, Niche, PartialEq)]
 pub struct PartialScopeStack {
     #[niche]
     scopes: ReversibleList<Handle<Node>>,

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -47,8 +47,8 @@ use smallvec::SmallVec;
 use crate::arena::Deque;
 use crate::arena::DequeCell;
 use crate::arena::Handle;
+use crate::arena::HashArena;
 use crate::arena::ReversibleList;
-use crate::arena::VecArena;
 use crate::cycles::Appendables;
 use crate::cycles::AppendingCycleDetector;
 use crate::graph::Edge;
@@ -2853,17 +2853,17 @@ struct Join {
 /// Manages the state of a collection of partial paths built up as part of the partial-path-finding
 /// algorithm or path-stitching algorithm.
 pub struct PartialPaths {
-    pub(crate) partial_symbol_stacks: VecArena<DequeCell<PartialScopedSymbol>>,
-    pub(crate) partial_scope_stacks: VecArena<DequeCell<Handle<Node>>>,
-    pub(crate) partial_path_edges: VecArena<DequeCell<PartialPathEdge>>,
+    pub(crate) partial_symbol_stacks: HashArena<DequeCell<PartialScopedSymbol>>,
+    pub(crate) partial_scope_stacks: HashArena<DequeCell<Handle<Node>>>,
+    pub(crate) partial_path_edges: HashArena<DequeCell<PartialPathEdge>>,
 }
 
 impl PartialPaths {
     pub fn new() -> PartialPaths {
         PartialPaths {
-            partial_symbol_stacks: VecArena::new(),
-            partial_scope_stacks: VecArena::new(),
-            partial_path_edges: VecArena::new(),
+            partial_symbol_stacks: HashArena::new(),
+            partial_scope_stacks: HashArena::new(),
+            partial_path_edges: HashArena::new(),
         }
     }
 }

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -44,10 +44,10 @@ use enumset::EnumSetType;
 use smallvec::SmallVec;
 
 use crate::arena::Deque;
-use crate::arena::DequeArena;
+use crate::arena::DequeCell;
 use crate::arena::Handle;
 use crate::arena::ReversibleList;
-use crate::arena::ReversibleListArena;
+use crate::arena::VecArena;
 use crate::cycles::Appendables;
 use crate::cycles::AppendingCycleDetector;
 use crate::graph::Edge;
@@ -2672,17 +2672,17 @@ struct Join {
 /// Manages the state of a collection of partial paths built up as part of the partial-path-finding
 /// algorithm or path-stitching algorithm.
 pub struct PartialPaths {
-    pub(crate) partial_symbol_stacks: ReversibleListArena<PartialScopedSymbol>,
-    pub(crate) partial_scope_stacks: ReversibleListArena<Handle<Node>>,
-    pub(crate) partial_path_edges: DequeArena<PartialPathEdge>,
+    pub(crate) partial_symbol_stacks: VecArena<DequeCell<PartialScopedSymbol>>,
+    pub(crate) partial_scope_stacks: VecArena<DequeCell<Handle<Node>>>,
+    pub(crate) partial_path_edges: VecArena<DequeCell<PartialPathEdge>>,
 }
 
 impl PartialPaths {
     pub fn new() -> PartialPaths {
         PartialPaths {
-            partial_symbol_stacks: ReversibleList::new_arena(),
-            partial_scope_stacks: ReversibleList::new_arena(),
-            partial_path_edges: Deque::new_arena(),
+            partial_symbol_stacks: VecArena::new(),
+            partial_scope_stacks: VecArena::new(),
+            partial_path_edges: VecArena::new(),
         }
     }
 }

--- a/stack-graphs/src/stitching.rs
+++ b/stack-graphs/src/stitching.rs
@@ -45,7 +45,6 @@ use crate::arena::Arena;
 use crate::arena::Handle;
 use crate::arena::HandleSet;
 use crate::arena::List;
-use crate::arena::ListArena;
 use crate::arena::ListCell;
 use crate::arena::SupplementalArena;
 use crate::arena::VecArena;
@@ -77,7 +76,7 @@ use crate::CancellationFlag;
 pub struct Database {
     pub(crate) partial_paths: VecArena<PartialPath>,
     pub(crate) local_nodes: HandleSet<Node>,
-    symbol_stack_keys: ListArena<Handle<Symbol>>,
+    symbol_stack_keys: VecArena<ListCell<Handle<Symbol>>>,
     symbol_stack_key_cache: HashMap<SymbolStackCacheKey, SymbolStackKeyHandle>,
     paths_by_start_node: SupplementalArena<Node, Vec<Handle<PartialPath>>>,
     root_paths_by_precondition: SupplementalArena<SymbolStackKeyCell, Vec<Handle<PartialPath>>>,
@@ -89,7 +88,7 @@ impl Database {
         Database {
             partial_paths: VecArena::new(),
             local_nodes: HandleSet::new(),
-            symbol_stack_keys: List::new_arena(),
+            symbol_stack_keys: VecArena::new(),
             symbol_stack_key_cache: HashMap::new(),
             paths_by_start_node: SupplementalArena::new(),
             root_paths_by_precondition: SupplementalArena::new(),

--- a/stack-graphs/src/stitching.rs
+++ b/stack-graphs/src/stitching.rs
@@ -48,6 +48,7 @@ use crate::arena::List;
 use crate::arena::ListArena;
 use crate::arena::ListCell;
 use crate::arena::SupplementalArena;
+use crate::arena::VecArena;
 use crate::cycles::Appendables;
 use crate::cycles::AppendingCycleDetector;
 use crate::cycles::SimilarPathDetector;
@@ -74,7 +75,7 @@ use crate::CancellationFlag;
 /// partial paths that are actually needed, placing them into a `Database` instance as they're
 /// needed.
 pub struct Database {
-    pub(crate) partial_paths: Arena<PartialPath>,
+    pub(crate) partial_paths: VecArena<PartialPath>,
     pub(crate) local_nodes: HandleSet<Node>,
     symbol_stack_keys: ListArena<Handle<Symbol>>,
     symbol_stack_key_cache: HashMap<SymbolStackCacheKey, SymbolStackKeyHandle>,
@@ -86,7 +87,7 @@ impl Database {
     /// Creates a new, empty database.
     pub fn new() -> Database {
         Database {
-            partial_paths: Arena::new(),
+            partial_paths: VecArena::new(),
             local_nodes: HandleSet::new(),
             symbol_stack_keys: List::new_arena(),
             symbol_stack_key_cache: HashMap::new(),

--- a/stack-graphs/tests/it/arena.rs
+++ b/stack-graphs/tests/it/arena.rs
@@ -8,16 +8,17 @@
 use stack_graphs::arena::Arena;
 use stack_graphs::arena::Deque;
 use stack_graphs::arena::DequeArena;
-use stack_graphs::arena::InterningArena;
+use stack_graphs::arena::HashArena;
 use stack_graphs::arena::List;
 use stack_graphs::arena::ListArena;
 use stack_graphs::arena::ReversibleList;
 use stack_graphs::arena::ReversibleListArena;
 use stack_graphs::arena::SupplementalArena;
+use stack_graphs::arena::VecArena;
 
 #[test]
 fn can_allocate_in_arena() {
-    let mut arena = Arena::new();
+    let mut arena = VecArena::new();
     let hello1 = arena.add("hello".to_string());
     let hello2 = arena.add("hello".to_string());
     let there = arena.add("there".to_string());
@@ -31,7 +32,7 @@ fn can_allocate_in_arena() {
 
 #[test]
 fn can_allocate_in_supplemental_arena() {
-    let mut arena = Arena::<u32>::new();
+    let mut arena = VecArena::<u32>::new();
     let h1 = arena.add(1);
     let h2 = arena.add(2);
     let h3 = arena.add(3);
@@ -233,7 +234,7 @@ fn can_compare_deques() {
 
 #[test]
 fn can_allocate_in_interning_arena() {
-    let mut arena = InterningArena::new();
+    let mut arena = HashArena::new();
     let hello1 = arena.add("hello".to_string());
     let hello2 = arena.add("hello".to_string());
     let there = arena.add("there".to_string());

--- a/stack-graphs/tests/it/arena.rs
+++ b/stack-graphs/tests/it/arena.rs
@@ -8,6 +8,7 @@
 use stack_graphs::arena::Arena;
 use stack_graphs::arena::Deque;
 use stack_graphs::arena::DequeArena;
+use stack_graphs::arena::InterningArena;
 use stack_graphs::arena::List;
 use stack_graphs::arena::ListArena;
 use stack_graphs::arena::ReversibleList;
@@ -228,4 +229,18 @@ fn can_compare_deques() {
     deque1.ensure_backwards(&mut arena);
     deque10.ensure_backwards(&mut arena);
     assert_eq!(deque1.cmp(&mut arena, deque10), Ordering::Less);
+}
+
+#[test]
+fn can_allocate_in_interning_arena() {
+    let mut arena = InterningArena::new();
+    let hello1 = arena.add("hello".to_string());
+    let hello2 = arena.add("hello".to_string());
+    let there = arena.add("there".to_string());
+    assert_eq!(hello1, hello2);
+    assert_ne!(hello1, there);
+    assert_ne!(hello2, there);
+    assert_eq!(arena.get(hello1), arena.get(hello2));
+    assert_ne!(arena.get(hello1), arena.get(there));
+    assert_ne!(arena.get(hello2), arena.get(there));
 }

--- a/stack-graphs/tests/it/arena.rs
+++ b/stack-graphs/tests/it/arena.rs
@@ -31,6 +31,20 @@ fn can_allocate_in_arena() {
 }
 
 #[test]
+fn can_allocate_in_interning_arena() {
+    let mut arena = HashArena::new();
+    let hello1 = arena.add("hello".to_string());
+    let hello2 = arena.add("hello".to_string());
+    let there = arena.add("there".to_string());
+    assert_eq!(hello1, hello2);
+    assert_ne!(hello1, there);
+    assert_ne!(hello2, there);
+    assert_eq!(arena.get(hello1), arena.get(hello2));
+    assert_ne!(arena.get(hello1), arena.get(there));
+    assert_ne!(arena.get(hello2), arena.get(there));
+}
+
+#[test]
 fn can_allocate_in_supplemental_arena() {
     let mut arena = VecArena::<u32>::new();
     let h1 = arena.add(1);
@@ -50,43 +64,48 @@ fn can_create_lists() {
     fn collect(list: &List<u32>, arena: &impl ListArena<u32>) -> Vec<u32> {
         list.iter(arena).copied().collect()
     }
-
-    let mut arena = List::new_arena();
-    let mut list = List::empty();
-    assert_eq!(collect(&list, &arena), vec![] as Vec<u32>);
-    list.push_front(&mut arena, 1);
-    assert_eq!(collect(&list, &arena), vec![1]);
-    list.push_front(&mut arena, 2);
-    list.push_front(&mut arena, 3);
-    assert_eq!(collect(&list, &arena), vec![3, 2, 1]);
+    fn run(mut arena: impl ListArena<u32>) {
+        let mut list = List::empty();
+        assert_eq!(collect(&list, &arena), vec![] as Vec<u32>);
+        list.push_front(&mut arena, 1);
+        assert_eq!(collect(&list, &arena), vec![1]);
+        list.push_front(&mut arena, 2);
+        list.push_front(&mut arena, 3);
+        assert_eq!(collect(&list, &arena), vec![3, 2, 1]);
+    }
+    run(VecArena::new());
+    run(HashArena::new());
 }
 
 #[test]
 fn can_compare_lists() {
-    use std::cmp::Ordering;
-    let mut arena = List::new_arena();
-    let mut from_slice = |slice: &[u32]| {
-        let mut list = List::empty();
-        for element in slice.iter().rev() {
-            list.push_front(&mut arena, *element);
-        }
-        list
-    };
-    let list0 = from_slice(&[]);
-    let list1 = from_slice(&[1]);
-    let list2 = from_slice(&[2]);
-    let list12 = from_slice(&[1, 2]);
-    assert!(list0.equals(&arena, list0));
-    assert_eq!(list0.cmp(&arena, list0), Ordering::Equal);
-    assert!(!list0.equals(&arena, list1));
-    assert_eq!(list0.cmp(&arena, list1), Ordering::Less);
-    assert!(list1.equals(&arena, list1));
-    assert_eq!(list1.cmp(&arena, list1), Ordering::Equal);
-    assert!(!list1.equals(&arena, list2));
-    assert_eq!(list1.cmp(&arena, list2), Ordering::Less);
-    assert!(list2.equals(&arena, list2));
-    assert_eq!(list2.cmp(&arena, list12), Ordering::Greater);
-    assert_eq!(list1.cmp(&arena, list12), Ordering::Less);
+    fn run(mut arena: impl ListArena<u32>) {
+        use std::cmp::Ordering;
+        let mut from_slice = |slice: &[u32]| {
+            let mut list = List::empty();
+            for element in slice.iter().rev() {
+                list.push_front(&mut arena, *element);
+            }
+            list
+        };
+        let list0 = from_slice(&[]);
+        let list1 = from_slice(&[1]);
+        let list2 = from_slice(&[2]);
+        let list12 = from_slice(&[1, 2]);
+        assert!(list0.equals(&arena, list0));
+        assert_eq!(list0.cmp(&arena, list0), Ordering::Equal);
+        assert!(!list0.equals(&arena, list1));
+        assert_eq!(list0.cmp(&arena, list1), Ordering::Less);
+        assert!(list1.equals(&arena, list1));
+        assert_eq!(list1.cmp(&arena, list1), Ordering::Equal);
+        assert!(!list1.equals(&arena, list2));
+        assert_eq!(list1.cmp(&arena, list2), Ordering::Less);
+        assert!(list2.equals(&arena, list2));
+        assert_eq!(list2.cmp(&arena, list12), Ordering::Greater);
+        assert_eq!(list1.cmp(&arena, list12), Ordering::Less);
+    }
+    run(VecArena::new());
+    run(HashArena::new());
 }
 
 #[test]
@@ -94,56 +113,61 @@ fn can_create_reversible_lists() {
     fn collect(list: &ReversibleList<u32>, arena: &impl ReversibleListArena<u32>) -> Vec<u32> {
         list.iter(arena).copied().collect()
     }
-
-    let mut arena = ReversibleList::new_arena();
-    let mut list = ReversibleList::empty();
-    assert_eq!(collect(&list, &arena), vec![] as Vec<u32>);
-    list.push_front(&mut arena, 1);
-    assert_eq!(collect(&list, &arena), vec![1]);
-    list.push_front(&mut arena, 2);
-    list.push_front(&mut arena, 3);
-    assert_eq!(collect(&list, &arena), vec![3, 2, 1]);
-    list.reverse(&mut arena);
-    assert_eq!(collect(&list, &arena), vec![1, 2, 3]);
-    list.push_front(&mut arena, 4);
-    list.push_front(&mut arena, 5);
-    assert_eq!(collect(&list, &arena), vec![5, 4, 1, 2, 3]);
-    list.reverse(&mut arena);
-    assert_eq!(collect(&list, &arena), vec![3, 2, 1, 4, 5]);
-    // Verify that we stash away the re-reversal so that we don't have to recompute it.
-    assert!(list.have_reversal(&arena));
+    fn run(mut arena: impl ReversibleListArena<u32>) {
+        let mut list = ReversibleList::empty();
+        assert_eq!(collect(&list, &arena), vec![] as Vec<u32>);
+        list.push_front(&mut arena, 1);
+        assert_eq!(collect(&list, &arena), vec![1]);
+        list.push_front(&mut arena, 2);
+        list.push_front(&mut arena, 3);
+        assert_eq!(collect(&list, &arena), vec![3, 2, 1]);
+        list.reverse(&mut arena);
+        assert_eq!(collect(&list, &arena), vec![1, 2, 3]);
+        list.push_front(&mut arena, 4);
+        list.push_front(&mut arena, 5);
+        assert_eq!(collect(&list, &arena), vec![5, 4, 1, 2, 3]);
+        list.reverse(&mut arena);
+        assert_eq!(collect(&list, &arena), vec![3, 2, 1, 4, 5]);
+        // Verify that we stash away the re-reversal so that we don't have to recompute it.
+        assert!(list.have_reversal(&arena));
+    }
+    run(VecArena::new());
+    run(HashArena::new());
 }
 
 #[test]
 fn can_compare_reversible_lists() {
     use std::cmp::Ordering;
-    let mut arena = ReversibleList::new_arena();
-    let mut from_slice = |slice: &[u32]| {
-        let mut list = ReversibleList::empty();
-        for element in slice.iter().rev() {
-            list.push_front(&mut arena, *element);
-        }
-        list
-    };
-    let list0 = from_slice(&[]);
-    let list1 = from_slice(&[1]);
-    let list2 = from_slice(&[2]);
-    let list12 = from_slice(&[1, 2]);
-    assert!(list0.equals(&arena, list0));
-    assert_eq!(list0.cmp(&arena, list0), Ordering::Equal);
-    assert!(!list0.equals(&arena, list1));
-    assert_eq!(list0.cmp(&arena, list1), Ordering::Less);
-    assert!(list1.equals(&arena, list1));
-    assert_eq!(list1.cmp(&arena, list1), Ordering::Equal);
-    assert!(!list1.equals(&arena, list2));
-    assert_eq!(list1.cmp(&arena, list2), Ordering::Less);
-    assert!(list2.equals(&arena, list2));
-    assert_eq!(list2.cmp(&arena, list12), Ordering::Greater);
-    assert_eq!(list1.cmp(&arena, list12), Ordering::Less);
-    let mut list21 = list12;
-    list21.reverse(&mut arena);
-    assert_eq!(list2.cmp(&arena, list21), Ordering::Less);
-    assert_eq!(list1.cmp(&arena, list21), Ordering::Less);
+    fn run(mut arena: impl ReversibleListArena<u32>) {
+        let mut from_slice = |slice: &[u32]| {
+            let mut list = ReversibleList::empty();
+            for element in slice.iter().rev() {
+                list.push_front(&mut arena, *element);
+            }
+            list
+        };
+        let list0 = from_slice(&[]);
+        let list1 = from_slice(&[1]);
+        let list2 = from_slice(&[2]);
+        let list12 = from_slice(&[1, 2]);
+        assert!(list0.equals(&arena, list0));
+        assert_eq!(list0.cmp(&arena, list0), Ordering::Equal);
+        assert!(!list0.equals(&arena, list1));
+        assert_eq!(list0.cmp(&arena, list1), Ordering::Less);
+        assert!(list1.equals(&arena, list1));
+        assert_eq!(list1.cmp(&arena, list1), Ordering::Equal);
+        assert!(!list1.equals(&arena, list2));
+        assert_eq!(list1.cmp(&arena, list2), Ordering::Less);
+        assert!(list2.equals(&arena, list2));
+        assert_eq!(list2.cmp(&arena, list12), Ordering::Greater);
+        assert_eq!(list1.cmp(&arena, list12), Ordering::Less);
+        let mut list21 = list12;
+        list21.reverse(&mut arena);
+        assert_eq!(list2.cmp(&arena, list21), Ordering::Less);
+        assert_eq!(list1.cmp(&arena, list21), Ordering::Less);
+    }
+    run(VecArena::new());
+    run(HashArena::new());
 }
 
 #[test]
@@ -157,39 +181,40 @@ fn can_create_deques() {
     fn collect_rev(deque: &Deque<u32>, arena: &mut impl DequeArena<u32>) -> Vec<u32> {
         deque.iter_reversed(arena).copied().collect()
     }
-
-    let mut arena = Deque::new_arena();
-    let mut deque = Deque::empty();
-    assert_eq!(collect(&deque, &mut arena), vec![] as Vec<u32>);
-    assert_eq!(collect_rev(&deque, &mut arena), vec![] as Vec<u32>);
-    deque.push_front(&mut arena, 1);
-    assert_eq!(collect(&deque, &mut arena), vec![1]);
-    assert_eq!(collect_rev(&deque, &mut arena), vec![1]);
-    deque.push_front(&mut arena, 2);
-    deque.push_front(&mut arena, 3);
-    assert_eq!(collect(&deque, &mut arena), vec![3, 2, 1]);
-    assert_eq!(collect_rev(&deque, &mut arena), vec![1, 2, 3]);
-    deque.push_back(&mut arena, 4);
-    assert_eq!(collect(&deque, &mut arena), vec![3, 2, 1, 4]);
-    assert_eq!(collect_rev(&deque, &mut arena), vec![4, 1, 2, 3]);
-    deque.push_back(&mut arena, 5);
-    deque.push_back(&mut arena, 6);
-    assert_eq!(collect(&deque, &mut arena), vec![3, 2, 1, 4, 5, 6]);
-    assert_eq!(collect_rev(&deque, &mut arena), vec![6, 5, 4, 1, 2, 3]);
-    deque.push_front(&mut arena, 7);
-    deque.push_front(&mut arena, 8);
-    assert_eq!(collect(&deque, &mut arena), vec![8, 7, 3, 2, 1, 4, 5, 6]);
-    assert_eq!(collect_reused(&deque, &arena), vec![8, 7, 3, 2, 1, 4, 5, 6]);
-    assert_eq!(
-        collect_rev(&deque, &mut arena),
-        vec![6, 5, 4, 1, 2, 3, 7, 8]
-    );
+    fn run(mut arena: impl ReversibleListArena<u32>) {
+        let mut deque = Deque::empty();
+        assert_eq!(collect(&deque, &mut arena), vec![] as Vec<u32>);
+        assert_eq!(collect_rev(&deque, &mut arena), vec![] as Vec<u32>);
+        deque.push_front(&mut arena, 1);
+        assert_eq!(collect(&deque, &mut arena), vec![1]);
+        assert_eq!(collect_rev(&deque, &mut arena), vec![1]);
+        deque.push_front(&mut arena, 2);
+        deque.push_front(&mut arena, 3);
+        assert_eq!(collect(&deque, &mut arena), vec![3, 2, 1]);
+        assert_eq!(collect_rev(&deque, &mut arena), vec![1, 2, 3]);
+        deque.push_back(&mut arena, 4);
+        assert_eq!(collect(&deque, &mut arena), vec![3, 2, 1, 4]);
+        assert_eq!(collect_rev(&deque, &mut arena), vec![4, 1, 2, 3]);
+        deque.push_back(&mut arena, 5);
+        deque.push_back(&mut arena, 6);
+        assert_eq!(collect(&deque, &mut arena), vec![3, 2, 1, 4, 5, 6]);
+        assert_eq!(collect_rev(&deque, &mut arena), vec![6, 5, 4, 1, 2, 3]);
+        deque.push_front(&mut arena, 7);
+        deque.push_front(&mut arena, 8);
+        assert_eq!(collect(&deque, &mut arena), vec![8, 7, 3, 2, 1, 4, 5, 6]);
+        assert_eq!(collect_reused(&deque, &arena), vec![8, 7, 3, 2, 1, 4, 5, 6]);
+        assert_eq!(
+            collect_rev(&deque, &mut arena),
+            vec![6, 5, 4, 1, 2, 3, 7, 8]
+        );
+    }
+    run(VecArena::new());
+    run(HashArena::new());
 }
 
 #[test]
 fn can_compare_deques() {
     use std::cmp::Ordering;
-    let mut arena = Deque::new_arena();
     // Build up deques in both directions so that our comparisons have to test the "reverse if
     // needed" logic.
     fn from_slice_forwards(slice: &[u32], arena: &mut impl DequeArena<u32>) -> Deque<u32> {
@@ -206,42 +231,32 @@ fn can_compare_deques() {
         }
         deque
     }
-    let deque0 = from_slice_forwards(&[], &mut arena);
-    let mut deque1 = from_slice_backwards(&[1], &mut arena);
-    let deque2 = from_slice_forwards(&[2], &mut arena);
-    let mut deque10 = from_slice_backwards(&[1, 0], &mut arena);
-    let deque12 = from_slice_backwards(&[1, 2], &mut arena);
-    assert!(deque0.equals(&mut arena, deque0));
-    assert_eq!(deque0.cmp(&mut arena, deque0), Ordering::Equal);
-    assert!(!deque0.equals(&mut arena, deque1));
-    assert_eq!(deque0.cmp(&mut arena, deque1), Ordering::Less);
-    assert!(deque1.equals(&mut arena, deque1));
-    assert_eq!(deque1.cmp(&mut arena, deque1), Ordering::Equal);
-    assert!(!deque1.equals(&mut arena, deque2));
-    assert_eq!(deque1.cmp(&mut arena, deque2), Ordering::Less);
-    assert!(deque2.equals(&mut arena, deque2));
-    assert_eq!(deque2.cmp(&mut arena, deque12), Ordering::Greater);
-    assert_eq!(deque1.cmp(&mut arena, deque12), Ordering::Less);
+    fn run(mut arena: impl ReversibleListArena<u32>) {
+        let deque0 = from_slice_forwards(&[], &mut arena);
+        let mut deque1 = from_slice_backwards(&[1], &mut arena);
+        let deque2 = from_slice_forwards(&[2], &mut arena);
+        let mut deque10 = from_slice_backwards(&[1, 0], &mut arena);
+        let deque12 = from_slice_backwards(&[1, 2], &mut arena);
+        assert!(deque0.equals(&mut arena, deque0));
+        assert_eq!(deque0.cmp(&mut arena, deque0), Ordering::Equal);
+        assert!(!deque0.equals(&mut arena, deque1));
+        assert_eq!(deque0.cmp(&mut arena, deque1), Ordering::Less);
+        assert!(deque1.equals(&mut arena, deque1));
+        assert_eq!(deque1.cmp(&mut arena, deque1), Ordering::Equal);
+        assert!(!deque1.equals(&mut arena, deque2));
+        assert_eq!(deque1.cmp(&mut arena, deque2), Ordering::Less);
+        assert!(deque2.equals(&mut arena, deque2));
+        assert_eq!(deque2.cmp(&mut arena, deque12), Ordering::Greater);
+        assert_eq!(deque1.cmp(&mut arena, deque12), Ordering::Less);
 
-    // We should get the same result regardless of which direction the deques are pointing.
-    deque1.ensure_forwards(&mut arena);
-    deque10.ensure_forwards(&mut arena);
-    assert_eq!(deque1.cmp(&mut arena, deque10), Ordering::Less);
-    deque1.ensure_backwards(&mut arena);
-    deque10.ensure_backwards(&mut arena);
-    assert_eq!(deque1.cmp(&mut arena, deque10), Ordering::Less);
-}
-
-#[test]
-fn can_allocate_in_interning_arena() {
-    let mut arena = HashArena::new();
-    let hello1 = arena.add("hello".to_string());
-    let hello2 = arena.add("hello".to_string());
-    let there = arena.add("there".to_string());
-    assert_eq!(hello1, hello2);
-    assert_ne!(hello1, there);
-    assert_ne!(hello2, there);
-    assert_eq!(arena.get(hello1), arena.get(hello2));
-    assert_ne!(arena.get(hello1), arena.get(there));
-    assert_ne!(arena.get(hello2), arena.get(there));
+        // We should get the same result regardless of which direction the deques are pointing.
+        deque1.ensure_forwards(&mut arena);
+        deque10.ensure_forwards(&mut arena);
+        assert_eq!(deque1.cmp(&mut arena, deque10), Ordering::Less);
+        deque1.ensure_backwards(&mut arena);
+        deque10.ensure_backwards(&mut arena);
+        assert_eq!(deque1.cmp(&mut arena, deque10), Ordering::Less);
+    }
+    run(VecArena::new());
+    run(HashArena::new());
 }

--- a/stack-graphs/tests/it/arena.rs
+++ b/stack-graphs/tests/it/arena.rs
@@ -10,7 +10,7 @@ use stack_graphs::arena::Deque;
 use stack_graphs::arena::DequeCell;
 use stack_graphs::arena::HashArena;
 use stack_graphs::arena::List;
-use stack_graphs::arena::ListArena;
+use stack_graphs::arena::ListCell;
 use stack_graphs::arena::ReversibleList;
 use stack_graphs::arena::ReversibleListCell;
 use stack_graphs::arena::SupplementalArena;
@@ -47,7 +47,7 @@ fn can_allocate_in_supplemental_arena() {
 
 #[test]
 fn can_create_lists() {
-    fn collect(list: &List<u32>, arena: &ListArena<u32>) -> Vec<u32> {
+    fn collect(list: &List<u32>, arena: &impl Arena<ListCell<u32>>) -> Vec<u32> {
         list.iter(arena).copied().collect()
     }
 

--- a/stack-graphs/tests/it/arena.rs
+++ b/stack-graphs/tests/it/arena.rs
@@ -7,12 +7,12 @@
 
 use stack_graphs::arena::Arena;
 use stack_graphs::arena::Deque;
-use stack_graphs::arena::DequeCell;
+use stack_graphs::arena::DequeArena;
 use stack_graphs::arena::HashArena;
 use stack_graphs::arena::List;
-use stack_graphs::arena::ListCell;
+use stack_graphs::arena::ListArena;
 use stack_graphs::arena::ReversibleList;
-use stack_graphs::arena::ReversibleListCell;
+use stack_graphs::arena::ReversibleListArena;
 use stack_graphs::arena::SupplementalArena;
 use stack_graphs::arena::VecArena;
 
@@ -47,7 +47,7 @@ fn can_allocate_in_supplemental_arena() {
 
 #[test]
 fn can_create_lists() {
-    fn collect(list: &List<u32>, arena: &impl Arena<ListCell<u32>>) -> Vec<u32> {
+    fn collect(list: &List<u32>, arena: &impl ListArena<u32>) -> Vec<u32> {
         list.iter(arena).copied().collect()
     }
 
@@ -91,10 +91,7 @@ fn can_compare_lists() {
 
 #[test]
 fn can_create_reversible_lists() {
-    fn collect(
-        list: &ReversibleList<u32>,
-        arena: &impl Arena<ReversibleListCell<u32>>,
-    ) -> Vec<u32> {
+    fn collect(list: &ReversibleList<u32>, arena: &impl ReversibleListArena<u32>) -> Vec<u32> {
         list.iter(arena).copied().collect()
     }
 
@@ -151,13 +148,13 @@ fn can_compare_reversible_lists() {
 
 #[test]
 fn can_create_deques() {
-    fn collect(deque: &Deque<u32>, arena: &mut impl Arena<DequeCell<u32>>) -> Vec<u32> {
+    fn collect(deque: &Deque<u32>, arena: &mut impl DequeArena<u32>) -> Vec<u32> {
         deque.iter(arena).copied().collect()
     }
-    fn collect_reused(deque: &Deque<u32>, arena: &impl Arena<DequeCell<u32>>) -> Vec<u32> {
+    fn collect_reused(deque: &Deque<u32>, arena: &impl DequeArena<u32>) -> Vec<u32> {
         deque.iter_reused(arena).copied().collect()
     }
-    fn collect_rev(deque: &Deque<u32>, arena: &mut impl Arena<DequeCell<u32>>) -> Vec<u32> {
+    fn collect_rev(deque: &Deque<u32>, arena: &mut impl DequeArena<u32>) -> Vec<u32> {
         deque.iter_reversed(arena).copied().collect()
     }
 
@@ -195,14 +192,14 @@ fn can_compare_deques() {
     let mut arena = Deque::new_arena();
     // Build up deques in both directions so that our comparisons have to test the "reverse if
     // needed" logic.
-    fn from_slice_forwards(slice: &[u32], arena: &mut impl Arena<DequeCell<u32>>) -> Deque<u32> {
+    fn from_slice_forwards(slice: &[u32], arena: &mut impl DequeArena<u32>) -> Deque<u32> {
         let mut deque = Deque::empty();
         for element in slice.iter() {
             deque.push_back(arena, *element);
         }
         deque
     }
-    fn from_slice_backwards(slice: &[u32], arena: &mut impl Arena<DequeCell<u32>>) -> Deque<u32> {
+    fn from_slice_backwards(slice: &[u32], arena: &mut impl DequeArena<u32>) -> Deque<u32> {
         let mut deque = Deque::empty();
         for element in slice.iter().rev() {
             deque.push_front(arena, *element);

--- a/stack-graphs/tests/it/arena.rs
+++ b/stack-graphs/tests/it/arena.rs
@@ -7,12 +7,12 @@
 
 use stack_graphs::arena::Arena;
 use stack_graphs::arena::Deque;
-use stack_graphs::arena::DequeArena;
+use stack_graphs::arena::DequeCell;
 use stack_graphs::arena::HashArena;
 use stack_graphs::arena::List;
 use stack_graphs::arena::ListArena;
 use stack_graphs::arena::ReversibleList;
-use stack_graphs::arena::ReversibleListArena;
+use stack_graphs::arena::ReversibleListCell;
 use stack_graphs::arena::SupplementalArena;
 use stack_graphs::arena::VecArena;
 
@@ -91,7 +91,10 @@ fn can_compare_lists() {
 
 #[test]
 fn can_create_reversible_lists() {
-    fn collect(list: &ReversibleList<u32>, arena: &ReversibleListArena<u32>) -> Vec<u32> {
+    fn collect(
+        list: &ReversibleList<u32>,
+        arena: &impl Arena<ReversibleListCell<u32>>,
+    ) -> Vec<u32> {
         list.iter(arena).copied().collect()
     }
 
@@ -148,13 +151,13 @@ fn can_compare_reversible_lists() {
 
 #[test]
 fn can_create_deques() {
-    fn collect(deque: &Deque<u32>, arena: &mut DequeArena<u32>) -> Vec<u32> {
+    fn collect(deque: &Deque<u32>, arena: &mut impl Arena<DequeCell<u32>>) -> Vec<u32> {
         deque.iter(arena).copied().collect()
     }
-    fn collect_reused(deque: &Deque<u32>, arena: &DequeArena<u32>) -> Vec<u32> {
+    fn collect_reused(deque: &Deque<u32>, arena: &impl Arena<DequeCell<u32>>) -> Vec<u32> {
         deque.iter_reused(arena).copied().collect()
     }
-    fn collect_rev(deque: &Deque<u32>, arena: &mut DequeArena<u32>) -> Vec<u32> {
+    fn collect_rev(deque: &Deque<u32>, arena: &mut impl Arena<DequeCell<u32>>) -> Vec<u32> {
         deque.iter_reversed(arena).copied().collect()
     }
 
@@ -192,20 +195,20 @@ fn can_compare_deques() {
     let mut arena = Deque::new_arena();
     // Build up deques in both directions so that our comparisons have to test the "reverse if
     // needed" logic.
-    let from_slice_forwards = |slice: &[u32], arena: &mut DequeArena<u32>| {
+    fn from_slice_forwards(slice: &[u32], arena: &mut impl Arena<DequeCell<u32>>) -> Deque<u32> {
         let mut deque = Deque::empty();
         for element in slice.iter() {
             deque.push_back(arena, *element);
         }
         deque
-    };
-    let from_slice_backwards = |slice: &[u32], arena: &mut DequeArena<u32>| {
+    }
+    fn from_slice_backwards(slice: &[u32], arena: &mut impl Arena<DequeCell<u32>>) -> Deque<u32> {
         let mut deque = Deque::empty();
         for element in slice.iter().rev() {
             deque.push_front(arena, *element);
         }
         deque
-    };
+    }
     let deque0 = from_slice_forwards(&[], &mut arena);
     let mut deque1 = from_slice_backwards(&[1], &mut arena);
     let deque2 = from_slice_forwards(&[2], &mut arena);


### PR DESCRIPTION
Implements an interning Arena that is used for deduplicating symbol and scope stacks.
