### PR TITLE
Introduce `status` command

### DIFF
--- a/stack-graphs/src/storage.rs
+++ b/stack-graphs/src/storage.rs
@@ -391,7 +391,7 @@ impl SQLiteWriter {
     /// Get the file's status in the database. If a tag is provided, it must match or the file
     /// is reported missing.
     pub fn status_for_file(&mut self, file: &str, tag: Option<&str>) -> Result<FileStatus> {
-        file_status(&self.conn, file, tag)
+        status_for_file(&self.conn, file, tag)
     }
 
     /// Convert this writer into a reader for the same database.
@@ -443,8 +443,8 @@ impl SQLiteReader {
 
     /// Get the file's status in the database. If a tag is provided, it must match or the file
     /// is reported missing.
-    pub fn file_status(&mut self, file: &str, tag: Option<&str>) -> Result<FileStatus> {
-        file_status(&self.conn, file, tag)
+    pub fn status_for_file(&mut self, file: &str, tag: Option<&str>) -> Result<FileStatus> {
+        status_for_file(&self.conn, file, tag)
     }
 
     /// Returns a [`Files`][] value that can be used to iterate over all files in the database.
@@ -676,7 +676,7 @@ fn set_pragmas_and_functions(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
-fn file_status<'a>(conn: &'a Connection, file: &str, tag: Option<&str>) -> Result<FileStatus> {
+fn status_for_file<'a>(conn: &'a Connection, file: &str, tag: Option<&str>) -> Result<FileStatus> {
     let result = if let Some(tag) = tag {
         let mut stmt =
             conn.prepare_cached("SELECT error FROM graphs WHERE file = ? AND tag = ?")?;

--- a/stack-graphs/src/storage.rs
+++ b/stack-graphs/src/storage.rs
@@ -676,7 +676,7 @@ fn set_pragmas_and_functions(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
-fn status_for_file<'a>(conn: &'a Connection, file: &str, tag: Option<&str>) -> Result<FileStatus> {
+fn status_for_file(conn: &Connection, file: &str, tag: Option<&str>) -> Result<FileStatus> {
     let result = if let Some(tag) = tag {
         let mut stmt =
             conn.prepare_cached("SELECT error FROM graphs WHERE file = ? AND tag = ?")?;

--- a/tree-sitter-stack-graphs/src/cli.rs
+++ b/tree-sitter-stack-graphs/src/cli.rs
@@ -66,6 +66,7 @@ pub mod load;
 pub mod lsp;
 pub mod parse;
 pub mod query;
+pub mod status;
 pub mod test;
 mod util;
 
@@ -82,6 +83,7 @@ pub mod path_loading {
     use crate::cli::lsp::LspArgs;
     use crate::cli::parse::ParseArgs;
     use crate::cli::query::QueryArgs;
+    use crate::cli::status::StatusArgs;
     use crate::cli::test::TestArgs;
 
     use super::database::DatabaseArgs;
@@ -95,6 +97,7 @@ pub mod path_loading {
         Lsp(Lsp),
         Parse(Parse),
         Query(Query),
+        Status(Status),
         Test(Test),
     }
 
@@ -108,6 +111,7 @@ pub mod path_loading {
                 Self::Lsp(cmd) => cmd.run(default_db_path),
                 Self::Parse(cmd) => cmd.run(),
                 Self::Query(cmd) => cmd.run(default_db_path),
+                Self::Status(cmd) => cmd.run(default_db_path),
                 Self::Test(cmd) => cmd.run(),
             }
         }
@@ -214,6 +218,22 @@ pub mod path_loading {
         }
     }
 
+    /// Status command
+    #[derive(clap::Parser)]
+    pub struct Status {
+        #[clap(flatten)]
+        db_args: DatabaseArgs,
+        #[clap(flatten)]
+        status_args: StatusArgs,
+    }
+
+    impl Status {
+        pub fn run(self, default_db_path: PathBuf) -> anyhow::Result<()> {
+            let db_path = self.db_args.get_or(default_db_path);
+            self.status_args.run(&db_path)
+        }
+    }
+
     /// Test command
     #[derive(clap::Parser)]
     pub struct Test {
@@ -243,6 +263,7 @@ pub mod provided_languages {
     use crate::cli::lsp::LspArgs;
     use crate::cli::parse::ParseArgs;
     use crate::cli::query::QueryArgs;
+    use crate::cli::status::StatusArgs;
     use crate::cli::test::TestArgs;
     use crate::loader::LanguageConfiguration;
 
@@ -256,6 +277,7 @@ pub mod provided_languages {
         Lsp(Lsp),
         Parse(Parse),
         Query(Query),
+        Status(Status),
         Test(Test),
     }
 
@@ -272,6 +294,7 @@ pub mod provided_languages {
                 Self::Lsp(cmd) => cmd.run(default_db_path, configurations),
                 Self::Parse(cmd) => cmd.run(configurations),
                 Self::Query(cmd) => cmd.run(default_db_path),
+                Self::Status(cmd) => cmd.run(default_db_path),
                 Self::Test(cmd) => cmd.run(configurations),
             }
         }
@@ -370,6 +393,22 @@ pub mod provided_languages {
         pub fn run(self, default_db_path: PathBuf) -> anyhow::Result<()> {
             let db_path = self.db_args.get_or(default_db_path);
             self.query_args.run(&db_path)
+        }
+    }
+
+    /// Status command
+    #[derive(clap::Parser)]
+    pub struct Status {
+        #[clap(flatten)]
+        db_args: DatabaseArgs,
+        #[clap(flatten)]
+        status_args: StatusArgs,
+    }
+
+    impl Status {
+        pub fn run(self, default_db_path: PathBuf) -> anyhow::Result<()> {
+            let db_path = self.db_args.get_or(default_db_path);
+            self.status_args.run(&db_path)
         }
     }
 

--- a/tree-sitter-stack-graphs/src/cli/query.rs
+++ b/tree-sitter-stack-graphs/src/cli/query.rs
@@ -88,7 +88,7 @@ impl Definition {
             let source = file_reader.get(&reference.path)?;
             let tag = sha1(source);
 
-            match db.file_status(&source_path, Some(&tag))? {
+            match db.status_for_file(&source_path, Some(&tag))? {
                 FileStatus::Indexed => {}
                 _ => {
                     logger.failure("file not indexed", None);

--- a/tree-sitter-stack-graphs/src/cli/status.rs
+++ b/tree-sitter-stack-graphs/src/cli/status.rs
@@ -1,0 +1,83 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2023, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use clap::ArgGroup;
+use clap::Args;
+use clap::ValueHint;
+use stack_graphs::storage::FileEntry;
+use stack_graphs::storage::FileStatus;
+use stack_graphs::storage::SQLiteReader;
+use std::path::Path;
+use std::path::PathBuf;
+
+use super::util::ConsoleFileLogger;
+use super::util::FileLogger;
+
+/// Status of files in the database
+#[derive(Args)]
+#[clap(group(
+    ArgGroup::new("paths")
+        .required(true)
+        .args(&["source-paths", "all"]),
+))]
+
+pub struct StatusArgs {
+    /// Source file or directory paths.
+    #[clap(
+        value_name = "SOURCE_PATH",
+        value_hint = ValueHint::AnyPath,
+        parse(from_os_str),
+    )]
+    pub source_paths: Vec<PathBuf>,
+
+    /// List all data from the database.
+    #[clap(long, short = 'a')]
+    pub all: bool,
+
+    #[clap(long, short = 'v')]
+    pub verbose: bool,
+}
+
+impl StatusArgs {
+    pub fn run(self, db_path: &Path) -> anyhow::Result<()> {
+        let mut db = SQLiteReader::open(&db_path)?;
+        if self.all {
+            let mut files = db.list_all()?;
+            let mut entries = files.try_iter()?;
+            self.status(&mut entries)?;
+        } else {
+            for source_path in &self.source_paths {
+                let mut files = db.list_file_or_directory(&source_path)?;
+                let mut entries = files.try_iter()?;
+                self.status(&mut entries)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn status(
+        &self,
+        entries: &mut impl Iterator<Item = stack_graphs::storage::Result<FileEntry>>,
+    ) -> anyhow::Result<()> {
+        for entry in entries {
+            let entry = entry?;
+            let mut logger = ConsoleFileLogger::new(&Path::new(&entry.path), true, self.verbose);
+            match &entry.status {
+                FileStatus::Missing => {
+                    logger.skipped("missing", None);
+                }
+                FileStatus::Indexed => {
+                    logger.success("indexed", None);
+                }
+                FileStatus::Error(error) => {
+                    logger.failure("failed", Some(error));
+                }
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
| ◀️ #254 | #256 ▶️ |
|-|-|

This PR is part of the work to implement an LSP server (#242). It changes the database so that we can record indexing failures. A new `status` command shows the status of files in the database. This is helpful for debugging.

## Limitations

The command does not yet report on files that are present on the file system but missing from the database.