### PR TITLE
Improve CLI reported errors

### DIFF
--- a/languages/tree-sitter-stack-graphs-java/rust/bin.rs
+++ b/languages/tree-sitter-stack-graphs-java/rust/bin.rs
@@ -1,13 +1,18 @@
+use anyhow::anyhow;
 use clap::Parser;
 use tree_sitter_stack_graphs::cli::provided_languages::Subcommands;
 use tree_sitter_stack_graphs::NoCancellation;
 
 fn main() -> anyhow::Result<()> {
+    let lc = match tree_sitter_stack_graphs_java::try_language_configuration(&NoCancellation) {
+        Ok(lc) => lc,
+        Err(err) => {
+            eprintln!("{}", err);
+            return Err(anyhow!("Language configuration error"));
+        }
+    };
     let cli = Cli::parse();
-    cli.subcommand
-        .run(vec![tree_sitter_stack_graphs_java::language_configuration(
-            &NoCancellation,
-        )])
+    cli.subcommand.run(vec![lc])
 }
 
 #[derive(Parser)]

--- a/languages/tree-sitter-stack-graphs-java/rust/bin.rs
+++ b/languages/tree-sitter-stack-graphs-java/rust/bin.rs
@@ -7,7 +7,7 @@ fn main() -> anyhow::Result<()> {
     let lc = match tree_sitter_stack_graphs_java::try_language_configuration(&NoCancellation) {
         Ok(lc) => lc,
         Err(err) => {
-            eprintln!("{}", err);
+            eprintln!("{}", err.display_pretty());
             return Err(anyhow!("Language configuration error"));
         }
     };

--- a/languages/tree-sitter-stack-graphs-java/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-java/rust/lib.rs
@@ -10,6 +10,8 @@ pub const STACK_GRAPHS_TSG_SOURCE: &str = include_str!("../src/stack-graphs.tsg"
 
 /// The stack graphs builtins configuration for this language.
 pub const STACK_GRAPHS_BUILTINS_CONFIG: &str = include_str!("../src/builtins.cfg");
+/// The stack graphs builtins path for this language.
+pub const STACK_GRAPHS_BUILTINS_PATH: &str = "src/builtins.java";
 /// The stack graphs builtins source for this language.
 pub const STACK_GRAPHS_BUILTINS_SOURCE: &str = include_str!("../src/builtins.java");
 
@@ -32,7 +34,10 @@ pub fn try_language_configuration(
         vec![String::from("java")],
         STACK_GRAPHS_TSG_PATH.into(),
         STACK_GRAPHS_TSG_SOURCE,
-        Some(STACK_GRAPHS_BUILTINS_SOURCE),
+        Some((
+            STACK_GRAPHS_BUILTINS_PATH.into(),
+            STACK_GRAPHS_BUILTINS_SOURCE,
+        )),
         Some(STACK_GRAPHS_BUILTINS_CONFIG),
         FileAnalyzers::new(),
         cancellation_flag,

--- a/languages/tree-sitter-stack-graphs-java/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-java/rust/lib.rs
@@ -19,10 +19,7 @@ pub const FILE_PATH_VAR: &str = "FILE_PATH";
 pub const PROJECT_NAME_VAR: &str = "PROJECT_NAME";
 
 pub fn language_configuration(cancellation_flag: &dyn CancellationFlag) -> LanguageConfiguration {
-    match try_language_configuration(cancellation_flag) {
-        Ok(lc) => lc,
-        Err(err) => panic!("{}", err),
-    }
+    try_language_configuration(cancellation_flag).unwrap_or_else(|err| panic!("{}", err))
 }
 
 pub fn try_language_configuration(

--- a/languages/tree-sitter-stack-graphs-java/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-java/rust/lib.rs
@@ -16,7 +16,7 @@ pub const FILE_PATH_VAR: &str = "FILE_PATH";
 pub const PROJECT_NAME_VAR: &str = "PROJECT_NAME";
 
 pub fn language_configuration(cancellation_flag: &dyn CancellationFlag) -> LanguageConfiguration {
-    LanguageConfiguration::from_tsg_str(
+    match LanguageConfiguration::from_tsg_str(
         tree_sitter_java::language(),
         Some(String::from("source.java")),
         None,
@@ -26,6 +26,8 @@ pub fn language_configuration(cancellation_flag: &dyn CancellationFlag) -> Langu
         Some(STACK_GRAPHS_BUILTINS_CONFIG),
         FileAnalyzers::new(),
         cancellation_flag,
-    )
-    .unwrap()
+    ) {
+        Ok(lc) => lc,
+        Err(err) => panic!("{}", err),
+    }
 }

--- a/languages/tree-sitter-stack-graphs-java/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-java/rust/lib.rs
@@ -1,5 +1,6 @@
 use tree_sitter_stack_graphs::loader::FileAnalyzers;
 use tree_sitter_stack_graphs::loader::LanguageConfiguration;
+use tree_sitter_stack_graphs::loader::LoadError;
 use tree_sitter_stack_graphs::CancellationFlag;
 
 /// The stack graphs tsg source for this language
@@ -16,7 +17,16 @@ pub const FILE_PATH_VAR: &str = "FILE_PATH";
 pub const PROJECT_NAME_VAR: &str = "PROJECT_NAME";
 
 pub fn language_configuration(cancellation_flag: &dyn CancellationFlag) -> LanguageConfiguration {
-    match LanguageConfiguration::from_tsg_str(
+    match try_language_configuration(cancellation_flag) {
+        Ok(lc) => lc,
+        Err(err) => panic!("{}", err),
+    }
+}
+
+pub fn try_language_configuration(
+    cancellation_flag: &dyn CancellationFlag,
+) -> Result<LanguageConfiguration, LoadError> {
+    LanguageConfiguration::from_tsg_str(
         tree_sitter_java::language(),
         Some(String::from("source.java")),
         None,
@@ -26,8 +36,5 @@ pub fn language_configuration(cancellation_flag: &dyn CancellationFlag) -> Langu
         Some(STACK_GRAPHS_BUILTINS_CONFIG),
         FileAnalyzers::new(),
         cancellation_flag,
-    ) {
-        Ok(lc) => lc,
-        Err(err) => panic!("{}", err),
-    }
+    )
 }

--- a/languages/tree-sitter-stack-graphs-java/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-java/rust/lib.rs
@@ -1,16 +1,16 @@
-use std::path::PathBuf;
-
 use tree_sitter_stack_graphs::loader::FileAnalyzers;
 use tree_sitter_stack_graphs::loader::LanguageConfiguration;
 use tree_sitter_stack_graphs::loader::LoadError;
 use tree_sitter_stack_graphs::CancellationFlag;
 
-/// The stack graphs tsg source for this language
+/// The stacks graphs tsg path for this language.
+pub const STACK_GRAPHS_TSG_PATH: &str = "src/stack-graphs.tsg";
+/// The stack graphs tsg source for this language.
 pub const STACK_GRAPHS_TSG_SOURCE: &str = include_str!("../src/stack-graphs.tsg");
 
-/// The stack graphs builtins configuration for this language
+/// The stack graphs builtins configuration for this language.
 pub const STACK_GRAPHS_BUILTINS_CONFIG: &str = include_str!("../src/builtins.cfg");
-/// The stack graphs builtins source for this language
+/// The stack graphs builtins source for this language.
 pub const STACK_GRAPHS_BUILTINS_SOURCE: &str = include_str!("../src/builtins.java");
 
 /// The name of the file path global variable
@@ -25,12 +25,12 @@ pub fn language_configuration(cancellation_flag: &dyn CancellationFlag) -> Langu
 pub fn try_language_configuration(
     cancellation_flag: &dyn CancellationFlag,
 ) -> Result<LanguageConfiguration, LoadError> {
-    LanguageConfiguration::from_tsg_file(
+    LanguageConfiguration::from_sources(
         tree_sitter_java::language(),
         Some(String::from("source.java")),
         None,
         vec![String::from("java")],
-        PathBuf::from("src/stack-graphs.tsg"),
+        STACK_GRAPHS_TSG_PATH.into(),
         STACK_GRAPHS_TSG_SOURCE,
         Some(STACK_GRAPHS_BUILTINS_SOURCE),
         Some(STACK_GRAPHS_BUILTINS_CONFIG),

--- a/languages/tree-sitter-stack-graphs-java/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-java/rust/lib.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use tree_sitter_stack_graphs::loader::FileAnalyzers;
 use tree_sitter_stack_graphs::loader::LanguageConfiguration;
 use tree_sitter_stack_graphs::loader::LoadError;
@@ -26,11 +28,12 @@ pub fn language_configuration(cancellation_flag: &dyn CancellationFlag) -> Langu
 pub fn try_language_configuration(
     cancellation_flag: &dyn CancellationFlag,
 ) -> Result<LanguageConfiguration, LoadError> {
-    LanguageConfiguration::from_tsg_str(
+    LanguageConfiguration::from_tsg_file(
         tree_sitter_java::language(),
         Some(String::from("source.java")),
         None,
         vec![String::from("java")],
+        PathBuf::from("src/stack-graphs.tsg"),
         STACK_GRAPHS_TSG_SOURCE,
         Some(STACK_GRAPHS_BUILTINS_SOURCE),
         Some(STACK_GRAPHS_BUILTINS_CONFIG),

--- a/languages/tree-sitter-stack-graphs-java/rust/test.rs
+++ b/languages/tree-sitter-stack-graphs-java/rust/test.rs
@@ -6,7 +6,7 @@ fn main() -> anyhow::Result<()> {
     let lc = match tree_sitter_stack_graphs_java::try_language_configuration(&NoCancellation) {
         Ok(lc) => lc,
         Err(err) => {
-            eprintln!("{}", err);
+            eprintln!("{}", err.display_pretty());
             return Err(anyhow!("Language configuration error"));
         }
     };

--- a/languages/tree-sitter-stack-graphs-java/rust/test.rs
+++ b/languages/tree-sitter-stack-graphs-java/rust/test.rs
@@ -1,13 +1,15 @@
+use anyhow::anyhow;
 use std::path::PathBuf;
 use tree_sitter_stack_graphs::{ci::Tester, NoCancellation};
 
 fn main() -> anyhow::Result<()> {
+    let lc = match tree_sitter_stack_graphs_java::try_language_configuration(&NoCancellation) {
+        Ok(lc) => lc,
+        Err(err) => {
+            eprintln!("{}", err);
+            return Err(anyhow!("Language configuration error"));
+        }
+    };
     let test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test");
-    Tester::new(
-        vec![tree_sitter_stack_graphs_java::language_configuration(
-            &NoCancellation,
-        )],
-        vec![test_path],
-    )
-    .run()
+    Tester::new(vec![lc], vec![test_path]).run()
 }

--- a/languages/tree-sitter-stack-graphs-typescript/rust/bin.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/bin.rs
@@ -5,15 +5,22 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+use anyhow::anyhow;
 use clap::Parser;
 use tree_sitter_stack_graphs::cli::provided_languages::Subcommands;
 use tree_sitter_stack_graphs::NoCancellation;
 
 fn main() -> anyhow::Result<()> {
+    let lc = match tree_sitter_stack_graphs_typescript::try_language_configuration(&NoCancellation)
+    {
+        Ok(lc) => lc,
+        Err(err) => {
+            eprintln!("{}", err);
+            return Err(anyhow!("Language configuration error"));
+        }
+    };
     let cli = Cli::parse();
-    cli.subcommand.run(vec![
-        tree_sitter_stack_graphs_typescript::language_configuration(&NoCancellation),
-    ])
+    cli.subcommand.run(vec![lc])
 }
 
 #[derive(Parser)]

--- a/languages/tree-sitter-stack-graphs-typescript/rust/bin.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/bin.rs
@@ -15,7 +15,7 @@ fn main() -> anyhow::Result<()> {
     {
         Ok(lc) => lc,
         Err(err) => {
-            eprintln!("{}", err);
+            eprintln!("{}", err.display_pretty());
             return Err(anyhow!("Language configuration error"));
         }
     };

--- a/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
@@ -33,10 +33,7 @@ pub const FILE_PATH_VAR: &str = "FILE_PATH";
 pub const PROJECT_NAME_VAR: &str = "PROJECT_NAME";
 
 pub fn language_configuration(cancellation_flag: &dyn CancellationFlag) -> LanguageConfiguration {
-    match try_language_configuration(cancellation_flag) {
-        Ok(lc) => lc,
-        Err(err) => panic!("{}", err),
-    }
+    try_language_configuration(cancellation_flag).unwrap_or_else(|err| panic!("{}", err))
 }
 
 pub fn try_language_configuration(

--- a/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
@@ -30,7 +30,7 @@ pub const FILE_PATH_VAR: &str = "FILE_PATH";
 pub const PROJECT_NAME_VAR: &str = "PROJECT_NAME";
 
 pub fn language_configuration(cancellation_flag: &dyn CancellationFlag) -> LanguageConfiguration {
-    LanguageConfiguration::from_tsg_str(
+    match LanguageConfiguration::from_tsg_str(
         tree_sitter_typescript::language_typescript(),
         Some(String::from("source.ts")),
         None,
@@ -42,6 +42,8 @@ pub fn language_configuration(cancellation_flag: &dyn CancellationFlag) -> Langu
             .add("tsconfig.json".to_string(), TsConfigAnalyzer {})
             .add("package.json".to_string(), NpmPackageAnalyzer {}),
         cancellation_flag,
-    )
-    .unwrap()
+    ) {
+        Ok(lc) => lc,
+        Err(err) => panic!("{}", err),
+    }
 }

--- a/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
@@ -5,6 +5,8 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+use std::path::PathBuf;
+
 use tree_sitter_stack_graphs::loader::FileAnalyzers;
 use tree_sitter_stack_graphs::loader::LanguageConfiguration;
 use tree_sitter_stack_graphs::loader::LoadError;
@@ -40,11 +42,12 @@ pub fn language_configuration(cancellation_flag: &dyn CancellationFlag) -> Langu
 pub fn try_language_configuration(
     cancellation_flag: &dyn CancellationFlag,
 ) -> Result<LanguageConfiguration, LoadError> {
-    LanguageConfiguration::from_tsg_str(
+    LanguageConfiguration::from_tsg_file(
         tree_sitter_typescript::language_typescript(),
         Some(String::from("source.ts")),
         None,
         vec![String::from("ts")],
+        PathBuf::from("src/stack-graphs.tsg"),
         STACK_GRAPHS_TSG_SOURCE,
         Some(STACK_GRAPHS_BUILTINS_SOURCE),
         Some(STACK_GRAPHS_BUILTINS_CONFIG),

--- a/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
@@ -5,8 +5,6 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-use std::path::PathBuf;
-
 use tree_sitter_stack_graphs::loader::FileAnalyzers;
 use tree_sitter_stack_graphs::loader::LanguageConfiguration;
 use tree_sitter_stack_graphs::loader::LoadError;
@@ -19,6 +17,8 @@ pub mod npm_package;
 pub mod tsconfig;
 pub mod util;
 
+/// The stacks graphs tsg path for this language.
+pub const STACK_GRAPHS_TSG_PATH: &str = "src/stack-graphs.tsg";
 /// The stack graphs tsg source for this language
 pub const STACK_GRAPHS_TSG_SOURCE: &str = include_str!("../src/stack-graphs.tsg");
 
@@ -39,12 +39,12 @@ pub fn language_configuration(cancellation_flag: &dyn CancellationFlag) -> Langu
 pub fn try_language_configuration(
     cancellation_flag: &dyn CancellationFlag,
 ) -> Result<LanguageConfiguration, LoadError> {
-    LanguageConfiguration::from_tsg_file(
+    LanguageConfiguration::from_sources(
         tree_sitter_typescript::language_typescript(),
         Some(String::from("source.ts")),
         None,
         vec![String::from("ts")],
-        PathBuf::from("src/stack-graphs.tsg"),
+        STACK_GRAPHS_TSG_PATH.into(),
         STACK_GRAPHS_TSG_SOURCE,
         Some(STACK_GRAPHS_BUILTINS_SOURCE),
         Some(STACK_GRAPHS_BUILTINS_CONFIG),

--- a/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
@@ -24,6 +24,8 @@ pub const STACK_GRAPHS_TSG_SOURCE: &str = include_str!("../src/stack-graphs.tsg"
 
 /// The stack graphs builtins configuration for this language
 pub const STACK_GRAPHS_BUILTINS_CONFIG: &str = include_str!("../src/builtins.cfg");
+/// The stack graphs builtins path for this language
+pub const STACK_GRAPHS_BUILTINS_PATH: &str = "src/builtins.ts";
 /// The stack graphs builtins source for this language
 pub const STACK_GRAPHS_BUILTINS_SOURCE: &str = include_str!("../src/builtins.ts");
 
@@ -46,7 +48,10 @@ pub fn try_language_configuration(
         vec![String::from("ts")],
         STACK_GRAPHS_TSG_PATH.into(),
         STACK_GRAPHS_TSG_SOURCE,
-        Some(STACK_GRAPHS_BUILTINS_SOURCE),
+        Some((
+            STACK_GRAPHS_BUILTINS_PATH.into(),
+            STACK_GRAPHS_BUILTINS_SOURCE,
+        )),
         Some(STACK_GRAPHS_BUILTINS_CONFIG),
         FileAnalyzers::new()
             .add("tsconfig.json".to_string(), TsConfigAnalyzer {})

--- a/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
@@ -7,6 +7,7 @@
 
 use tree_sitter_stack_graphs::loader::FileAnalyzers;
 use tree_sitter_stack_graphs::loader::LanguageConfiguration;
+use tree_sitter_stack_graphs::loader::LoadError;
 use tree_sitter_stack_graphs::CancellationFlag;
 
 use crate::npm_package::NpmPackageAnalyzer;
@@ -30,7 +31,16 @@ pub const FILE_PATH_VAR: &str = "FILE_PATH";
 pub const PROJECT_NAME_VAR: &str = "PROJECT_NAME";
 
 pub fn language_configuration(cancellation_flag: &dyn CancellationFlag) -> LanguageConfiguration {
-    match LanguageConfiguration::from_tsg_str(
+    match try_language_configuration(cancellation_flag) {
+        Ok(lc) => lc,
+        Err(err) => panic!("{}", err),
+    }
+}
+
+pub fn try_language_configuration(
+    cancellation_flag: &dyn CancellationFlag,
+) -> Result<LanguageConfiguration, LoadError> {
+    LanguageConfiguration::from_tsg_str(
         tree_sitter_typescript::language_typescript(),
         Some(String::from("source.ts")),
         None,
@@ -42,8 +52,5 @@ pub fn language_configuration(cancellation_flag: &dyn CancellationFlag) -> Langu
             .add("tsconfig.json".to_string(), TsConfigAnalyzer {})
             .add("package.json".to_string(), NpmPackageAnalyzer {}),
         cancellation_flag,
-    ) {
-        Ok(lc) => lc,
-        Err(err) => panic!("{}", err),
-    }
+    )
 }

--- a/languages/tree-sitter-stack-graphs-typescript/rust/npm_package.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/npm_package.rs
@@ -12,8 +12,8 @@ use std::path::Path;
 use stack_graphs::arena::Handle;
 use stack_graphs::graph::File;
 use stack_graphs::graph::StackGraph;
+use tree_sitter_stack_graphs::BuildError;
 use tree_sitter_stack_graphs::FileAnalyzer;
-use tree_sitter_stack_graphs::LoadError;
 
 use crate::util::*;
 
@@ -29,13 +29,13 @@ impl FileAnalyzer for NpmPackageAnalyzer {
         _all_paths: &mut dyn Iterator<Item = &'a Path>,
         globals: &HashMap<String, String>,
         _cancellation_flag: &dyn tree_sitter_stack_graphs::CancellationFlag,
-    ) -> Result<(), tree_sitter_stack_graphs::LoadError> {
+    ) -> Result<(), tree_sitter_stack_graphs::BuildError> {
         // read globals
         let proj_name = globals.get(crate::PROJECT_NAME_VAR).map(String::as_str);
 
         // parse source
         let npm_pkg: NpmPackage =
-            serde_json::from_str(source).map_err(|_| LoadError::ParseError)?;
+            serde_json::from_str(source).map_err(|_| BuildError::ParseError)?;
 
         // root node
         let root = StackGraph::root_node();

--- a/languages/tree-sitter-stack-graphs-typescript/rust/test.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/test.rs
@@ -5,17 +5,20 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+use anyhow::anyhow;
 use std::path::PathBuf;
 use tree_sitter_stack_graphs::ci::Tester;
 use tree_sitter_stack_graphs::NoCancellation;
 
 fn main() -> anyhow::Result<()> {
+    let lc = match tree_sitter_stack_graphs_typescript::try_language_configuration(&NoCancellation)
+    {
+        Ok(lc) => lc,
+        Err(err) => {
+            eprintln!("{}", err);
+            return Err(anyhow!("Language configuration error"));
+        }
+    };
     let test_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test");
-    Tester::new(
-        vec![tree_sitter_stack_graphs_typescript::language_configuration(
-            &NoCancellation,
-        )],
-        vec![test_path],
-    )
-    .run()
+    Tester::new(vec![lc], vec![test_path]).run()
 }

--- a/languages/tree-sitter-stack-graphs-typescript/rust/test.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/test.rs
@@ -15,7 +15,7 @@ fn main() -> anyhow::Result<()> {
     {
         Ok(lc) => lc,
         Err(err) => {
-            eprintln!("{}", err);
+            eprintln!("{}", err.display_pretty());
             return Err(anyhow!("Language configuration error"));
         }
     };

--- a/languages/tree-sitter-stack-graphs-typescript/rust/tsconfig.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/tsconfig.rs
@@ -14,8 +14,8 @@ use std::path::PathBuf;
 use stack_graphs::arena::Handle;
 use stack_graphs::graph::File;
 use stack_graphs::graph::StackGraph;
+use tree_sitter_stack_graphs::BuildError;
 use tree_sitter_stack_graphs::FileAnalyzer;
-use tree_sitter_stack_graphs::LoadError;
 
 use crate::util::*;
 
@@ -31,12 +31,12 @@ impl FileAnalyzer for TsConfigAnalyzer {
         all_paths: &mut dyn Iterator<Item = &'a Path>,
         globals: &HashMap<String, String>,
         _cancellation_flag: &dyn tree_sitter_stack_graphs::CancellationFlag,
-    ) -> Result<(), tree_sitter_stack_graphs::LoadError> {
+    ) -> Result<(), tree_sitter_stack_graphs::BuildError> {
         // read globals
         let proj_name = globals.get(crate::PROJECT_NAME_VAR).map(String::as_str);
 
         // parse source
-        let tsc = TsConfig::parse_str(path, source).map_err(|_| LoadError::ParseError)?;
+        let tsc = TsConfig::parse_str(path, source).map_err(|_| BuildError::ParseError)?;
 
         // root node
         let root = StackGraph::root_node();
@@ -159,9 +159,9 @@ struct TsConfig {
 }
 
 impl TsConfig {
-    fn parse_str(path: &Path, source: &str) -> Result<Self, LoadError> {
-        let project_dir = path.parent().ok_or(LoadError::ParseError)?.to_path_buf();
-        let tsc = tsconfig::TsConfig::parse_str(source).map_err(|_| LoadError::ParseError)?;
+    fn parse_str(path: &Path, source: &str) -> Result<Self, BuildError> {
+        let project_dir = path.parent().ok_or(BuildError::ParseError)?.to_path_buf();
+        let tsc = tsconfig::TsConfig::parse_str(source).map_err(|_| BuildError::ParseError)?;
         Ok(Self { project_dir, tsc })
     }
 }

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -58,7 +58,7 @@ thiserror = "1.0"
 time = { version = "0.3", optional = true }
 tree-sitter = ">= 0.19"
 tree-sitter-config = { version = "0.19", optional = true }
-tree-sitter-graph = "0.7"
+tree-sitter-graph = "0.8"
 tree-sitter-loader = "0.20"
 walkdir = { version = "2.3", optional = true }
 

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -34,6 +34,7 @@ cli = [
   "stack-graphs/visualization",
   "time",
   "tree-sitter-config",
+  "tree-sitter-graph/term-colors",
   "walkdir"
 ]
 

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -59,7 +59,7 @@ thiserror = "1.0"
 time = { version = "0.3", optional = true }
 tree-sitter = ">= 0.19"
 tree-sitter-config = { version = "0.19", optional = true }
-tree-sitter-graph = "0.9"
+tree-sitter-graph = "0.9.1"
 tree-sitter-loader = "0.20"
 walkdir = { version = "2.3", optional = true }
 

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -59,7 +59,7 @@ thiserror = "1.0"
 time = { version = "0.3", optional = true }
 tree-sitter = ">= 0.19"
 tree-sitter-config = { version = "0.19", optional = true }
-tree-sitter-graph = "0.8"
+tree-sitter-graph = "0.9"
 tree-sitter-loader = "0.20"
 walkdir = { version = "2.3", optional = true }
 

--- a/tree-sitter-stack-graphs/src/cli.rs
+++ b/tree-sitter-stack-graphs/src/cli.rs
@@ -53,8 +53,6 @@
 //! }
 //! ```
 
-pub(self) const MAX_PARSE_ERRORS: usize = 5;
-
 pub mod analyze;
 pub mod init;
 pub mod load;

--- a/tree-sitter-stack-graphs/src/cli/analyze.rs
+++ b/tree-sitter-stack-graphs/src/cli/analyze.rs
@@ -220,7 +220,12 @@ impl AnalyzeArgs {
                 if !self.hide_error_details {
                     println!(
                         "{}",
-                        err.display_pretty(source_path, source, Path::new(""), "")
+                        err.display_pretty(
+                            source_path,
+                            source,
+                            lc.sgl.tsg_path(),
+                            lc.sgl.tsg_source()
+                        )
                     );
                 }
                 return Ok(());
@@ -228,10 +233,15 @@ impl AnalyzeArgs {
             Err(err) => {
                 file_status.error("failed to build stack graph")?;
                 if !self.hide_error_details {
-                    // TODO can we have access to the TSG source here?
-                    let tsg_path = Path::new("");
-                    let tsg = "";
-                    println!("{}", err.display_pretty(source_path, source, tsg_path, tsg));
+                    println!(
+                        "{}",
+                        err.display_pretty(
+                            source_path,
+                            source,
+                            lc.sgl.tsg_path(),
+                            lc.sgl.tsg_source()
+                        )
+                    );
                 }
                 return Err(anyhow!(
                     "Failed to build graph for {}",

--- a/tree-sitter-stack-graphs/src/cli/analyze.rs
+++ b/tree-sitter-stack-graphs/src/cli/analyze.rs
@@ -24,9 +24,9 @@ use crate::cli::util::duration_from_seconds_str;
 use crate::cli::util::path_exists;
 use crate::loader::FileReader;
 use crate::loader::Loader;
+use crate::BuildError;
 use crate::CancelAfterDuration;
 use crate::CancellationFlag;
-use crate::LoadError;
 use crate::NoCancellation;
 
 use super::util::FileStatusLogger;
@@ -211,11 +211,11 @@ impl AnalyzeArgs {
             )
         };
         match result {
-            Err(LoadError::Cancelled(_)) => {
+            Err(BuildError::Cancelled(_)) => {
                 file_status.warn("parsing timed out")?;
                 return Ok(());
             }
-            Err(err @ LoadError::ParseErrors(_)) => {
+            Err(err @ BuildError::ParseErrors(_)) => {
                 file_status.error("parsing failed")?;
                 if !self.hide_error_details {
                     println!(

--- a/tree-sitter-stack-graphs/src/cli/init.rs
+++ b/tree-sitter-stack-graphs/src/cli/init.rs
@@ -579,10 +579,7 @@ impl ProjectSettings {
             pub const FILE_PATH_VAR: &str = "FILE_PATH";
 
             pub fn language_configuration(cancellation_flag: &dyn CancellationFlag) -> LanguageConfiguration {{
-                match try_language_configuration(cancellation_flag) {{
-                    Ok(lc) => lc,
-                    Err(err) => panic!("{{}}", err),
-                }}
+                try_language_configuration(cancellation_flag).unwrap_or_else(|err| panic!("{{}}", err))
             }}
 
             pub fn try_language_configuration(

--- a/tree-sitter-stack-graphs/src/cli/init.rs
+++ b/tree-sitter-stack-graphs/src/cli/init.rs
@@ -569,7 +569,7 @@ impl ProjectSettings {
             pub const FILE_PATH_VAR: &str = "FILE_PATH";
 
             pub fn language_configuration(cancellation_flag: &dyn CancellationFlag) -> LanguageConfiguration {{
-                LanguageConfiguration::from_tsg_str(
+                match LanguageConfiguration::from_tsg_str(
                     {}::language(),
                     Some(String::from("source.{}")),
                     None,
@@ -579,8 +579,10 @@ impl ProjectSettings {
                     Some(STACK_GRAPHS_BUILTINS_CONFIG),
                     FileAnalyzers::new(),
                     cancellation_flag,
-                )
-                .unwrap()
+                ) {{
+                    Ok(lc) => lc,
+                    Err(err) => panic!("{{}}", err),
+                }}
             }}
             "#,
             self.language_file_extension,

--- a/tree-sitter-stack-graphs/src/cli/init.rs
+++ b/tree-sitter-stack-graphs/src/cli/init.rs
@@ -536,7 +536,7 @@ impl ProjectSettings {
                 {{
                     Ok(lc) => lc,
                     Err(err) => {{
-                        eprintln!("{{}}", err);
+                        eprintln!("{{}}", err.display_pretty());
                         return Err(anyhow!("Language configuration error"));
                     }}
                 }};
@@ -572,6 +572,8 @@ impl ProjectSettings {
 
             /// The stack graphs builtins configuration for this language.
             pub const STACK_GRAPHS_BUILTINS_CONFIG: &str = include_str!("../src/builtins.cfg");
+            /// The stack graphs builtins path for this language
+            pub const STACK_GRAPHS_BUILTINS_PATH: &str = "src/builtins.{}";
             /// The stack graphs builtins source for this language.
             pub const STACK_GRAPHS_BUILTINS_SOURCE: &str = include_str!("../src/builtins.{}");
 
@@ -592,13 +594,17 @@ impl ProjectSettings {
                     vec![String::from("{}")],
                     STACK_GRAPHS_TSG_PATH.into(),
                     STACK_GRAPHS_TSG_SOURCE,
-                    Some(STACK_GRAPHS_BUILTINS_SOURCE),
+                    Some((
+                        STACK_GRAPHS_BUILTINS_PATH.into(),
+                        STACK_GRAPHS_BUILTINS_SOURCE,
+                    )),
                     Some(STACK_GRAPHS_BUILTINS_CONFIG),
                     FileAnalyzers::new(),
                     cancellation_flag,
                 )
             }}
             "#,
+            self.language_file_extension,
             self.language_file_extension,
             self.grammar_package_name(),
             self.language_file_extension,
@@ -621,7 +627,7 @@ impl ProjectSettings {
                 {{
                     Ok(lc) => lc,
                     Err(err) => {{
-                        eprintln!("{{}}", err);
+                        eprintln!("{{}}", err.display_pretty());
                         return Err(anyhow!("Language configuration error"));
                     }}
                 }};

--- a/tree-sitter-stack-graphs/src/cli/init.rs
+++ b/tree-sitter-stack-graphs/src/cli/init.rs
@@ -560,22 +560,22 @@ impl ProjectSettings {
         let mut file = File::create(project_path.join("rust/lib.rs"))?;
         self.write_license_header(&mut file, "// ")?;
         writedoc! {file, r#"
-            use std::path::PathBuf;
-
             use tree_sitter_stack_graphs::loader::FileAnalyzers;
             use tree_sitter_stack_graphs::loader::LanguageConfiguration;
             use tree_sitter_stack_graphs::loader::LoadError;
             use tree_sitter_stack_graphs::CancellationFlag;
 
-            /// The stack graphs tsg source for this language
+            /// The stack graphs tsg source for this language.
+            pub const STACK_GRAPHS_TSG_PATH: &str = "src/stack-graphs.tsg";
+            /// The stack graphs tsg source for this language.
             pub const STACK_GRAPHS_TSG_SOURCE: &str = include_str!("../src/stack-graphs.tsg");
 
-            /// The stack graphs builtins configuration for this language
+            /// The stack graphs builtins configuration for this language.
             pub const STACK_GRAPHS_BUILTINS_CONFIG: &str = include_str!("../src/builtins.cfg");
-            /// The stack graphs builtins source for this language
+            /// The stack graphs builtins source for this language.
             pub const STACK_GRAPHS_BUILTINS_SOURCE: &str = include_str!("../src/builtins.{}");
 
-            /// The name of the file path global variable
+            /// The name of the file path global variable.
             pub const FILE_PATH_VAR: &str = "FILE_PATH";
 
             pub fn language_configuration(cancellation_flag: &dyn CancellationFlag) -> LanguageConfiguration {{
@@ -585,12 +585,12 @@ impl ProjectSettings {
             pub fn try_language_configuration(
                 cancellation_flag: &dyn CancellationFlag,
             ) -> Result<LanguageConfiguration, LoadError> {{
-                LanguageConfiguration::from_tsg_file(
+                LanguageConfiguration::from_sources(
                     {}::language(),
                     Some(String::from("source.{}")),
                     None,
                     vec![String::from("{}")],
-                    PathBuf::from("src/stack-graphs.tsg"),
+                    STACK_GRAPHS_TSG_PATH.into(),
                     STACK_GRAPHS_TSG_SOURCE,
                     Some(STACK_GRAPHS_BUILTINS_SOURCE),
                     Some(STACK_GRAPHS_BUILTINS_CONFIG),

--- a/tree-sitter-stack-graphs/src/cli/init.rs
+++ b/tree-sitter-stack-graphs/src/cli/init.rs
@@ -560,6 +560,8 @@ impl ProjectSettings {
         let mut file = File::create(project_path.join("rust/lib.rs"))?;
         self.write_license_header(&mut file, "// ")?;
         writedoc! {file, r#"
+            use std::path::PathBuf;
+
             use tree_sitter_stack_graphs::loader::FileAnalyzers;
             use tree_sitter_stack_graphs::loader::LanguageConfiguration;
             use tree_sitter_stack_graphs::loader::LoadError;
@@ -586,11 +588,12 @@ impl ProjectSettings {
             pub fn try_language_configuration(
                 cancellation_flag: &dyn CancellationFlag,
             ) -> Result<LanguageConfiguration, LoadError> {{
-                LanguageConfiguration::from_tsg_str(
+                LanguageConfiguration::from_tsg_file(
                     {}::language(),
                     Some(String::from("source.{}")),
                     None,
                     vec![String::from("{}")],
+                    PathBuf::from("src/stack-graphs.tsg"),
                     STACK_GRAPHS_TSG_SOURCE,
                     Some(STACK_GRAPHS_BUILTINS_SOURCE),
                     Some(STACK_GRAPHS_BUILTINS_CONFIG),

--- a/tree-sitter-stack-graphs/src/cli/load.rs
+++ b/tree-sitter-stack-graphs/src/cli/load.rs
@@ -50,7 +50,7 @@ impl PathLoaderArgs {
         }
     }
 
-    pub fn get(&self) -> Result<Loader, LoadError> {
+    pub fn get(&self) -> Result<Loader, LoadError<'static>> {
         let tsg_paths = match &self.tsg {
             Some(tsg_path) => vec![LoadPath::Regular(tsg_path.clone())],
             None => DEFAULT_TSG_PATHS.clone(),
@@ -96,7 +96,10 @@ impl LanguageConfigurationsLoaderArgs {
         Self { scope: None }
     }
 
-    pub fn get(&self, configurations: Vec<LanguageConfiguration>) -> Result<Loader, LoadError> {
+    pub fn get(
+        &self,
+        configurations: Vec<LanguageConfiguration>,
+    ) -> Result<Loader, LoadError<'static>> {
         let loader = Loader::from_language_configurations(configurations, self.scope.clone())?;
         Ok(loader)
     }

--- a/tree-sitter-stack-graphs/src/cli/parse.rs
+++ b/tree-sitter-stack-graphs/src/cli/parse.rs
@@ -16,7 +16,7 @@ use tree_sitter_graph::parse_error::ParseError;
 use crate::cli::util::path_exists;
 use crate::loader::FileReader;
 use crate::loader::Loader;
-use crate::util::map_parse_errors;
+use crate::util::DisplayParseErrorsPretty;
 use crate::BuildError;
 
 /// Parse file
@@ -46,14 +46,15 @@ impl ParseArgs {
         let tree = parser.parse(source, None).ok_or(BuildError::ParseError)?;
         let parse_errors = ParseError::into_all(tree);
         if parse_errors.errors().len() > 0 {
-            let parse_error = map_parse_errors(
-                file_path,
-                &parse_errors,
-                &source,
-                "",
-                crate::MAX_PARSE_ERRORS,
+            eprintln!(
+                "{}",
+                DisplayParseErrorsPretty {
+                    parse_errors: &parse_errors,
+                    path: file_path,
+                    source: &source,
+                    max_errors: crate::MAX_PARSE_ERRORS,
+                }
             );
-            println!("{}", parse_error);
             return Err(anyhow!("Failed to parse file {}", file_path.display()));
         }
         let tree = parse_errors.into_tree();

--- a/tree-sitter-stack-graphs/src/cli/parse.rs
+++ b/tree-sitter-stack-graphs/src/cli/parse.rs
@@ -16,9 +16,8 @@ use tree_sitter_graph::parse_error::ParseError;
 use crate::cli::util::path_exists;
 use crate::loader::FileReader;
 use crate::loader::Loader;
+use crate::util::map_parse_errors;
 use crate::LoadError;
-
-use super::util::map_parse_errors;
 
 /// Parse file
 #[derive(Args)]
@@ -47,7 +46,13 @@ impl ParseArgs {
         let tree = parser.parse(source, None).ok_or(LoadError::ParseError)?;
         let parse_errors = ParseError::into_all(tree);
         if parse_errors.errors().len() > 0 {
-            let parse_error = map_parse_errors(file_path, &parse_errors, &source, "");
+            let parse_error = map_parse_errors(
+                file_path,
+                &parse_errors,
+                &source,
+                "",
+                crate::MAX_PARSE_ERRORS,
+            );
             println!("{}", parse_error);
             return Err(anyhow!("Failed to parse file {}", file_path.display()));
         }

--- a/tree-sitter-stack-graphs/src/cli/parse.rs
+++ b/tree-sitter-stack-graphs/src/cli/parse.rs
@@ -17,7 +17,7 @@ use crate::cli::util::path_exists;
 use crate::loader::FileReader;
 use crate::loader::Loader;
 use crate::util::map_parse_errors;
-use crate::LoadError;
+use crate::BuildError;
 
 /// Parse file
 #[derive(Args)]
@@ -43,7 +43,7 @@ impl ParseArgs {
 
         let mut parser = Parser::new();
         parser.set_language(lang)?;
-        let tree = parser.parse(source, None).ok_or(LoadError::ParseError)?;
+        let tree = parser.parse(source, None).ok_or(BuildError::ParseError)?;
         let parse_errors = ParseError::into_all(tree);
         if parse_errors.errors().len() > 0 {
             let parse_error = map_parse_errors(

--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -278,10 +278,15 @@ impl TestArgs {
                 Err(err) => {
                     file_status.error("failed to build stack graph")?;
                     if !self.hide_error_details {
-                        // TODO can we have access to the TSG source here?
-                        let tsg_path = Path::new("");
-                        let tsg = "";
-                        println!("{}", err.display_pretty(test_path, source, tsg_path, tsg));
+                        println!(
+                            "{}",
+                            err.display_pretty(
+                                test_path,
+                                source,
+                                lc.sgl.tsg_path(),
+                                lc.sgl.tsg_source(),
+                            )
+                        );
                     }
                     return Err(anyhow!("Failed to build graph for {}", test_path.display()));
                 }

--- a/tree-sitter-stack-graphs/src/cli/util.rs
+++ b/tree-sitter-stack-graphs/src/cli/util.rs
@@ -239,6 +239,13 @@ impl<'a> FileStatusLogger<'a> {
         std::io::stdout().flush()
     }
 
+    pub fn error_if_processing(&mut self, status: &str) -> std::io::Result<()> {
+        if !self.path_logged {
+            return Ok(());
+        }
+        self.error(status)
+    }
+
     fn print_path(&mut self) {
         if self.path_logged {
             return;

--- a/tree-sitter-stack-graphs/src/cli/util.rs
+++ b/tree-sitter-stack-graphs/src/cli/util.rs
@@ -15,9 +15,6 @@ use std::path::PathBuf;
 use std::time::Duration;
 #[cfg(debug_assertions)]
 use std::time::Instant;
-use tree_sitter_graph::parse_error::TreeWithParseErrorVec;
-
-use crate::cli::MAX_PARSE_ERRORS;
 
 pub fn path_exists(path: &OsStr) -> anyhow::Result<PathBuf> {
     let path = PathBuf::from(path);
@@ -125,37 +122,6 @@ impl From<&str> for PathSpec {
     fn from(s: &str) -> Self {
         Self { spec: s.into() }
     }
-}
-
-pub fn map_parse_errors(
-    test_path: &Path,
-    parse_errors: &TreeWithParseErrorVec,
-    source: &str,
-    prefix: &str,
-) -> anyhow::Error {
-    let mut error = String::new();
-    let parse_errors = parse_errors.errors();
-    for parse_error in parse_errors.iter().take(MAX_PARSE_ERRORS) {
-        let line = parse_error.node().start_position().row;
-        let column = parse_error.node().start_position().column;
-        error.push_str(&format!(
-            "{}{}:{}:{}: {}\n",
-            prefix,
-            test_path.display(),
-            line + 1,
-            column + 1,
-            parse_error.display(&source, false)
-        ));
-    }
-    if parse_errors.len() > MAX_PARSE_ERRORS {
-        let more_errors = parse_errors.len() - MAX_PARSE_ERRORS;
-        error.push_str(&format!(
-            "  {} more parse error{} omitted\n",
-            more_errors,
-            if more_errors > 1 { "s" } else { "" },
-        ));
-    }
-    anyhow!(error)
 }
 
 pub fn duration_from_seconds_str(s: &str) -> Result<Duration, anyhow::Error> {

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -335,6 +335,7 @@ use tree_sitter_graph::graph::Value;
 use tree_sitter_graph::parse_error::ParseError;
 use tree_sitter_graph::parse_error::TreeWithParseErrorVec;
 use tree_sitter_graph::ExecutionConfig;
+use util::DisplayParseErrorsPretty;
 
 #[cfg(feature = "cli")]
 pub mod ci;
@@ -347,8 +348,6 @@ mod util;
 
 pub use tree_sitter_graph::VariableError;
 pub use tree_sitter_graph::Variables;
-
-use crate::util::map_parse_errors;
 
 pub(self) const MAX_PARSE_ERRORS: usize = 5;
 
@@ -772,16 +771,16 @@ impl std::fmt::Display for DisplayBuildErrorPretty<'_> {
                 "{}",
                 err.display_pretty(self.source_path, self.source, self.tsg_path, self.tsg)
             ),
-            BuildError::ParseErrors(parse_errors) => {
-                let parse_error = map_parse_errors(
-                    self.source_path,
+            BuildError::ParseErrors(parse_errors) => write!(
+                f,
+                "{}",
+                DisplayParseErrorsPretty {
                     parse_errors,
-                    self.source,
-                    "",
-                    crate::MAX_PARSE_ERRORS,
-                );
-                write!(f, "{}", parse_error)
-            }
+                    path: self.source_path,
+                    source: self.source,
+                    max_errors: crate::MAX_PARSE_ERRORS,
+                }
+            ),
             err => err.fmt(f),
         }
     }

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -487,6 +487,18 @@ pub enum LanguageError {
     ParseError(#[from] tree_sitter_graph::ParseError),
 }
 
+impl LanguageError {
+    pub fn display_pretty<'a>(
+        &'a self,
+        path: &'a Path,
+        source: &'a str,
+    ) -> impl std::fmt::Display + 'a {
+        match self {
+            Self::ParseError(err) => err.display_pretty(path, source),
+        }
+    }
+}
+
 impl StackGraphLanguage {
     /// Executes the graph construction rules for this language against a source file, creating new
     /// nodes and edges in `stack_graph`.  Any new nodes that we create will belong to `file`.

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -392,7 +392,7 @@ static ROOT_NODE_VAR: &'static str = "ROOT_NODE";
 static JUMP_TO_SCOPE_NODE_VAR: &'static str = "JUMP_TO_SCOPE_NODE";
 static FILE_PATH_VAR: &'static str = "FILE_PATH";
 
-/// Holds information about how to construct stack graphs for a particular language
+/// Holds information about how to construct stack graphs for a particular language.
 pub struct StackGraphLanguage {
     language: tree_sitter::Language,
     tsg: tree_sitter_graph::ast::File,
@@ -435,10 +435,11 @@ impl StackGraphLanguage {
         })
     }
 
-    /// Creates a new stack graph language for the given language, loading the
-    /// TSG stack graph construction rules from a string. Keeps the path and
-    /// source, which can later be used for [`BuildError::display_pretty`][].
-    pub fn from_file(
+    /// Creates a new stack graph language for the given language, loading the TSG
+    /// stack graph construction rules from the given source. The path is purely for
+    /// informational purposes, and is not accessed. The source and path are kept,
+    /// e.g. to use for [`BuildError::display_pretty`][].
+    pub fn from_source(
         language: tree_sitter::Language,
         tsg_path: PathBuf,
         tsg_source: &str,

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -406,15 +406,15 @@ impl StackGraphLanguage {
     pub fn new(
         language: tree_sitter::Language,
         tsg: tree_sitter_graph::ast::File,
-    ) -> Result<StackGraphLanguage, LanguageError> {
+    ) -> StackGraphLanguage {
         debug_assert_eq!(language, tsg.language);
-        Ok(StackGraphLanguage {
+        StackGraphLanguage {
             language,
             tsg,
             tsg_path: PathBuf::from("<tsg>"),
             tsg_source: Cow::from(String::new()),
             functions: Self::default_functions(),
-        })
+        }
     }
 
     /// Creates a new stack graph language for the given language, loading the

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -58,6 +58,56 @@ impl LanguageConfiguration {
         cancellation_flag: &dyn CancellationFlag,
     ) -> Result<Self, LoadError> {
         let sgl = StackGraphLanguage::from_str(language, tsg_source)?;
+        Self::from_sgl(
+            language,
+            scope,
+            content_regex,
+            file_types,
+            sgl,
+            builtins_source,
+            builtins_config,
+            special_files,
+            cancellation_flag,
+        )
+    }
+
+    pub fn from_tsg_file(
+        language: Language,
+        scope: Option<String>,
+        content_regex: Option<Regex>,
+        file_types: Vec<String>,
+        tsg_path: PathBuf,
+        tsg_source: &str,
+        builtins_source: Option<&str>,
+        builtins_config: Option<&str>,
+        special_files: FileAnalyzers,
+        cancellation_flag: &dyn CancellationFlag,
+    ) -> Result<Self, LoadError> {
+        let sgl = StackGraphLanguage::from_file(language, tsg_path, tsg_source)?;
+        Self::from_sgl(
+            language,
+            scope,
+            content_regex,
+            file_types,
+            sgl,
+            builtins_source,
+            builtins_config,
+            special_files,
+            cancellation_flag,
+        )
+    }
+
+    fn from_sgl(
+        language: Language,
+        scope: Option<String>,
+        content_regex: Option<Regex>,
+        file_types: Vec<String>,
+        sgl: StackGraphLanguage,
+        builtins_source: Option<&str>,
+        builtins_config: Option<&str>,
+        special_files: FileAnalyzers,
+        cancellation_flag: &dyn CancellationFlag,
+    ) -> Result<Self, LoadError> {
         let mut builtins = StackGraph::new();
         if let Some(builtins_source) = builtins_source {
             let mut builtins_globals = Variables::new();

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -304,17 +304,17 @@ pub enum LoadError {
     #[error(transparent)]
     Reader(Box<dyn std::error::Error + Send + Sync>),
     #[error(transparent)]
-    StackGraph(crate::LoadError),
+    StackGraph(crate::BuildError),
     #[error(transparent)]
     TsgParse(#[from] tree_sitter_graph::ParseError),
     #[error(transparent)]
     TreeSitter(anyhow::Error),
 }
 
-impl From<crate::LoadError> for LoadError {
-    fn from(value: crate::LoadError) -> Self {
+impl From<crate::BuildError> for LoadError {
+    fn from(value: crate::BuildError) -> Self {
         match value {
-            crate::LoadError::Cancelled(at) => Self::Cancelled(at),
+            crate::BuildError::Cancelled(at) => Self::Cancelled(at),
             other => Self::StackGraph(other),
         }
     }

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -46,32 +46,9 @@ pub struct LanguageConfiguration {
 }
 
 impl LanguageConfiguration {
-    pub fn from_tsg_str(
-        language: Language,
-        scope: Option<String>,
-        content_regex: Option<Regex>,
-        file_types: Vec<String>,
-        tsg_source: &str,
-        builtins_source: Option<&str>,
-        builtins_config: Option<&str>,
-        special_files: FileAnalyzers,
-        cancellation_flag: &dyn CancellationFlag,
-    ) -> Result<Self, LoadError> {
-        let sgl = StackGraphLanguage::from_str(language, tsg_source)?;
-        Self::from_sgl(
-            language,
-            scope,
-            content_regex,
-            file_types,
-            sgl,
-            builtins_source,
-            builtins_config,
-            special_files,
-            cancellation_flag,
-        )
-    }
-
-    pub fn from_tsg_file(
+    /// Build a language configuration from tsg and builtins sources. The tsg path
+    /// is kept for informational only, see [`StackGraphLanguage::from_source`][].
+    pub fn from_sources(
         language: Language,
         scope: Option<String>,
         content_regex: Option<Regex>,
@@ -83,31 +60,7 @@ impl LanguageConfiguration {
         special_files: FileAnalyzers,
         cancellation_flag: &dyn CancellationFlag,
     ) -> Result<Self, LoadError> {
-        let sgl = StackGraphLanguage::from_file(language, tsg_path, tsg_source)?;
-        Self::from_sgl(
-            language,
-            scope,
-            content_regex,
-            file_types,
-            sgl,
-            builtins_source,
-            builtins_config,
-            special_files,
-            cancellation_flag,
-        )
-    }
-
-    fn from_sgl(
-        language: Language,
-        scope: Option<String>,
-        content_regex: Option<Regex>,
-        file_types: Vec<String>,
-        sgl: StackGraphLanguage,
-        builtins_source: Option<&str>,
-        builtins_config: Option<&str>,
-        special_files: FileAnalyzers,
-        cancellation_flag: &dyn CancellationFlag,
-    ) -> Result<Self, LoadError> {
+        let sgl = StackGraphLanguage::from_source(language, tsg_path, tsg_source)?;
         let mut builtins = StackGraph::new();
         if let Some(builtins_source) = builtins_source {
             let mut builtins_globals = Variables::new();

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -428,7 +428,7 @@ impl PathLoader {
             Some(index) => index,
             None => {
                 let tsg = self.load_tsg_from_paths(&language)?;
-                let sgl = StackGraphLanguage::new(language.language, tsg)?;
+                let sgl = StackGraphLanguage::new(language.language, tsg);
 
                 let mut builtins = StackGraph::new();
                 self.load_builtins_from_paths_into(

--- a/tree-sitter-stack-graphs/src/util.rs
+++ b/tree-sitter-stack-graphs/src/util.rs
@@ -1,0 +1,42 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use anyhow::anyhow;
+use std::path::Path;
+use tree_sitter_graph::parse_error::TreeWithParseErrorVec;
+
+pub fn map_parse_errors(
+    test_path: &Path,
+    parse_errors: &TreeWithParseErrorVec,
+    source: &str,
+    prefix: &str,
+    max_errors: usize,
+) -> anyhow::Error {
+    let mut error = String::new();
+    let parse_errors = parse_errors.errors();
+    for parse_error in parse_errors.iter().take(max_errors) {
+        let line = parse_error.node().start_position().row;
+        let column = parse_error.node().start_position().column;
+        error.push_str(&format!(
+            "{}{}:{}:{}: {}\n",
+            prefix,
+            test_path.display(),
+            line + 1,
+            column + 1,
+            parse_error.display(&source, false)
+        ));
+    }
+    if parse_errors.len() > max_errors {
+        let more_errors = parse_errors.len() - max_errors;
+        error.push_str(&format!(
+            "  {} more parse error{} omitted\n",
+            more_errors,
+            if more_errors > 1 { "s" } else { "" },
+        ));
+    }
+    anyhow!(error)
+}

--- a/tree-sitter-stack-graphs/src/util.rs
+++ b/tree-sitter-stack-graphs/src/util.rs
@@ -5,38 +5,31 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-use anyhow::anyhow;
 use std::path::Path;
 use tree_sitter_graph::parse_error::TreeWithParseErrorVec;
 
-pub fn map_parse_errors(
-    test_path: &Path,
-    parse_errors: &TreeWithParseErrorVec,
-    source: &str,
-    prefix: &str,
-    max_errors: usize,
-) -> anyhow::Error {
-    let mut error = String::new();
-    let parse_errors = parse_errors.errors();
-    for parse_error in parse_errors.iter().take(max_errors) {
-        let line = parse_error.node().start_position().row;
-        let column = parse_error.node().start_position().column;
-        error.push_str(&format!(
-            "{}{}:{}:{}: {}\n",
-            prefix,
-            test_path.display(),
-            line + 1,
-            column + 1,
-            parse_error.display(&source, false)
-        ));
+pub struct DisplayParseErrorsPretty<'a> {
+    pub parse_errors: &'a TreeWithParseErrorVec,
+    pub path: &'a Path,
+    pub source: &'a str,
+    pub max_errors: usize,
+}
+
+impl std::fmt::Display for DisplayParseErrorsPretty<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let parse_errors = self.parse_errors.errors();
+        for parse_error in parse_errors.iter().take(self.max_errors) {
+            write!(f, "{}", parse_error.display_pretty(self.path, &self.source))?;
+        }
+        if parse_errors.len() > self.max_errors {
+            let more_errors = parse_errors.len() - self.max_errors;
+            write!(
+                f,
+                "{} more parse error{} omitted\n",
+                more_errors,
+                if more_errors > 1 { "s" } else { "" },
+            )?;
+        }
+        Ok(())
     }
-    if parse_errors.len() > max_errors {
-        let more_errors = parse_errors.len() - max_errors;
-        error.push_str(&format!(
-            "  {} more parse error{} omitted\n",
-            more_errors,
-            if more_errors > 1 { "s" } else { "" },
-        ));
-    }
-    anyhow!(error)
 }

--- a/tree-sitter-stack-graphs/tests/it/main.rs
+++ b/tree-sitter-stack-graphs/tests/it/main.rs
@@ -9,7 +9,7 @@ use stack_graphs::arena::Handle;
 use stack_graphs::graph::File;
 use stack_graphs::graph::StackGraph;
 use tree_sitter_graph::Variables;
-use tree_sitter_stack_graphs::LoadError;
+use tree_sitter_stack_graphs::BuildError;
 use tree_sitter_stack_graphs::NoCancellation;
 use tree_sitter_stack_graphs::StackGraphLanguage;
 
@@ -22,7 +22,7 @@ mod test;
 pub(self) fn build_stack_graph(
     python_source: &str,
     tsg_source: &str,
-) -> Result<(StackGraph, Handle<File>), LoadError> {
+) -> Result<(StackGraph, Handle<File>), BuildError> {
     let language =
         StackGraphLanguage::from_str(tree_sitter_python::language(), tsg_source).unwrap();
     let mut graph = StackGraph::new();

--- a/tree-sitter-stack-graphs/tests/it/nodes.rs
+++ b/tree-sitter-stack-graphs/tests/it/nodes.rs
@@ -9,7 +9,7 @@ use pretty_assertions::assert_eq;
 use stack_graphs::arena::Handle;
 use stack_graphs::graph::File;
 use stack_graphs::graph::StackGraph;
-use tree_sitter_stack_graphs::LoadError;
+use tree_sitter_stack_graphs::BuildError;
 
 use super::build_stack_graph;
 
@@ -57,7 +57,7 @@ fn cannot_create_definition_node_without_symbol() {
     "#;
     let python = "a";
     let result = build_stack_graph(python, tsg);
-    assert!(matches!(result, Err(LoadError::MissingSymbol(_))));
+    assert!(matches!(result, Err(BuildError::MissingSymbol(_))));
 }
 
 #[test]
@@ -141,7 +141,7 @@ fn cannot_create_pop_symbol_node_without_symbol() {
     "#;
     let python = "a";
     let result = build_stack_graph(python, tsg);
-    assert!(matches!(result, Err(LoadError::MissingSymbol(_))));
+    assert!(matches!(result, Err(BuildError::MissingSymbol(_))));
 }
 
 #[test]
@@ -166,7 +166,7 @@ fn cannot_create_pop_scoped_symbol_node_without_symbol() {
     "#;
     let python = "a";
     let result = build_stack_graph(python, tsg);
-    assert!(matches!(result, Err(LoadError::MissingSymbol(_))));
+    assert!(matches!(result, Err(BuildError::MissingSymbol(_))));
 }
 
 #[test]
@@ -191,7 +191,7 @@ fn cannot_create_push_symbol_node_without_symbol() {
     "#;
     let python = "a";
     let result = build_stack_graph(python, tsg);
-    assert!(matches!(result, Err(LoadError::MissingSymbol(_))));
+    assert!(matches!(result, Err(BuildError::MissingSymbol(_))));
 }
 
 #[test]
@@ -227,7 +227,7 @@ fn cannot_create_push_scoped_symbol_node_without_symbol() {
     "#;
     let python = "a";
     let result = build_stack_graph(python, tsg);
-    assert!(matches!(result, Err(LoadError::MissingSymbol(_))));
+    assert!(matches!(result, Err(BuildError::MissingSymbol(_))));
 }
 
 #[test]
@@ -252,7 +252,7 @@ fn cannot_create_reference_node_without_symbol() {
     "#;
     let python = "a";
     let result = build_stack_graph(python, tsg);
-    assert!(matches!(result, Err(LoadError::MissingSymbol(_))));
+    assert!(matches!(result, Err(BuildError::MissingSymbol(_))));
 }
 
 #[test]

--- a/tree-sitter-stack-graphs/tests/it/test.rs
+++ b/tree-sitter-stack-graphs/tests/it/test.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use tree_sitter_graph::Variables;
 use tree_sitter_stack_graphs::test::Test;
-use tree_sitter_stack_graphs::LoadError;
+use tree_sitter_stack_graphs::BuildError;
 use tree_sitter_stack_graphs::NoCancellation;
 use tree_sitter_stack_graphs::StackGraphLanguage;
 
@@ -68,7 +68,7 @@ fn build_stack_graph_into(
     python_source: &str,
     tsg_source: &str,
     globals: &Variables,
-) -> Result<(), LoadError> {
+) -> Result<(), BuildError> {
     let language =
         StackGraphLanguage::from_str(tree_sitter_python::language(), tsg_source).unwrap();
     language.build_stack_graph_into(graph, file, python_source, globals, &NoCancellation)?;


### PR DESCRIPTION
This PR improves various error messages that are reported by the CLI.

- Most error types now have a `display_pretty` method, which uses the `display_pretty` methods from TSG when they exist.
- The language specific libraries have a new `try_language_configuration` which doesn't panic but gives back the error to the user, allowing them to print it nicely if we are in a console context. This is used by the CLI and test runner to print a nice error when there are problems with the TSG, instead of the obscure panic it used to be.

## Examples

#### Parse errors in source files in `parse` and `test`

![image](https://user-images.githubusercontent.com/999073/229509208-b0210560-f285-4a0f-84fe-0a947bcdd725.png)

#### Parse errors in the TSG

![image](https://user-images.githubusercontent.com/999073/229512019-4b488a64-bc5b-4076-9f4a-624aec79d333.png)

![image](https://user-images.githubusercontent.com/999073/229512112-721101a2-6c46-4cf2-a1e0-3825e5dcbe27.png)

#### Execution errors in the TSG

![image](https://user-images.githubusercontent.com/999073/229512355-8a4d943e-a358-4d93-87fb-04072ce28a5e.png)
