### PR TITLE
Find paths depth-first instead of breadth-first

### DIFF
--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -2525,7 +2525,7 @@ impl PartialPaths {
                     )
                 }),
         );
-        while let Some((path, path_cycle_detector)) = queue.pop_front() {
+        while let Some((path, path_cycle_detector)) = queue.pop_back() {
             cancellation_flag.check("finding partial paths in file")?;
             let is_seed = path.edges.is_empty();
             copious_debugging!(" => {}", path.display(graph, self));
@@ -2585,7 +2585,7 @@ impl PartialPaths {
             .collect::<VecDeque<_>>();
         let mut partials = PartialPaths::new();
         let mut edges = Appendables::new();
-        while let Some((path, path_cycle_detector)) = queue.pop_front() {
+        while let Some((path, path_cycle_detector)) = queue.pop_back() {
             cancellation_flag.check("finding complete paths")?;
             if path.is_complete(graph) {
                 copious_debugging!("    * visit");

--- a/stack-graphs/src/stitching.rs
+++ b/stack-graphs/src/stitching.rs
@@ -736,7 +736,7 @@ impl ForwardPartialPathStitcher {
                 .zip(self.next_iteration.1.drain(..)),
         );
         let mut work_performed = 0;
-        while let Some((partial_path, cycle_detector)) = self.queue.pop_front() {
+        while let Some((partial_path, cycle_detector)) = self.queue.pop_back() {
             copious_debugging!(
                 "--> Candidate partial path {}",
                 partial_path.display(graph, partials)

--- a/stack-graphs/tests/it/serde.rs
+++ b/stack-graphs/tests/it/serde.rs
@@ -1061,14 +1061,35 @@ fn can_serialize_partial_paths() {
                             "file" : "test.py",
                             "local_id" : 5
                         }
+                    },
+                    {
+                        "precedence" : 0,
+                        "source" : {
+                            "file" : "test.py",
+                            "local_id" : 6
+                        }
+                    },
+                    {
+                        "precedence" : 0,
+                        "source" : {
+                            "file" : "test.py",
+                            "local_id" : 7
+                        }
+                    },
+                    {
+                        "precedence" : 0,
+                        "source" : {
+                            "file" : "test.py",
+                            "local_id" : 8
+                        }
                     }
                 ],
                 "end_node" : {
-                    "local_id" : 1
+                    "file" : "test.py",
+                    "local_id" : 9
                 },
                 "scope_stack_postcondition" : {
-                    "scopes" : [],
-                    "variable" : 1
+                    "scopes" : []
                 },
                 "scope_stack_precondition" : {
                     "scopes" : [],
@@ -1079,26 +1100,7 @@ fn can_serialize_partial_paths() {
                     "local_id" : 1
                 },
                 "symbol_stack_postcondition" : {
-                    "symbols" : [
-                        {
-                            "scopes" : {
-                                "scopes" : [
-                                    {
-                                        "file" : "test.py",
-                                        "local_id" : 3
-                                    }
-                                ],
-                                "variable" : 1
-                            },
-                            "symbol" : "()"
-                        },
-                        {
-                            "symbol" : "."
-                        },
-                        {
-                            "symbol" : "x"
-                        }
-                    ],
+                    "symbols" : [],
                     "variable" : 1
                 },
                 "symbol_stack_precondition" : {
@@ -1211,35 +1213,14 @@ fn can_serialize_partial_paths() {
                             "file" : "test.py",
                             "local_id" : 5
                         }
-                    },
-                    {
-                        "precedence" : 0,
-                        "source" : {
-                            "file" : "test.py",
-                            "local_id" : 6
-                        }
-                    },
-                    {
-                        "precedence" : 0,
-                        "source" : {
-                            "file" : "test.py",
-                            "local_id" : 7
-                        }
-                    },
-                    {
-                        "precedence" : 0,
-                        "source" : {
-                            "file" : "test.py",
-                            "local_id" : 8
-                        }
                     }
                 ],
                 "end_node" : {
-                    "file" : "test.py",
-                    "local_id" : 9
+                    "local_id" : 1
                 },
                 "scope_stack_postcondition" : {
-                    "scopes" : []
+                    "scopes" : [],
+                    "variable" : 1
                 },
                 "scope_stack_precondition" : {
                     "scopes" : [],
@@ -1250,7 +1231,26 @@ fn can_serialize_partial_paths() {
                     "local_id" : 1
                 },
                 "symbol_stack_postcondition" : {
-                    "symbols" : [],
+                    "symbols" : [
+                        {
+                            "scopes" : {
+                                "scopes" : [
+                                    {
+                                        "file" : "test.py",
+                                        "local_id" : 3
+                                    }
+                                ],
+                                "variable" : 1
+                            },
+                            "symbol" : "()"
+                        },
+                        {
+                            "symbol" : "."
+                        },
+                        {
+                            "symbol" : "x"
+                        }
+                    ],
                     "variable" : 1
                 },
                 "symbol_stack_precondition" : {


### PR DESCRIPTION
Now that we have per-path cycle detection, we can experiment with different strategies for path finding. This PR replaces the previous breadth-first search with a depth-first search to see if that has any impact on the memory usage of indexing.
