### PR TITLE
Add skeleton LSP server and VSCode extension

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch tree-sitter-stack-graphs-typescript LSP extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}/languages/tree-sitter-stack-graphs-typescript/vscode"
+            ],
+            "preLaunchTask": {
+                "type": "npm",
+                "script": "build"
+            },
+            "outFiles": [
+                "${workspaceFolder}/languages/tree-sitter-stack-graphs-typescript/vscode/out/**/*.js"
+            ]
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,20 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "Compile tree-sitter-stack-graphs-typescript LSP extension",
+			"type": "npm",
+			"script": "build",
+			"group": {
+				"kind": "build"
+			},
+			"options": {
+				"cwd": "${workspaceFolder}/languages/tree-sitter-stack-graphs-typescript/vscode",
+			},
+			"presentation": {
+				"panel": "dedicated",
+				"reveal": "never"
+			}
+		}
+	]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,7 +13,7 @@
 			},
 			"presentation": {
 				"panel": "dedicated",
-				"reveal": "never"
+				"reveal": "always"
 			}
 		}
 	]

--- a/languages/tree-sitter-stack-graphs-java/rust/bin.rs
+++ b/languages/tree-sitter-stack-graphs-java/rust/bin.rs
@@ -14,7 +14,7 @@ fn main() -> anyhow::Result<()> {
     };
     let cli = Cli::parse();
     let default_db_path = default_user_database_path_for_crate(env!("CARGO_PKG_NAME"))?;
-    cli.subcommand.run(&default_db_path, vec![lc])
+    cli.subcommand.run(default_db_path, vec![lc])
 }
 
 #[derive(Parser)]

--- a/languages/tree-sitter-stack-graphs-typescript/Cargo.toml
+++ b/languages/tree-sitter-stack-graphs-typescript/Cargo.toml
@@ -26,6 +26,7 @@ required-features = ["test"] # should be a forced feature, but Cargo does not su
 [features]
 default = ["test"] # test is enabled by default because we cannot specify it as a forced featured for [[test]] above
 cli = ["anyhow", "clap", "tree-sitter-stack-graphs/cli"]
+lsp = ["tree-sitter-stack-graphs/lsp"]
 test = ["anyhow", "tree-sitter-stack-graphs/cli"]
 
 [dependencies]

--- a/languages/tree-sitter-stack-graphs-typescript/rust/bin.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/bin.rs
@@ -22,7 +22,7 @@ fn main() -> anyhow::Result<()> {
     };
     let cli = Cli::parse();
     let default_db_path = default_user_database_path_for_crate(env!("CARGO_PKG_NAME"))?;
-    cli.subcommand.run(&default_db_path, vec![lc])
+    cli.subcommand.run(default_db_path, vec![lc])
 }
 
 #[derive(Parser)]

--- a/languages/tree-sitter-stack-graphs-typescript/vscode/.gitignore
+++ b/languages/tree-sitter-stack-graphs-typescript/vscode/.gitignore
@@ -1,0 +1,3 @@
+/node_modules/
+/out/
+/target/

--- a/languages/tree-sitter-stack-graphs-typescript/vscode/package-lock.json
+++ b/languages/tree-sitter-stack-graphs-typescript/vscode/package-lock.json
@@ -1,0 +1,138 @@
+{
+    "name": "tree-sitter-stack-graphs-typescript",
+    "version": "0.0.1",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "tree-sitter-stack-graphs-typescript",
+            "version": "0.0.1",
+            "license": "MIT OR Apache-2.0",
+            "dependencies": {
+                "vscode-languageclient": "^8.1.0"
+            },
+            "devDependencies": {
+                "@types/node": "^16",
+                "@types/vscode": "^1.76.0",
+                "typescript": "^5"
+            },
+            "engines": {
+                "vscode": "^1.76.0"
+            }
+        },
+        "node_modules/@types/node": {
+            "version": "16.18.21",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.21.tgz",
+            "integrity": "sha512-TassPGd0AEZWA10qcNnXnSNwHlLfSth8XwUaWc3gTSDmBz/rKb613Qw5qRf6o2fdRBrLbsgeC9PMZshobkuUqg==",
+            "dev": true
+        },
+        "node_modules/@types/vscode": {
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.76.0.tgz",
+            "integrity": "sha512-CQcY3+Fe5hNewHnOEAVYj4dd1do/QHliXaknAEYSXx2KEHUzFibDZSKptCon+HPgK55xx20pR+PBJjf0MomnBA==",
+            "dev": true
+        },
+        "node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+        },
+        "node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/minimatch": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/semver": {
+            "version": "7.3.8",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
+            "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=12.20"
+            }
+        },
+        "node_modules/vscode-jsonrpc": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
+            "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/vscode-languageclient": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0.tgz",
+            "integrity": "sha512-GL4QdbYUF/XxQlAsvYWZRV3V34kOkpRlvV60/72ghHfsYFnS/v2MANZ9P6sHmxFcZKOse8O+L9G7Czg0NUWing==",
+            "dependencies": {
+                "minimatch": "^5.1.0",
+                "semver": "^7.3.7",
+                "vscode-languageserver-protocol": "3.17.3"
+            },
+            "engines": {
+                "vscode": "^1.67.0"
+            }
+        },
+        "node_modules/vscode-languageserver-protocol": {
+            "version": "3.17.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
+            "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
+            "dependencies": {
+                "vscode-jsonrpc": "8.1.0",
+                "vscode-languageserver-types": "3.17.3"
+            }
+        },
+        "node_modules/vscode-languageserver-types": {
+            "version": "3.17.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
+            "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
+        },
+        "node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+    }
+}

--- a/languages/tree-sitter-stack-graphs-typescript/vscode/package.json
+++ b/languages/tree-sitter-stack-graphs-typescript/vscode/package.json
@@ -1,0 +1,32 @@
+{
+    "name": "tree-sitter-stack-graphs-typescript",
+    "description": "Stack graphs based navigation for TypeScript",
+    "publisher": "GitHub",
+    "license": "(MIT OR Apache-2.0)",
+    "version": "0.0.1",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/github/stack-graphs"
+    },
+    "engines": {
+        "vscode": "^1.76.0"
+    },
+    "activationEvents": [
+        "onStartupFinished"
+    ],
+    "main": "./out/extension",
+    "dependencies": {
+        "vscode-languageclient": "^8.1.0"
+    },
+    "scripts": {
+        "build-cli": "cargo build --features cli,lsp --release --target-dir target",
+        "install-cli": "mkdir -p out/bin && cp target/release/tree-sitter-stack-graphs-typescript out/bin",
+        "build-ext": "tsc -b",
+        "build": "npm run build-cli && npm run build-ext && npm run install-cli"
+    },
+    "devDependencies": {
+        "@types/node": "^16",
+        "@types/vscode": "^1.76.0",
+        "typescript": "^5"
+    }
+}

--- a/languages/tree-sitter-stack-graphs-typescript/vscode/package.json
+++ b/languages/tree-sitter-stack-graphs-typescript/vscode/package.json
@@ -15,10 +15,36 @@
     "engines": {
         "vscode": "^1.76.0"
     },
+    "main": "./out/extension",
     "activationEvents": [
         "onStartupFinished"
     ],
-    "main": "./out/extension",
+    "contributes": {
+        "configuration": {
+            "title": "tree-sitter-stack-graphs-typescript",
+            "properties": {
+                "tree-sitter-stack-graphs-typescript.database.defaultLocation": {
+                    "markdownDescription": "The default location for the database, if an explicit path is not provided. _Requires reload for changes to take effect._",
+                    "type": "string",
+                    "default": "workspace",
+                    "enum": ["workspace", "user"],
+                    "enumDescriptions": [
+                        "Use a workspace-local database. Indexing data will not be shared between workspaces.",
+                        "Use the user database, stored in the user's local data directory. Indexing data is shared between workspaces."
+                    ],
+                    "scope": "machine-overridable",
+                    "order": 0
+                },
+                "tree-sitter-stack-graphs-typescript.database.path": {
+                    "markdownDescription": "The path to the database. Expands ~ to the user's home directory. _Requires reload for changes to take effect._",
+                    "type": "string",
+                    "default": null,
+                    "scope": "machine-overridable",
+                    "order": 1
+                }
+            }
+        }
+    },
     "dependencies": {
         "vscode-languageclient": "^8.1.0"
     },

--- a/languages/tree-sitter-stack-graphs-typescript/vscode/package.json
+++ b/languages/tree-sitter-stack-graphs-typescript/vscode/package.json
@@ -1,9 +1,13 @@
 {
     "name": "tree-sitter-stack-graphs-typescript",
     "description": "Stack graphs based navigation for TypeScript",
-    "publisher": "GitHub",
+    "author": "GitHub <opensource+stack-graphs@github.com>",
+    "contributors": [
+        "Hendrik van Antwerpen <hendrikvanantwerpen@github.com>"
+    ],
+    "publisher": "github",
     "license": "(MIT OR Apache-2.0)",
-    "version": "0.0.1",
+    "version": "0.1.0",
     "repository": {
         "type": "git",
         "url": "https://github.com/github/stack-graphs"

--- a/languages/tree-sitter-stack-graphs-typescript/vscode/src/extension.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/vscode/src/extension.ts
@@ -1,0 +1,38 @@
+import { workspace, ExtensionContext } from 'vscode';
+
+import {
+    Executable,
+    LanguageClient,
+    LanguageClientOptions,
+    ServerOptions,
+    TransportKind
+} from 'vscode-languageclient/node';
+
+let client: LanguageClient;
+
+export function activate(context: ExtensionContext) {
+    let path = context.asAbsolutePath("out/bin/tree-sitter-stack-graphs-typescript");
+    const serverOptions: ServerOptions = {
+        command: path,
+        args: ["lsp"]
+    };
+
+    const clientOptions: LanguageClientOptions = {
+    };
+
+    client = new LanguageClient(
+        "tree-sitter-stack-graphs-typescript",
+        "Stack graphs based navigation for TypeScript",
+        serverOptions,
+        clientOptions
+    );
+
+    client.start();
+}
+
+export function deactivate(): Thenable<void> | undefined {
+    if (!client) {
+        return undefined;
+    }
+    return client.stop();
+}

--- a/languages/tree-sitter-stack-graphs-typescript/vscode/src/extension.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/vscode/src/extension.ts
@@ -1,20 +1,21 @@
-import { workspace, ExtensionContext } from 'vscode';
+import { mkdirSync } from 'fs';
+import { ExtensionContext, Uri } from 'vscode';
 
 import {
-    Executable,
     LanguageClient,
     LanguageClientOptions,
-    ServerOptions,
-    TransportKind
+    ServerOptions
 } from 'vscode-languageclient/node';
 
 let client: LanguageClient;
 
 export function activate(context: ExtensionContext) {
     let path = context.asAbsolutePath("out/bin/tree-sitter-stack-graphs-typescript");
+    mkdirSync(context.storageUri.fsPath, { recursive: true });
+    let db = Uri.joinPath(context.storageUri, "tree-sitter-stack-graphs-typescript.sqlite").fsPath;
     const serverOptions: ServerOptions = {
         command: path,
-        args: ["lsp"]
+        args: ["lsp", "-D", db]
     };
 
     const clientOptions: LanguageClientOptions = {
@@ -31,8 +32,6 @@ export function activate(context: ExtensionContext) {
 }
 
 export function deactivate(): Thenable<void> | undefined {
-    if (!client) {
-        return undefined;
     }
-    return client.stop();
+    return client ? client.stop() : undefined;
 }

--- a/languages/tree-sitter-stack-graphs-typescript/vscode/src/extension.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/vscode/src/extension.ts
@@ -1,5 +1,5 @@
 import { mkdirSync } from 'fs';
-import { ExtensionContext, Uri } from 'vscode';
+import { ExtensionContext, StatusBarItem, Uri, window } from 'vscode';
 
 import {
     LanguageClient,
@@ -8,6 +8,7 @@ import {
 } from 'vscode-languageclient/node';
 
 let client: LanguageClient;
+let status: StatusBarItem;
 
 export function activate(context: ExtensionContext) {
     let path = context.asAbsolutePath("out/bin/tree-sitter-stack-graphs-typescript");
@@ -28,10 +29,16 @@ export function activate(context: ExtensionContext) {
         clientOptions
     );
 
+    status = window.createStatusBarItem();
+    status.text = "tree-sitter-stack-graphs-typescript"
+    status.show();
+
     client.start();
 }
 
 export function deactivate(): Thenable<void> | undefined {
+    if (status) {
+        status.dispose();
     }
     return client ? client.stop() : undefined;
 }

--- a/languages/tree-sitter-stack-graphs-typescript/vscode/tsconfig.json
+++ b/languages/tree-sitter-stack-graphs-typescript/vscode/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "compilerOptions": {
+        "module": "CommonJS",
+        "target": "ES2021",
+        "outDir": "out",
+        "rootDir": "src"
+    },
+    "include": [ "src" ],
+    "exclude": [ "node_modules" ]
+}

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -39,7 +39,11 @@ cli = [
   "time",
   "tree-sitter-config",
   "tree-sitter-graph/term-colors",
-  "walkdir"
+  "walkdir",
+]
+lsp = [
+  "tokio",
+  "tower-lsp",
 ]
 
 [dependencies]
@@ -64,6 +68,8 @@ sha1 = { version="0.10", optional=true }
 stack-graphs = { version="0.10", path="../stack-graphs" }
 thiserror = "1.0"
 time = { version = "0.3", optional = true }
+tokio = { version = "1.26", optional = true, features = ["rt", "io-std"] }
+tower-lsp = { version = "0.19", optional = true }
 tree-sitter = ">= 0.19"
 tree-sitter-config = { version = "0.19", optional = true }
 tree-sitter-graph = "0.9.1"

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -68,7 +68,7 @@ sha1 = { version="0.10", optional=true }
 stack-graphs = { version="0.10", path="../stack-graphs" }
 thiserror = "1.0"
 time = { version = "0.3", optional = true }
-tokio = { version = "1.26", optional = true, features = ["rt", "io-std"] }
+tokio = { version = "1.26", optional = true, features = ["io-std", "rt", "rt-multi-thread"] }
 tower-lsp = { version = "0.19", optional = true }
 tree-sitter = ">= 0.19"
 tree-sitter-config = { version = "0.19", optional = true }

--- a/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/main.rs
+++ b/tree-sitter-stack-graphs/src/bin/tree-sitter-stack-graphs/main.rs
@@ -19,5 +19,5 @@ pub struct Cli {
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     let default_db_path = default_user_database_path_for_crate(env!("CARGO_PKG_NAME"))?;
-    cli.subcommand.run(&default_db_path)
+    cli.subcommand.run(default_db_path)
 }

--- a/tree-sitter-stack-graphs/src/ci.rs
+++ b/tree-sitter-stack-graphs/src/ci.rs
@@ -61,8 +61,8 @@ impl Tester {
                 panic!("Test path {} does not exist", test_path.display());
             }
         }
-        let mut loader = Loader::from_language_configurations(self.configurations, None)
+        let loader = Loader::from_language_configurations(self.configurations, None)
             .expect("Expected loader");
-        TestArgs::new(test_paths).run(&mut loader)
+        TestArgs::new(test_paths).run(loader)
     }
 }

--- a/tree-sitter-stack-graphs/src/cli/clean.rs
+++ b/tree-sitter-stack-graphs/src/cli/clean.rs
@@ -41,7 +41,7 @@ pub struct CleanArgs {
 }
 
 impl CleanArgs {
-    pub fn run(&self, db_path: &Path) -> anyhow::Result<()> {
+    pub fn run(self, db_path: &Path) -> anyhow::Result<()> {
         if self.delete {
             self.delete(db_path)
         } else {

--- a/tree-sitter-stack-graphs/src/cli/database.rs
+++ b/tree-sitter-stack-graphs/src/cli/database.rs
@@ -8,7 +8,6 @@
 use anyhow::anyhow;
 use clap::Args;
 use clap::ValueHint;
-use std::path::Path;
 use std::path::PathBuf;
 
 /// CLI arguments for using a database.
@@ -25,10 +24,8 @@ pub struct DatabaseArgs {
 }
 
 impl DatabaseArgs {
-    pub fn get_or(&self, default_path: &Path) -> PathBuf {
-        self.database
-            .clone()
-            .unwrap_or_else(|| default_path.to_path_buf())
+    pub fn get_or(self, default_path: PathBuf) -> PathBuf {
+        self.database.clone().unwrap_or_else(|| default_path)
     }
 }
 

--- a/tree-sitter-stack-graphs/src/cli/index.rs
+++ b/tree-sitter-stack-graphs/src/cli/index.rs
@@ -92,7 +92,7 @@ impl IndexArgs {
         }
     }
 
-    pub fn run(&self, db_path: &Path, loader: &mut Loader) -> anyhow::Result<()> {
+    pub fn run(self, db_path: &Path, mut loader: Loader) -> anyhow::Result<()> {
         if self.wait_at_start {
             wait_for_input()?;
         }
@@ -113,7 +113,7 @@ impl IndexArgs {
                     self.analyze_file(
                         source_root,
                         source_path,
-                        loader,
+                        &mut loader,
                         &mut seen_mark,
                         &mut db,
                         false,
@@ -127,7 +127,7 @@ impl IndexArgs {
                 self.analyze_file(
                     source_root,
                     source_path,
-                    loader,
+                    &mut loader,
                     &mut seen_mark,
                     &mut db,
                     true,

--- a/tree-sitter-stack-graphs/src/cli/init.rs
+++ b/tree-sitter-stack-graphs/src/cli/init.rs
@@ -51,7 +51,7 @@ impl InitArgs {
         Self { project_path }
     }
 
-    pub fn run(&self) -> anyhow::Result<()> {
+    pub fn run(self) -> anyhow::Result<()> {
         self.check_project_dir()?;
         let mut config = ProjectSettings::default();
         loop {

--- a/tree-sitter-stack-graphs/src/cli/lsp.rs
+++ b/tree-sitter-stack-graphs/src/cli/lsp.rs
@@ -1,0 +1,55 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2023, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use clap::Args;
+use tower_lsp::jsonrpc::Result;
+use tower_lsp::lsp_types::*;
+use tower_lsp::Client;
+use tower_lsp::LanguageServer;
+use tower_lsp::LspService;
+use tower_lsp::Server;
+
+use crate::loader::Loader;
+
+#[derive(Args)]
+pub struct LspArgs {}
+
+impl LspArgs {
+    pub fn run(&self, _loader: &mut Loader) -> anyhow::Result<()> {
+        let rt = tokio::runtime::Builder::new_current_thread().build()?;
+        rt.block_on(async {
+            let stdin = tokio::io::stdin();
+            let stdout = tokio::io::stdout();
+
+            let (service, socket) = LspService::new(|client| Backend { client });
+            Server::new(stdin, stdout, socket).serve(service).await;
+        });
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct Backend {
+    client: Client,
+}
+
+#[tower_lsp::async_trait]
+impl LanguageServer for Backend {
+    async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
+        Ok(InitializeResult::default())
+    }
+
+    async fn initialized(&self, _: InitializedParams) {
+        self.client
+            .log_message(MessageType::INFO, "server initialized!")
+            .await;
+    }
+
+    async fn shutdown(&self) -> Result<()> {
+        Ok(())
+    }
+}

--- a/tree-sitter-stack-graphs/src/cli/lsp.rs
+++ b/tree-sitter-stack-graphs/src/cli/lsp.rs
@@ -6,7 +6,11 @@
 // ------------------------------------------------------------------------------------------------
 
 use clap::Args;
+use stack_graphs::storage::SQLiteWriter;
 use std::path::PathBuf;
+use std::sync::Arc;
+use tower_lsp::jsonrpc::Error;
+use tower_lsp::jsonrpc::ErrorCode;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::Client;
@@ -20,13 +24,16 @@ use crate::loader::Loader;
 pub struct LspArgs {}
 
 impl LspArgs {
-    pub fn run(self, _db_path: PathBuf, _loader: Loader) -> anyhow::Result<()> {
-        let rt = tokio::runtime::Builder::new_current_thread().build()?;
+    pub fn run(self, db_path: PathBuf, loader: Loader) -> anyhow::Result<()> {
+        let rt = tokio::runtime::Runtime::new()?;
         rt.block_on(async {
             let stdin = tokio::io::stdin();
             let stdout = tokio::io::stdout();
-
-            let (service, socket) = LspService::new(|client| Backend { client });
+            let (service, socket) = LspService::new(|client| Backend {
+                client,
+                db_path,
+                _loader: Arc::new(std::sync::Mutex::new(loader)),
+            });
             Server::new(stdin, stdout, socket).serve(service).await;
         });
         Ok(())
@@ -35,24 +42,147 @@ impl LspArgs {
 
 struct Backend {
     client: Client,
+    db_path: PathBuf,
+    _loader: Arc<std::sync::Mutex<Loader>>,
 }
 
 #[tower_lsp::async_trait]
 impl LanguageServer for Backend {
-    async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
-        Ok(InitializeResult::default())
+    async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
+        self.info("Initializing").await;
+
+        let _ = match SQLiteWriter::open(&self.db_path) {
+            Ok(db) => {
+                self.info(format!("Using database {}", self.db_path.display()))
+                    .await;
+                db
+            }
+            Err(err) => {
+                self.error(format!(
+                    "Failed to open database {}: {}",
+                    self.db_path.display(),
+                    err,
+                ))
+                .await;
+                return Err(err).from_error();
+            }
+        };
+
+        if let Some(folders) = params.workspace_folders {
+            for folder in &folders {
+                self.info(format!("Initial workspace folder {}", folder.uri))
+                    .await;
+            }
+        }
+
+        let result = InitializeResult {
+            capabilities: ServerCapabilities {
+                definition_provider: Some(OneOf::Left(true)),
+                text_document_sync: Some(
+                    TextDocumentSyncOptions {
+                        save: Some(true.into()),
+                        ..Default::default()
+                    }
+                    .into(),
+                ),
+                workspace: Some(WorkspaceServerCapabilities {
+                    workspace_folders: Some(WorkspaceFoldersServerCapabilities {
+                        supported: Some(true),
+                        change_notifications: Some(OneOf::Left(true)),
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        Ok(result)
     }
 
     async fn initialized(&self, _: InitializedParams) {
-        self.client
-            .log_message(MessageType::INFO, "Initialized")
+        self.info("Initialized").await;
+    }
+
+    async fn did_save(&self, params: DidSaveTextDocumentParams) {
+        self.info(format!("Saved document {}", params.text_document.uri))
             .await;
     }
 
+    async fn goto_definition(
+        &self,
+        params: GotoDefinitionParams,
+    ) -> Result<Option<GotoDefinitionResponse>> {
+        self.info(format!(
+            "Goto definition {}:{}:{}",
+            params.text_document_position_params.text_document.uri,
+            params.text_document_position_params.position.line + 1,
+            params.text_document_position_params.position.character + 1
+        ))
+        .await;
+        Ok(None)
+    }
+
+    async fn did_change_workspace_folders(&self, params: DidChangeWorkspaceFoldersParams) {
+        for folder in &params.event.removed {
+            self.info(format!("Removed workspace folder {}", folder.uri))
+                .await;
+        }
+        for folder in &params.event.added {
+            self.info(format!("Added workspace folder {}", folder.uri))
+                .await;
+        }
+    }
+
     async fn shutdown(&self) -> Result<()> {
-        self.client
-            .log_message(MessageType::INFO, "Shutting down")
-            .await;
+        self.info("Shutting down").await;
         Ok(())
+    }
+}
+
+impl Backend {
+    async fn info<M: std::fmt::Display>(&self, message: M) {
+        self.client.log_message(MessageType::INFO, message).await
+    }
+
+    async fn error<M: std::fmt::Display>(&self, message: M) {
+        self.client.log_message(MessageType::ERROR, message).await
+    }
+}
+
+trait FromStdError<T> {
+    #[must_use]
+    fn from_error(self) -> Result<T>;
+}
+
+impl<T, E: std::error::Error> FromStdError<T> for std::result::Result<T, E> {
+    #[must_use]
+    fn from_error(self) -> Result<T> {
+        match self {
+            Ok(value) => Ok(value),
+            Err(err) => Err(Error {
+                code: ErrorCode::ServerError(-1),
+                message: err.to_string(),
+                data: None,
+            }),
+        }
+    }
+}
+
+trait FromAnyhowError<T> {
+    #[must_use]
+    fn from_error(self) -> Result<T>;
+}
+
+impl<T> FromAnyhowError<T> for std::result::Result<T, anyhow::Error> {
+    #[must_use]
+    fn from_error(self) -> Result<T> {
+        match self {
+            Ok(value) => Ok(value),
+            Err(err) => Err(Error {
+                code: ErrorCode::ServerError(-1),
+                message: err.to_string(),
+                data: None,
+            }),
+        }
     }
 }

--- a/tree-sitter-stack-graphs/src/cli/lsp.rs
+++ b/tree-sitter-stack-graphs/src/cli/lsp.rs
@@ -6,6 +6,7 @@
 // ------------------------------------------------------------------------------------------------
 
 use clap::Args;
+use std::path::PathBuf;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::Client;
@@ -19,7 +20,7 @@ use crate::loader::Loader;
 pub struct LspArgs {}
 
 impl LspArgs {
-    pub fn run(&self, _loader: &mut Loader) -> anyhow::Result<()> {
+    pub fn run(self, _db_path: PathBuf, _loader: Loader) -> anyhow::Result<()> {
         let rt = tokio::runtime::Builder::new_current_thread().build()?;
         rt.block_on(async {
             let stdin = tokio::io::stdin();
@@ -32,7 +33,6 @@ impl LspArgs {
     }
 }
 
-#[derive(Debug)]
 struct Backend {
     client: Client,
 }
@@ -45,11 +45,14 @@ impl LanguageServer for Backend {
 
     async fn initialized(&self, _: InitializedParams) {
         self.client
-            .log_message(MessageType::INFO, "server initialized!")
+            .log_message(MessageType::INFO, "Initialized")
             .await;
     }
 
     async fn shutdown(&self) -> Result<()> {
+        self.client
+            .log_message(MessageType::INFO, "Shutting down")
+            .await;
         Ok(())
     }
 }

--- a/tree-sitter-stack-graphs/src/cli/parse.rs
+++ b/tree-sitter-stack-graphs/src/cli/parse.rs
@@ -28,8 +28,8 @@ pub struct ParseArgs {
 }
 
 impl ParseArgs {
-    pub fn run(&self, loader: &mut Loader) -> anyhow::Result<()> {
-        self.parse_file(&self.file_path, loader)?;
+    pub fn run(self, mut loader: Loader) -> anyhow::Result<()> {
+        self.parse_file(&self.file_path, &mut loader)?;
         Ok(())
     }
 

--- a/tree-sitter-stack-graphs/src/cli/query.rs
+++ b/tree-sitter-stack-graphs/src/cli/query.rs
@@ -35,7 +35,7 @@ pub struct QueryArgs {
 }
 
 impl QueryArgs {
-    pub fn run(&self, db_path: &Path) -> anyhow::Result<()> {
+    pub fn run(self, db_path: &Path) -> anyhow::Result<()> {
         if self.wait_at_start {
             wait_for_input()?;
         }
@@ -50,7 +50,7 @@ pub enum Target {
 }
 
 impl Target {
-    pub fn run(&self, db: &mut SQLiteReader) -> anyhow::Result<()> {
+    pub fn run(self, db: &mut SQLiteReader) -> anyhow::Result<()> {
         match self {
             Self::Definition(cmd) => cmd.run(db),
         }
@@ -70,9 +70,8 @@ pub struct Definition {
 }
 
 impl Definition {
-    pub fn run(&self, db: &mut SQLiteReader) -> anyhow::Result<()> {
-        for reference in &self.references {
-            let mut reference = reference.clone();
+    pub fn run(self, db: &mut SQLiteReader) -> anyhow::Result<()> {
+        for mut reference in self.references {
             reference.canonicalize()?;
 
             let mut file_reader = FileReader::new();

--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -162,7 +162,7 @@ impl TestArgs {
         }
     }
 
-    pub fn run(&self, loader: &mut Loader) -> anyhow::Result<()> {
+    pub fn run(self, mut loader: Loader) -> anyhow::Result<()> {
         let mut total_result = TestResult::new();
         for test_path in &self.test_paths {
             if test_path.is_dir() {
@@ -175,12 +175,12 @@ impl TestArgs {
                     .filter(|e| e.file_type().is_file())
                 {
                     let test_path = test_entry.path();
-                    let test_result = self.run_test(test_root, test_path, loader)?;
+                    let test_result = self.run_test(test_root, test_path, &mut loader)?;
                     total_result.absorb(test_result);
                 }
             } else {
                 let test_root = test_path.parent().unwrap();
-                let test_result = self.run_test(test_root, test_path, loader)?;
+                let test_result = self.run_test(test_root, test_path, &mut loader)?;
                 total_result.absorb(test_result);
             }
         }


### PR DESCRIPTION
| ◀️ #248 | #251 ▶️ |
|-|-|

This PR is part of the work to implement an LSP server (#242). This adds a noop LSP server and a VSCode plugin that uses it. This is just to get the scaffolding up, implementing the actual behavior will be done in follow-up PRs.

## Concerns

This PR implements the LSP server for `tree-sitter-stack-graphs-typescript`. This is because several configuration details (such as file extensions, language names) need to be replicated in the VSCode plugin `package.json`. This makes it a little difficult to set up the code such that we can easily have dedicated VSCode plugins for different languages as we can for the CLI itself.

I'm not sure yet what the best way to do that is. The main options I see are (a) using some templating in the VSCode plugin build, or (b) add a `vscode` command to the CLI that generates a plugin based on the language configuration in Rust.

Either way, I'm planning to first get to a working server + plugin for TypeScript and than think about how to reuse it.