### PR TITLE
Update Java tssg crate version

### DIFF
--- a/languages/tree-sitter-stack-graphs-java/Cargo.toml
+++ b/languages/tree-sitter-stack-graphs-java/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-stack-graphs-java"
-version = "0.1.0"
+version = "0.2.0"
 description = "Stack graphs for the Java programming language"
 
 homepage = "https://github.com/github/stack-graphs/tree/main/stack-graphs/languages/tree-sitter-stack-graphs-java"


### PR DESCRIPTION
Updates Java crate version to 0.2.0 to support the latest release: https://github.com/github/stack-graphs/pull/231