### PR TITLE
Implement indexing in the LSP server

### DIFF
--- a/languages/tree-sitter-stack-graphs-typescript/vscode/package-lock.json
+++ b/languages/tree-sitter-stack-graphs-typescript/vscode/package-lock.json
@@ -1,13 +1,13 @@
 {
     "name": "tree-sitter-stack-graphs-typescript",
-    "version": "0.0.1",
+    "version": "0.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "tree-sitter-stack-graphs-typescript",
-            "version": "0.0.1",
-            "license": "MIT OR Apache-2.0",
+            "version": "0.1.0",
+            "license": "(MIT OR Apache-2.0)",
             "dependencies": {
                 "vscode-languageclient": "^8.1.0"
             },

--- a/languages/tree-sitter-stack-graphs-typescript/vscode/package.json
+++ b/languages/tree-sitter-stack-graphs-typescript/vscode/package.json
@@ -27,20 +27,39 @@
                     "markdownDescription": "The default location for the database, if an explicit path is not provided. _Requires reload for changes to take effect._",
                     "type": "string",
                     "default": "workspace",
-                    "enum": ["workspace", "user"],
+                    "enum": [
+                        "workspace",
+                        "user"
+                    ],
                     "enumDescriptions": [
                         "Use a workspace-local database. Indexing data will not be shared between workspaces.",
                         "Use the user database, stored in the user's local data directory. Indexing data is shared between workspaces."
                     ],
                     "scope": "machine-overridable",
-                    "order": 0
+                    "order": 10
                 },
                 "tree-sitter-stack-graphs-typescript.database.path": {
                     "markdownDescription": "The path to the database. Expands ~ to the user's home directory. _Requires reload for changes to take effect._",
                     "type": "string",
                     "default": null,
                     "scope": "machine-overridable",
-                    "order": 1
+                    "order": 11
+                },
+                "tree-sitter-stack-graphs-typescript.index.maxFolderTime": {
+                    "markdownDescription": "Maximum index time per workspace folder in seconds (-1 means no limit). _Requires reload for changes to take effect._",
+                    "type": "integer",
+                    "minimum": -1,
+                    "default": -1,
+                    "scope": "machine-overridable",
+                    "order": 20
+                },
+                "tree-sitter-stack-graphs-typescript.index.maxFileTime": {
+                    "markdownDescription": "Maximum index time per file in seconds (-1 means no limit). _Requires reload for changes to take effect._",
+                    "type": "integer",
+                    "minimum": -1,
+                    "default": 10,
+                    "scope": "machine-overridable",
+                    "order": 20
                 }
             }
         }
@@ -49,7 +68,7 @@
         "vscode-languageclient": "^8.1.0"
     },
     "scripts": {
-        "build-cli": "cargo build --features cli,lsp --release --target-dir target",
+        "build-cli": "CARGO_PROFILE_RELEASE_DEBUG=true cargo build --features cli,lsp --release --target-dir target",
         "install-cli": "mkdir -p out/bin && cp target/release/tree-sitter-stack-graphs-typescript out/bin",
         "build-ext": "tsc -b",
         "build": "npm run build-cli && npm run build-ext && npm run install-cli"

--- a/languages/tree-sitter-stack-graphs-typescript/vscode/src/extension.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/vscode/src/extension.ts
@@ -29,7 +29,7 @@ export function activate(context: ExtensionContext) {
         switch (config.get<string>('database.defaultLocation')) {
             case "workspace":
                 if (!context?.storageUri?.fsPath) {
-                    window.showErrorMessage("Cannot start: no workspace open");
+                    // cannot start, no workspace is open
                     return;
                 }
                 mkdirSync(context.storageUri.fsPath, { recursive: true });

--- a/languages/tree-sitter-stack-graphs-typescript/vscode/src/extension.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/vscode/src/extension.ts
@@ -27,6 +27,10 @@ export function activate(context: ExtensionContext) {
     } else {
         switch (config.get<string>('database.defaultLocation')) {
             case "workspace":
+                if (!context?.storageUri?.fsPath) {
+                    window.showErrorMessage("Cannot start: no workspace open");
+                    return;
+                }
                 mkdirSync(context.storageUri.fsPath, { recursive: true });
                 let db_path = Uri.joinPath(context.storageUri, NAME + ".sqlite").fsPath;
                 args.push("-D", db_path);

--- a/languages/tree-sitter-stack-graphs-typescript/vscode/src/extension.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/vscode/src/extension.ts
@@ -9,7 +9,8 @@ const NAME = "tree-sitter-stack-graphs-typescript";
 import {
     LanguageClient,
     LanguageClientOptions,
-    ServerOptions
+    ServerOptions,
+    integer
 } from 'vscode-languageclient/node';
 
 let client: LanguageClient;
@@ -39,6 +40,15 @@ export function activate(context: ExtensionContext) {
                 // omit -D
                 break;
         }
+    }
+
+    let max_folder_index_time = config.get<integer>('index.maxFolderTime');
+    if (max_folder_index_time && max_folder_index_time >= 0) {
+        args.push("--max-folder-index-time", max_folder_index_time.toString());
+    }
+    let max_file_index_time = config.get<integer>('index.maxFileTime');
+    if (max_file_index_time && max_file_index_time >= 0) {
+        args.push("--max-file-index-time", max_file_index_time.toString());
     }
 
     const serverOptions: ServerOptions = { command, args };

--- a/stack-graphs/src/storage.rs
+++ b/stack-graphs/src/storage.rs
@@ -109,7 +109,7 @@ impl SQLiteWriter {
     pub fn clean<P: AsRef<Path>>(&mut self, path: Option<P>) -> Result<usize> {
         let count = if let Some(path) = path {
             let file = format!("{}%", path.as_ref().to_string_lossy());
-            self.conn.execute("BEGIN;", [])?;
+            self.conn.execute("BEGIN", [])?;
             self.conn
                 .execute("DELETE FROM file_paths WHERE file LIKE ?", [&file])?;
             self.conn
@@ -117,14 +117,14 @@ impl SQLiteWriter {
             let count = self
                 .conn
                 .execute("DELETE FROM graphs WHERE file LIKE ?", [&file])?;
-            self.conn.execute("COMMIT;", [])?;
+            self.conn.execute("COMMIT", [])?;
             count
         } else {
-            self.conn.execute("BEGIN;", [])?;
+            self.conn.execute("BEGIN", [])?;
             self.conn.execute("DELETE FROM file_paths", [])?;
             self.conn.execute("DELETE FROM root_paths", [])?;
             let count = self.conn.execute("DELETE FROM graphs", [])?;
-            self.conn.execute("COMMIT;", [])?;
+            self.conn.execute("COMMIT", [])?;
             count
         };
         Ok(count)
@@ -132,10 +132,10 @@ impl SQLiteWriter {
 
     /// Create database tables and write metadata.
     fn init(conn: &Connection) -> Result<()> {
-        conn.execute("BEGIN;", [])?;
+        conn.execute("BEGIN", [])?;
         conn.execute_batch(SCHEMA)?;
         conn.execute("INSERT INTO metadata (version) VALUES (?)", [VERSION])?;
-        conn.execute("COMMIT;", [])?;
+        conn.execute("COMMIT", [])?;
         Ok(())
     }
 

--- a/stack-graphs/src/storage.rs
+++ b/stack-graphs/src/storage.rs
@@ -189,8 +189,8 @@ impl SQLiteWriter {
         self.add_partial_paths_for_file(graph, file, partials, std::iter::once(path))
     }
 
-    /// Add partial paths for a file to the database.  Throws an error if the file does not exist in
-    /// the database.
+    /// Add partial paths for a file to the database.  Panics if the file does not exist in
+    /// the database, or if a path starts at a node that doesn't belong to the given file.
     pub fn add_partial_paths_for_file<'a, IP>(
         &mut self,
         graph: &StackGraph,

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -42,16 +42,20 @@ cli = [
   "walkdir",
 ]
 lsp = [
+  "capture-it",
+  "crossbeam-channel",
   "tokio",
   "tower-lsp",
 ]
 
 [dependencies]
 anyhow = "1.0"
-base64 = { version = "0.21", optional=true }
+base64 = { version = "0.21", optional = true }
+capture-it = { version = "0.3", optional = true }
 clap = { version = "3", optional = true, features=["derive"] }
 colored = { version = "2.0", optional = true }
 controlled-option = ">=0.4"
+crossbeam-channel = { version = "0.5", optional = true }
 dialoguer = { version = "0.10", optional = true }
 dirs = { version = "5", optional=true }
 env_logger = { version = "0.9", optional = true }

--- a/tree-sitter-stack-graphs/src/cli/index.rs
+++ b/tree-sitter-stack-graphs/src/cli/index.rs
@@ -5,7 +5,6 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-use anyhow::anyhow;
 use clap::Args;
 use clap::ValueHint;
 use stack_graphs::graph::StackGraph;
@@ -16,6 +15,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
+use thiserror::Error;
 use tree_sitter_graph::Variables;
 
 use crate::loader::FileReader;
@@ -30,7 +30,9 @@ use super::util::iter_files_and_directories;
 use super::util::path_exists;
 use super::util::sha1;
 use super::util::wait_for_input;
-use super::util::FileStatusLogger;
+use super::util::ConsoleLogger;
+use super::util::FileLogger;
+use super::util::Logger;
 
 /// Analyze sources
 #[derive(Args)]
@@ -97,86 +99,127 @@ impl IndexArgs {
             wait_for_input()?;
         }
         let mut db = SQLiteWriter::open(&db_path)?;
-        let mut seen_mark = false;
-        for (source_root, source_path, strict) in iter_files_and_directories(&self.source_paths) {
-            self.analyze_file(
-                &source_root,
-                &source_path,
-                &mut loader,
-                &mut seen_mark,
-                &mut db,
-                strict,
-            )?;
+        let logger = ConsoleLogger::new(self.verbose, !self.hide_error_details);
+        let mut indexer = Indexer::new(&mut db, &mut loader, &logger);
+        indexer.force = self.force;
+        indexer.max_file_time = self.max_file_time;
+        indexer.index_all(self.source_paths, self.continue_from)?;
+        Ok(())
+    }
+}
+
+pub struct Indexer<'a> {
+    db: &'a mut SQLiteWriter,
+    loader: &'a mut Loader,
+    logger: &'a dyn Logger,
+    /// Index files, even if they already exist in the database.
+    pub force: bool,
+    /// Maximum time per file.
+    pub max_file_time: Option<Duration>,
+}
+
+impl<'a> Indexer<'a> {
+    pub fn new(db: &'a mut SQLiteWriter, loader: &'a mut Loader, logger: &'a dyn Logger) -> Self {
+        Self {
+            db,
+            loader,
+            logger,
+            force: false,
+            max_file_time: None,
+        }
+    }
+
+    pub fn index_all<P, IP, Q>(
+        &mut self,
+        source_paths: IP,
+        mut continue_from: Option<Q>,
+    ) -> Result<()>
+    where
+        P: AsRef<Path>,
+        IP: IntoIterator<Item = P>,
+        Q: AsRef<Path>,
+    {
+        for (source_root, source_path, strict) in iter_files_and_directories(source_paths) {
+            self.index_file(&source_root, &source_path, strict, &mut continue_from)?;
         }
         Ok(())
     }
 
+    pub fn index(&mut self, source_root: &Path, source_path: &Path) -> Result<()> {
+        self.index_file(&source_root, &source_path, true, &mut None::<&Path>)?;
+        Ok(())
+    }
+
     /// Analyze file and add error context to any failures that are returned.
-    fn analyze_file(
-        &self,
+    fn index_file<P>(
+        &mut self,
         source_root: &Path,
         source_path: &Path,
-        loader: &mut Loader,
-        seen_mark: &mut bool,
-        db: &mut SQLiteWriter,
-        strict: bool,
-    ) -> anyhow::Result<()> {
-        let mut file_status = FileStatusLogger::new(source_path, self.verbose);
-        let source_root = source_root.canonicalize()?;
-        let source_path = source_path.canonicalize()?;
-        match self.analyze_file_inner(
-            &source_root,
-            &source_path,
-            loader,
-            seen_mark,
-            db,
-            strict,
-            &mut file_status,
+        missing_is_error: bool,
+        continue_from: &mut Option<P>,
+    ) -> Result<()>
+    where
+        P: AsRef<Path>,
+    {
+        let mut file_status = self.logger.file(source_path);
+        match self.index_file_inner(
+            source_root,
+            source_path,
+            missing_is_error,
+            continue_from,
+            file_status.as_mut(),
         ) {
             ok @ Ok(_) => ok,
             err @ Err(_) => {
-                file_status.error_if_processing("error")?;
-                println!("Error analyzing file {}. To continue analysis from this file later, add: --continue-from {}", source_path.display(), source_path.display());
+                file_status.default_failure("error", Some(&format!("Error analyzing file {}. To continue analysis from this file later, add: --continue-from {}", source_path.display(), source_path.display())));
                 err
             }
         }
     }
 
-    fn analyze_file_inner(
-        &self,
+    fn index_file_inner<P>(
+        &mut self,
         source_root: &Path,
         source_path: &Path,
-        loader: &mut Loader,
-        seen_mark: &mut bool,
-        db: &mut SQLiteWriter,
-        strict: bool,
-        file_status: &mut FileStatusLogger,
-    ) -> anyhow::Result<()> {
-        if self.should_skip(source_path, seen_mark) {
-            file_status.info("skipped")?;
+        missing_is_error: bool,
+        continue_from: &mut Option<P>,
+        file_status: &mut dyn FileLogger,
+    ) -> Result<()>
+    where
+        P: AsRef<Path>,
+    {
+        if self.should_skip(source_path, continue_from) {
+            file_status.skipped("skipped", None);
             return Ok(());
         }
 
         let mut file_reader = FileReader::new();
-        let lc = match loader.load_for_file(source_path, &mut file_reader, &NoCancellation) {
+        let lc = match self
+            .loader
+            .load_for_file(source_path, &mut file_reader, &NoCancellation)
+        {
             Ok(Some(sgl)) => sgl,
             Ok(None) => {
-                if strict {
-                    file_status.error("not supported")?;
+                if missing_is_error {
+                    file_status.failure("not supported", None);
                 }
                 return Ok(());
             }
             Err(crate::loader::LoadError::Cancelled(_)) => {
-                file_status.warn("language loading timed out")?;
+                file_status.warning("language loading timed out", None);
                 return Ok(());
             }
-            Err(e) => return Err(e.into()),
+            Err(e) => return Err(IndexError::LoadError(e)),
         };
         let source = file_reader.get(source_path)?;
         let tag = sha1(source);
 
-        if !self.force && db.file_exists(&source_path.to_string_lossy(), Some(&tag))? {
-            file_status.info("cached")?;
+        if !self.force
+            && self
+                .db
+                .file_exists(&source_path.to_string_lossy(), Some(&tag))?
+        {
+            file_status.skipped("cached", None);
             return Ok(());
         }
 
@@ -185,13 +228,12 @@ impl IndexArgs {
             cancellation_flag = CancelAfterDuration::new(max_file_time);
         }
 
-        file_status.processing()?;
+        file_status.processing();
 
         let mut graph = StackGraph::new();
-        let file = match graph.add_file(&source_path.to_string_lossy()) {
-            Ok(file) => file,
-            Err(_) => return Err(anyhow!("Duplicate file {}", source_path.display())),
-        };
+        let file = graph
+            .add_file(&source_path.to_string_lossy())
+            .expect("file not present in emtpy graph");
 
         let relative_source_path = source_path.strip_prefix(source_root).unwrap();
         let result = if let Some(fa) = source_path
@@ -219,45 +261,36 @@ impl IndexArgs {
         };
         match result {
             Err(BuildError::Cancelled(_)) => {
-                file_status.warn("parsing timed out")?;
+                file_status.warning("parsing timed out", None);
                 return Ok(());
             }
             Err(err @ BuildError::ParseErrors(_)) => {
-                file_status.error("parsing failed")?;
-                if !self.hide_error_details {
-                    println!(
-                        "{}",
-                        err.display_pretty(
-                            source_path,
-                            source,
-                            lc.sgl.tsg_path(),
-                            lc.sgl.tsg_source()
-                        )
-                    );
-                }
+                file_status.failure(
+                    "parsing failed",
+                    Some(&err.display_pretty(
+                        source_path,
+                        source,
+                        lc.sgl.tsg_path(),
+                        lc.sgl.tsg_source(),
+                    )),
+                );
                 return Ok(());
             }
             Err(err) => {
-                file_status.error("failed to build stack graph")?;
-                if !self.hide_error_details {
-                    println!(
-                        "{}",
-                        err.display_pretty(
-                            source_path,
-                            source,
-                            lc.sgl.tsg_path(),
-                            lc.sgl.tsg_source()
-                        )
-                    );
-                }
-                return Err(anyhow!(
-                    "Failed to build graph for {}",
-                    source_path.display()
-                ));
+                file_status.failure(
+                    "failed to build stack graph",
+                    Some(&err.display_pretty(
+                        source_path,
+                        source,
+                        lc.sgl.tsg_path(),
+                        lc.sgl.tsg_source(),
+                    )),
+                );
+                return Err(IndexError::StackGraph);
             }
             Ok(_) => {}
         };
-        db.add_graph_for_file(&graph, file, &tag)?;
+        self.db.add_graph_for_file(&graph, file, &tag)?;
 
         let mut partials = PartialPaths::new();
         match partials.find_minimal_partial_path_set_in_file(
@@ -265,36 +298,50 @@ impl IndexArgs {
             file,
             &cancellation_flag.as_ref(),
             |g, ps, p| {
-                db.add_partial_path_for_file(g, ps, &p, file)
+                self.db
+                    .add_partial_path_for_file(g, file, ps, &p)
                     .expect("adding path to database failed");
             },
         ) {
             Ok(_) => {}
             Err(_) => {
-                file_status.warn("path computation timed out")?;
+                file_status.warning("path computation timed out", None);
                 return Ok(());
             }
         }
 
-        file_status.ok("success")?;
+        file_status.success("success", None);
 
         Ok(())
     }
 
     /// Determines if a path should be skipped because we have not seen the
-    /// continue_from mark yet. The `seen_mark` parameter is necessary to keep
-    /// track of the mark between the calls in one run.
-    fn should_skip(&self, path: &Path, seen_mark: &mut bool) -> bool {
-        if *seen_mark {
-            return false; // return early and skip match
-        }
-        if let Some(mark) = &self.continue_from {
-            if path == mark {
-                *seen_mark = true; // this is the mark, we have seen it
-            }
-        } else {
-            *seen_mark = true; // early return from now on
-        }
-        return !*seen_mark; // skip if we haven't seen the mark yet
+    /// continue_from mark yet. If the mark is seen, it is cleared, after which
+    /// all paths are accepted.
+    fn should_skip<P>(&self, path: &Path, continue_from: &mut Option<P>) -> bool
+    where
+        P: AsRef<Path>,
+    {
+        match continue_from {
+            None => return false,
+            Some(continue_from) if continue_from.as_ref() != path => return true,
+            _ => {}
+        };
+        *continue_from = None;
+        false
     }
 }
+
+#[derive(Debug, Error)]
+pub enum IndexError {
+    #[error("failed to load language")]
+    LoadError(#[source] crate::loader::LoadError<'static>),
+    #[error("failed to read file")]
+    ReadError(#[from] std::io::Error),
+    #[error("failed to build stank graph")]
+    StackGraph,
+    #[error(transparent)]
+    StorageError(#[from] stack_graphs::storage::StorageError),
+}
+
+type Result<T> = std::result::Result<T, IndexError>;

--- a/tree-sitter-stack-graphs/src/cli/index.rs
+++ b/tree-sitter-stack-graphs/src/cli/index.rs
@@ -310,14 +310,13 @@ impl<'a> Indexer<'a> {
         }
 
         let mut partials = PartialPaths::new();
+        let mut paths = Vec::new();
         match partials.find_minimal_partial_path_set_in_file(
             &graph,
             file,
             &(&cancellation_flag as &dyn CancellationFlag),
-            |g, ps, p| {
-                self.db
-                    .add_partial_path_for_file(g, ps, &p, file)
-                    .expect("adding path to database failed");
+            |_g, _ps, p| {
+                paths.push(p);
             },
         ) {
             Ok(_) => {}
@@ -326,6 +325,9 @@ impl<'a> Indexer<'a> {
                 return Ok(());
             }
         }
+        self.db
+            .add_partial_paths_for_file(&graph, file, &mut partials, &paths)
+            .expect("adding path to database failed");
 
         file_status.success("success", None);
 

--- a/tree-sitter-stack-graphs/src/cli/index.rs
+++ b/tree-sitter-stack-graphs/src/cli/index.rs
@@ -316,7 +316,7 @@ impl<'a> Indexer<'a> {
             &(&cancellation_flag as &dyn CancellationFlag),
             |g, ps, p| {
                 self.db
-                    .add_partial_path_for_file(g, file, ps, &p)
+                    .add_partial_path_for_file(g, ps, &p, file)
                     .expect("adding path to database failed");
             },
         ) {

--- a/tree-sitter-stack-graphs/src/cli/index.rs
+++ b/tree-sitter-stack-graphs/src/cli/index.rs
@@ -13,7 +13,6 @@ use stack_graphs::storage::SQLiteWriter;
 use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
 use tree_sitter_graph::Variables;
@@ -223,9 +222,9 @@ impl<'a> Indexer<'a> {
             return Ok(());
         }
 
-        let mut cancellation_flag: Arc<dyn CancellationFlag> = Arc::new(NoCancellation);
+        let mut cancellation_flag: Box<dyn CancellationFlag> = Box::new(NoCancellation);
         if let Some(max_file_time) = self.max_file_time {
-            cancellation_flag = CancelAfterDuration::new(max_file_time);
+            cancellation_flag = Box::new(CancelAfterDuration::new(max_file_time));
         }
 
         file_status.processing();

--- a/tree-sitter-stack-graphs/src/cli/query.rs
+++ b/tree-sitter-stack-graphs/src/cli/query.rs
@@ -107,11 +107,11 @@ impl Definition {
                 }
             };
 
-            if reference.references_iter(graph).next().is_none() {
+            if reference.iter_references(graph).next().is_none() {
                 logger.failure("no references", None);
                 return Ok(());
             }
-            let starting_nodes = reference.references_iter(graph).collect::<Vec<_>>();
+            let starting_nodes = reference.iter_references(graph).collect::<Vec<_>>();
 
             let mut actual_paths = Vec::new();
             let mut reference_paths = Vec::new();

--- a/tree-sitter-stack-graphs/src/cli/query.rs
+++ b/tree-sitter-stack-graphs/src/cli/query.rs
@@ -9,6 +9,7 @@ use clap::Args;
 use clap::Parser;
 use clap::Subcommand;
 use clap::ValueHint;
+use itertools::Itertools;
 use lsp_positions::PositionedSubstring;
 use lsp_positions::SpanCalculator;
 use stack_graphs::storage::SQLiteReader;
@@ -20,7 +21,8 @@ use crate::loader::FileReader;
 
 use super::util::sha1;
 use super::util::wait_for_input;
-use super::util::FileStatusLogger;
+use super::util::ConsoleFileLogger;
+use super::util::FileLogger;
 use super::util::SourcePosition;
 
 /// Analyze sources
@@ -77,15 +79,16 @@ impl Definition {
             let mut file_reader = FileReader::new();
 
             let log_path = PathBuf::from(reference.to_string());
-            let mut logger = FileStatusLogger::new(&log_path, true);
-            logger.processing()?;
+            let mut logger = ConsoleFileLogger::new(&log_path, true, true);
+
+            logger.processing();
 
             let source_path = reference.path.to_string_lossy();
             let source = file_reader.get(&reference.path)?;
             let tag = sha1(source);
 
             if !db.file_exists(&source_path, Some(&tag))? {
-                logger.error("file not indexed")?;
+                logger.failure("file not indexed", None);
                 return Ok(());
             }
 
@@ -99,16 +102,16 @@ impl Definition {
             {
                 Ok(result) => result,
                 Err(_) => {
-                    logger.error("invalid file or position")?;
+                    logger.failure("invalid file or position", None);
                     return Ok(());
                 }
             };
 
-            if reference.iter_references(graph).next().is_none() {
-                logger.error("no references")?;
+            if reference.references_iter(graph).next().is_none() {
+                logger.failure("no references", None);
                 return Ok(());
             }
-            let starting_nodes = reference.iter_references(graph).collect::<Vec<_>>();
+            let starting_nodes = reference.references_iter(graph).collect::<Vec<_>>();
 
             let mut actual_paths = Vec::new();
             let mut reference_paths = Vec::new();
@@ -121,7 +124,7 @@ impl Definition {
             ) {
                 Ok(_) => {}
                 Err(StorageError::Cancelled(..)) => {
-                    logger.error("path finding timed out")?;
+                    logger.failure("path finding timed out", None);
                     return Ok(());
                 }
                 err => err?,
@@ -138,28 +141,35 @@ impl Definition {
             }
 
             if actual_paths.is_empty() {
-                logger.warn("no definitions")?;
+                logger.warning("no definitions", None);
                 return Ok(());
             }
 
-            logger.ok("found definitions:")?;
-            for (idx, path) in actual_paths.into_iter().enumerate() {
-                let file = match graph[path.end_node].id().file() {
-                    Some(f) => graph[f].to_string(),
-                    None => "?".to_string(),
-                };
-                let line_col = match graph.source_info(path.end_node) {
-                    Some(p) => format!(
-                        "{}:{}",
-                        p.span.start.line + 1,
-                        p.span.start.column.grapheme_offset + 1
-                    ),
-                    None => "?:?".to_string(),
-                };
-                println!("  {:2}: {}:{}", idx, file, line_col);
-            }
+            logger.success(
+                "found definitions:",
+                Some(
+                    &actual_paths
+                        .into_iter()
+                        .enumerate()
+                        .map(|(idx, path)| {
+                            let file = match graph[path.end_node].id().file() {
+                                Some(f) => graph[f].to_string(),
+                                None => "?".to_string(),
+                            };
+                            let line_col = match graph.source_info(path.end_node) {
+                                Some(p) => format!(
+                                    "{}:{}",
+                                    p.span.start.line + 1,
+                                    p.span.start.column.grapheme_offset + 1
+                                ),
+                                None => "?:?".to_string(),
+                            };
+                            format!("  {:2}: {}:{}", idx, file, line_col)
+                        })
+                        .join("\n"),
+                ),
+            );
         }
-
         Ok(())
     }
 }

--- a/tree-sitter-stack-graphs/src/cli/util.rs
+++ b/tree-sitter-stack-graphs/src/cli/util.rs
@@ -283,12 +283,12 @@ pub trait Logger {
 }
 
 pub trait FileLogger {
-    fn processing(&mut self);
-    fn failure(&mut self, status: &str, details: Option<&dyn std::fmt::Display>);
-    fn skipped(&mut self, status: &str, details: Option<&dyn std::fmt::Display>);
-    fn success(&mut self, status: &str, details: Option<&dyn std::fmt::Display>);
-    fn warning(&mut self, status: &str, details: Option<&dyn std::fmt::Display>);
-    fn default_failure(&mut self, status: &str, details: Option<&dyn std::fmt::Display>);
+    fn processing(&mut self) {}
+    fn failure(&mut self, _status: &str, _details: Option<&dyn std::fmt::Display>) {}
+    fn skipped(&mut self, _status: &str, _details: Option<&dyn std::fmt::Display>) {}
+    fn success(&mut self, _status: &str, _details: Option<&dyn std::fmt::Display>) {}
+    fn warning(&mut self, _status: &str, _details: Option<&dyn std::fmt::Display>) {}
+    fn default_failure(&mut self, _status: &str, _details: Option<&dyn std::fmt::Display>) {}
 }
 
 pub struct ConsoleLogger {

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -320,9 +320,6 @@ use std::collections::HashSet;
 use std::mem::transmute;
 use std::path::Path;
 use std::path::PathBuf;
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering;
-use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 use thiserror::Error;
@@ -336,6 +333,7 @@ use tree_sitter_graph::parse_error::ParseError;
 use tree_sitter_graph::parse_error::TreeWithParseErrorVec;
 use tree_sitter_graph::ExecutionConfig;
 use util::DisplayParseErrorsPretty;
+use util::TreeSitterCancellationFlag;
 
 #[cfg(feature = "cli")]
 pub mod ci;
@@ -567,12 +565,19 @@ impl<'a> Builder<'a> {
         globals: &'a Variables<'a>,
         cancellation_flag: &dyn CancellationFlag,
     ) -> Result<(), BuildError> {
-        let mut parser = Parser::new();
-        parser.set_language(self.sgl.language)?;
-        unsafe { parser.set_cancellation_flag(cancellation_flag.flag()) };
-        let tree = parser
-            .parse(self.source, None)
-            .ok_or(BuildError::ParseError)?;
+        let tree = {
+            let mut parser = Parser::new();
+            parser.set_language(self.sgl.language)?;
+            let ts_cancellation_flag = TreeSitterCancellationFlag::from(cancellation_flag);
+            // The parser.set_cancellation_flag` is unsafe, because it does not tie the
+            // lifetime of the parser to the lifetime of the cancellation flag in any way.
+            // To make it more obvious that the parser does not outlive the cancellation flag,
+            // it is put into its own block here, instead of extending to the end of the method.
+            unsafe { parser.set_cancellation_flag(Some(ts_cancellation_flag.as_ref())) };
+            parser
+                .parse(self.source, None)
+                .ok_or(BuildError::ParseError)?
+        };
         let parse_errors = ParseError::into_all(tree);
         if parse_errors.errors().len() > 0 {
             return Err(BuildError::ParseErrors(parse_errors));
@@ -619,7 +624,7 @@ impl<'a> Builder<'a> {
             tree,
             self.source,
             &mut config,
-            &cancellation_flag,
+            &(cancellation_flag as &dyn CancellationFlag),
         )?;
 
         self.load(cancellation_flag)
@@ -636,70 +641,55 @@ impl<'a> Builder<'a> {
 }
 
 /// Trait to signal that the execution is cancelled
-pub trait CancellationFlag {
-    fn flag(&self) -> Option<&AtomicUsize>;
+pub trait CancellationFlag: Sync {
+    fn check(&self, at: &'static str) -> Result<(), CancellationError>;
 }
+
+#[derive(Clone, Debug, Error)]
+#[error("Cancelled at \"{0}\"")]
+pub struct CancellationError(pub &'static str);
 
 impl stack_graphs::CancellationFlag for &dyn CancellationFlag {
     fn check(&self, at: &'static str) -> Result<(), stack_graphs::CancellationError> {
-        if self.flag().map_or(0, |f| f.load(Ordering::Relaxed)) != 0 {
-            return Err(stack_graphs::CancellationError(at));
-        }
-        Ok(())
+        CancellationFlag::check(*self, at).map_err(|err| stack_graphs::CancellationError(err.0))
     }
 }
 
 impl tree_sitter_graph::CancellationFlag for &dyn CancellationFlag {
     fn check(&self, at: &'static str) -> Result<(), tree_sitter_graph::CancellationError> {
-        if self.flag().map_or(0, |f| f.load(Ordering::Relaxed)) != 0 {
-            return Err(tree_sitter_graph::CancellationError(at));
-        }
-        Ok(())
+        CancellationFlag::check(*self, at)
+            .map_err(|err| tree_sitter_graph::CancellationError(err.0))
     }
 }
 
 pub struct NoCancellation;
 
 impl CancellationFlag for NoCancellation {
-    fn flag(&self) -> Option<&AtomicUsize> {
-        None
+    fn check(&self, _at: &'static str) -> Result<(), CancellationError> {
+        Ok(())
     }
 }
 
 pub struct CancelAfterDuration {
-    flag: AtomicUsize,
+    start: Instant,
+    limit: Duration,
 }
 
 impl CancelAfterDuration {
-    pub fn new(limit: Duration) -> Arc<Self> {
-        let result = Arc::new(Self {
-            flag: AtomicUsize::new(0),
-        });
-        let start = Instant::now();
-        let timer = Arc::downgrade(&result);
-        std::thread::spawn(move || {
-            loop {
-                std::thread::sleep(Duration::from_millis(10));
-                if let Some(timer) = timer.upgrade() {
-                    // the flag is still in use
-                    if start.elapsed().ge(&limit) {
-                        // set flag and stop polling
-                        timer.flag.store(1, Ordering::Relaxed);
-                        return;
-                    }
-                } else {
-                    // the flag is not in use anymore, stop polling
-                    return;
-                }
-            }
-        });
-        result
+    pub fn new(limit: Duration) -> Self {
+        Self {
+            start: Instant::now(),
+            limit,
+        }
     }
 }
 
 impl CancellationFlag for CancelAfterDuration {
-    fn flag(&self) -> Option<&AtomicUsize> {
-        Some(&self.flag)
+    fn check(&self, at: &'static str) -> Result<(), CancellationError> {
+        if self.start.elapsed().ge(&self.limit) {
+            return Err(CancellationError(at));
+        }
+        Ok(())
     }
 }
 

--- a/tree-sitter-stack-graphs/src/util.rs
+++ b/tree-sitter-stack-graphs/src/util.rs
@@ -54,11 +54,11 @@ impl<'a> TreeSitterCancellationFlag<'a> {
         // so that we can pass it to the polling thread. This is possible, because:
         //   (1) The lifetime parameter on `TreeSitterCancellationFlag` ensures it does
         //       not outlive the original reference.
-        //   (1) The thread captures a weak reference to the flag, which ensures that
+        //   (2) The thread captures a weak reference to the flag, which ensures that
         //       `cancellation_flag` are only accessed as long as the flag exists.
-        //   (2) The field `self.flag` is the only other reference to the flag, ensuring
+        //   (3) The field `self.flag` is the only other reference to the flag, ensuring
         //       the flag does not outlive the struct.
-        //   (3) The lifetime parameter `'a` ensures that the struct does not outlive the
+        //   (4) The lifetime parameter `'a` ensures that the struct does not outlive the
         //       `cancellation_flag` reference.
         // All of this ensures that the thread will not access `cancellation_flag` beyond
         // its lifetime.


### PR DESCRIPTION
| ◀️ #238 | #254 ▶️ |
|-|-|

This PR is part of the work to implement an LSP server (#242). This adds indexing of the workspace folders.

- Indexing is done in a background thread, so that the LSP server is not blocked for too long, which might make the client nervous.
- Cancellation flags were cleaned up a bit. Instead of exposing the usize required by Tree-sitter in the trait, we handle the bridging implcitly. This makes it easier to write combinators that combine different cancellation flags.
- Some timeout flags and VSCode extension config were added to control the indexing from the plugin.
- The indexing runs whenever workspace folders change.

## Issues

Indexing is not particulary fast. A few things were applied that should make it faster:

- Do not check foreign keys all the time.
- Do not do secure deletes (i.e., zero deleted records).
- Use a write-ahead log instead of the more expensive default.

Other ideas:

- Improve reporting of progress to the user. It is possible to see progress in the extension log, but users will usually not look at those.
- Run indexing in parallel. Files can be analyzed in parallel. However, this will require some changes to the `Indexer` because sharing the database struct between threads is not possible.