### PR TITLE
Generate visualization from database

### DIFF
--- a/tree-sitter-stack-graphs/src/cli.rs
+++ b/tree-sitter-stack-graphs/src/cli.rs
@@ -63,6 +63,7 @@ pub mod parse;
 pub mod query;
 pub mod test;
 mod util;
+pub mod visualize;
 
 pub mod path_loading {
     use clap::Subcommand;
@@ -74,6 +75,7 @@ pub mod path_loading {
     use crate::cli::parse::ParseArgs;
     use crate::cli::query::QueryArgs;
     use crate::cli::test::TestArgs;
+    use crate::cli::visualize::VisualizeArgs;
 
     #[derive(Subcommand)]
     pub enum Subcommands {
@@ -83,6 +85,7 @@ pub mod path_loading {
         Parse(Parse),
         Query(Query),
         Test(Test),
+        Visualize(Visualize),
     }
 
     impl Subcommands {
@@ -94,6 +97,7 @@ pub mod path_loading {
                 Self::Parse(cmd) => cmd.run(),
                 Self::Query(cmd) => cmd.run(),
                 Self::Test(cmd) => cmd.run(),
+                Self::Visualize(cmd) => cmd.run(),
             }
         }
     }
@@ -184,6 +188,19 @@ pub mod path_loading {
             self.test_args.run(&mut loader)
         }
     }
+
+    /// Visualize command
+    #[derive(clap::Parser)]
+    pub struct Visualize {
+        #[clap(flatten)]
+        visualize_args: VisualizeArgs,
+    }
+
+    impl Visualize {
+        pub fn run(&self) -> anyhow::Result<()> {
+            self.visualize_args.run()
+        }
+    }
 }
 
 pub mod provided_languages {
@@ -195,6 +212,7 @@ pub mod provided_languages {
     use crate::cli::parse::ParseArgs;
     use crate::cli::query::QueryArgs;
     use crate::cli::test::TestArgs;
+    use crate::cli::visualize::VisualizeArgs;
     use crate::loader::LanguageConfiguration;
 
     #[derive(Subcommand)]
@@ -204,6 +222,7 @@ pub mod provided_languages {
         Parse(Parse),
         Query(Query),
         Test(Test),
+        Visualize(Visualize),
     }
 
     impl Subcommands {
@@ -214,6 +233,7 @@ pub mod provided_languages {
                 Self::Parse(cmd) => cmd.run(configurations),
                 Self::Query(cmd) => cmd.run(configurations),
                 Self::Test(cmd) => cmd.run(configurations),
+                Self::Visualize(cmd) => cmd.run(configurations),
             }
         }
     }
@@ -289,6 +309,19 @@ pub mod provided_languages {
         pub fn run(&self, configurations: Vec<LanguageConfiguration>) -> anyhow::Result<()> {
             let mut loader = self.load_args.get(configurations)?;
             self.test_args.run(&mut loader)
+        }
+    }
+
+    /// Visualize command
+    #[derive(clap::Parser)]
+    pub struct Visualize {
+        #[clap(flatten)]
+        visualize_args: VisualizeArgs,
+    }
+
+    impl Visualize {
+        pub fn run(&self, _configurations: Vec<LanguageConfiguration>) -> anyhow::Result<()> {
+            self.visualize_args.run()
         }
     }
 }

--- a/tree-sitter-stack-graphs/src/cli/visualize.rs
+++ b/tree-sitter-stack-graphs/src/cli/visualize.rs
@@ -1,0 +1,147 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2023, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use anyhow::anyhow;
+use anyhow::Context;
+use clap::Args;
+use clap::ValueHint;
+use stack_graphs::serde::NoFilter;
+use stack_graphs::stitching::Database;
+use stack_graphs::stitching::ForwardPartialPathStitcher;
+use stack_graphs::storage::SQLiteReader;
+use stack_graphs::NoCancellation;
+use std::path::Path;
+use std::path::PathBuf;
+use walkdir::WalkDir;
+
+use super::util::path_exists;
+use super::util::wait_for_input;
+use super::util::FileStatusLogger;
+
+/// Analyze sources
+#[derive(Args)]
+pub struct VisualizeArgs {
+    /// Source file or directory paths.
+    #[clap(
+        value_name = "SOURCE_PATH",
+        required = true,
+        value_hint = ValueHint::AnyPath,
+        parse(from_os_str),
+        validator_os = path_exists,
+    )]
+    pub source_paths: Vec<PathBuf>,
+
+    #[clap(
+        long,
+        short = 'D',
+        value_name = "DATABASE_PATH",
+        value_hint = ValueHint::AnyPath,
+        parse(from_os_str),
+        validator_os = path_exists,
+    )]
+    pub database: PathBuf,
+
+    #[clap(
+        long,
+        short = 'o',
+        value_name = "OUTPUT_PATH",
+        value_hint = ValueHint::AnyPath,
+        parse(from_os_str),
+        default_value = "stack-graph.html",
+    )]
+    pub output: PathBuf,
+
+    #[clap(long, short = 'v')]
+    pub verbose: bool,
+
+    /// Wait for user input before starting analysis. Useful for profiling.
+    #[clap(long)]
+    pub wait_at_start: bool,
+}
+
+impl VisualizeArgs {
+    pub fn run(&self) -> anyhow::Result<()> {
+        if self.wait_at_start {
+            wait_for_input()?;
+        }
+
+        let mut db = SQLiteReader::open(&self.database)?;
+        for source_path in &self.source_paths {
+            let source_path = source_path.canonicalize()?;
+            if source_path.is_dir() {
+                let source_root = &source_path;
+                for source_entry in WalkDir::new(source_root)
+                    .follow_links(true)
+                    .sort_by_file_name()
+                    .into_iter()
+                    .filter_map(|e| e.ok())
+                    .filter(|e| e.file_type().is_file())
+                {
+                    let source_path = source_entry.path().canonicalize()?;
+                    self.load_file_data(&source_path, &mut db)?;
+                }
+            } else {
+                self.load_file_data(&source_path, &mut db)?;
+            }
+        }
+
+        self.create_html(&mut db)?;
+
+        Ok(())
+    }
+
+    fn load_file_data(&self, source_path: &Path, db: &mut SQLiteReader) -> anyhow::Result<()> {
+        let mut file_status = FileStatusLogger::new(source_path, self.verbose);
+        let source_path = source_path.to_string_lossy();
+
+        if !db.file_exists(&source_path, None)? {
+            file_status.info("not indexed")?;
+            return Ok(());
+        }
+
+        file_status.processing()?;
+
+        db.load_graph_for_file(&source_path)?;
+        let file = db
+            .get()
+            .0
+            .get_file(&source_path)
+            .ok_or_else(|| anyhow!("could not load {}", source_path))?;
+        db.load_all_paths_for_file(file)?;
+
+        file_status.ok("loaded")?;
+
+        Ok(())
+    }
+
+    fn create_html(&self, db: &mut SQLiteReader) -> anyhow::Result<()> {
+        let (graph, partials, db) = db.get();
+        let mut db = {
+            let mut complete_paths_db = Database::new();
+            ForwardPartialPathStitcher::find_all_complete_partial_paths(
+                graph,
+                partials,
+                db,
+                graph.iter_nodes(),
+                &NoCancellation,
+                |g, ps, p| {
+                    complete_paths_db.add_partial_path(g, ps, p.clone());
+                },
+            )?;
+            complete_paths_db
+        };
+
+        let html = graph.to_html_string("stack-graph", partials, &mut db, &NoFilter)?;
+        if let Some(dir) = self.output.parent() {
+            std::fs::create_dir_all(dir)?;
+        }
+        std::fs::write(&self.output, html)
+            .with_context(|| format!("Unable to write graph {}", self.output.display()))?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Adds a new `visualize` command that takes file paths and generates a visualization for the given files. Won't scale to many files, definitely not to a whole repo, but should be very useful to debug specific problems in larger repos.

## Todo

Use handles in the serialization for file references, instead of the strings themselves. Currently the JSON data becomes very big, especially when long files names are involved.