### PR TITLE
Implement LSP Go to Definition

### DIFF
--- a/languages/tree-sitter-stack-graphs-typescript/vscode/package.json
+++ b/languages/tree-sitter-stack-graphs-typescript/vscode/package.json
@@ -59,6 +59,14 @@
                     "minimum": -1,
                     "default": 10,
                     "scope": "machine-overridable",
+                    "order": 30
+                },
+                "tree-sitter-stack-graphs-typescript.query.maxTime": {
+                    "markdownDescription": "Maximum query time per file in milliseconds (-1 means no limit). _Requires reload for changes to take effect._",
+                    "type": "integer",
+                    "minimum": -1,
+                    "default": 100,
+                    "scope": "machine-overridable",
                     "order": 20
                 }
             }

--- a/languages/tree-sitter-stack-graphs-typescript/vscode/package.json
+++ b/languages/tree-sitter-stack-graphs-typescript/vscode/package.json
@@ -24,7 +24,7 @@
             "title": "tree-sitter-stack-graphs-typescript",
             "properties": {
                 "tree-sitter-stack-graphs-typescript.database.defaultLocation": {
-                    "markdownDescription": "The default location for the database, if an explicit path is not provided. _Requires reload for changes to take effect._",
+                    "markdownDescription": "The default location for the database, if an explicit path is not provided.",
                     "type": "string",
                     "default": "workspace",
                     "enum": [
@@ -39,14 +39,14 @@
                     "order": 10
                 },
                 "tree-sitter-stack-graphs-typescript.database.path": {
-                    "markdownDescription": "The path to the database. Expands ~ to the user's home directory. _Requires reload for changes to take effect._",
+                    "markdownDescription": "The path to the database. Expands ~ to the user's home directory.",
                     "type": "string",
                     "default": null,
                     "scope": "machine-overridable",
                     "order": 11
                 },
                 "tree-sitter-stack-graphs-typescript.index.maxFolderTime": {
-                    "markdownDescription": "Maximum index time per workspace folder in seconds (-1 means no limit). _Requires reload for changes to take effect._",
+                    "markdownDescription": "Maximum index time per workspace folder in seconds (-1 means no limit).",
                     "type": "integer",
                     "minimum": -1,
                     "default": -1,
@@ -54,20 +54,20 @@
                     "order": 20
                 },
                 "tree-sitter-stack-graphs-typescript.index.maxFileTime": {
-                    "markdownDescription": "Maximum index time per file in seconds (-1 means no limit). _Requires reload for changes to take effect._",
+                    "markdownDescription": "Maximum index time per file in seconds (-1 means no limit).",
                     "type": "integer",
                     "minimum": -1,
                     "default": 10,
                     "scope": "machine-overridable",
-                    "order": 30
+                    "order": 21
                 },
                 "tree-sitter-stack-graphs-typescript.query.maxTime": {
-                    "markdownDescription": "Maximum query time per file in milliseconds (-1 means no limit). _Requires reload for changes to take effect._",
+                    "markdownDescription": "Maximum query time per file in milliseconds (-1 means no limit).",
                     "type": "integer",
                     "minimum": -1,
                     "default": 100,
                     "scope": "machine-overridable",
-                    "order": 20
+                    "order": 30
                 }
             }
         }

--- a/languages/tree-sitter-stack-graphs-typescript/vscode/src/extension.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/vscode/src/extension.ts
@@ -1,7 +1,7 @@
 import exp = require('constants');
 import { mkdirSync } from 'fs';
 import { homedir } from 'os';
-import { ExtensionContext, StatusBarItem, Uri, window, workspace } from 'vscode';
+import { ExtensionContext, StatusBarItem, Uri, commands, window, workspace } from 'vscode';
 
 // should match `name` in `Cargo.toml`
 const NAME = "tree-sitter-stack-graphs-typescript";
@@ -49,6 +49,10 @@ export function activate(context: ExtensionContext) {
     let max_file_index_time = config.get<integer>('index.maxFileTime');
     if (max_file_index_time && max_file_index_time >= 0) {
         args.push("--max-file-index-time", max_file_index_time.toString());
+    }
+    let max_query_time = config.get<integer>('query.maxTime');
+    if (max_query_time && max_query_time >= 0) {
+        args.push("--max-query-time", max_query_time.toString());
     }
 
     const serverOptions: ServerOptions = { command, args };

--- a/languages/tree-sitter-stack-graphs-typescript/vscode/src/extension.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/vscode/src/extension.ts
@@ -1,5 +1,3 @@
-import exp = require('constants');
-import { mkdirSync } from 'fs';
 import { homedir } from 'os';
 import { ExtensionContext, StatusBarItem, Uri, commands, window, workspace } from 'vscode';
 
@@ -17,46 +15,17 @@ let client: LanguageClient;
 let status: StatusBarItem;
 
 export function activate(context: ExtensionContext) {
+    let storageUri = context?.storageUri;
+    if (!storageUri) {
+        // cannot start, no workspace is open
+        return;
+    }
+    // ensure workspace folder exists
+    workspace.fs.createDirectory(storageUri);
+
     let command = context.asAbsolutePath("out/bin/" + NAME);
-    let args = ["lsp"];
-
-    let config = workspace.getConfiguration(NAME);
-    let config_db_path = config.get<string>('database.path');
-    if (config_db_path) {
-        let db_path = config_db_path.replace(/^~(?=$|\/|\\)/, homedir());
-        args.push("-D", db_path);
-    } else {
-        switch (config.get<string>('database.defaultLocation')) {
-            case "workspace":
-                if (!context?.storageUri?.fsPath) {
-                    // cannot start, no workspace is open
-                    return;
-                }
-                mkdirSync(context.storageUri.fsPath, { recursive: true });
-                let db_path = Uri.joinPath(context.storageUri, NAME + ".sqlite").fsPath;
-                args.push("-D", db_path);
-                break;
-            case "user":
-                // omit -D
-                break;
-        }
-    }
-
-    let max_folder_index_time = config.get<integer>('index.maxFolderTime');
-    if (max_folder_index_time && max_folder_index_time >= 0) {
-        args.push("--max-folder-index-time", max_folder_index_time.toString());
-    }
-    let max_file_index_time = config.get<integer>('index.maxFileTime');
-    if (max_file_index_time && max_file_index_time >= 0) {
-        args.push("--max-file-index-time", max_file_index_time.toString());
-    }
-    let max_query_time = config.get<integer>('query.maxTime');
-    if (max_query_time && max_query_time >= 0) {
-        args.push("--max-query-time", max_query_time.toString());
-    }
-
+    let args = buildArgsFromConfig(storageUri);
     const serverOptions: ServerOptions = { command, args };
-
     const clientOptions: LanguageClientOptions = {
         // these should match `file_types` and `special_files` in `rust/lib.rs`
         documentSelector: [
@@ -78,11 +47,59 @@ export function activate(context: ExtensionContext) {
     status.show();
 
     client.start();
+
+    workspace.onDidChangeConfiguration((e) => {
+        if (e.affectsConfiguration(NAME)) {
+            serverOptions.args = buildArgsFromConfig(storageUri);
+            client.restart();
+        }
+    });
+}
+
+function buildArgsFromConfig(storageUri: Uri): string[] {
+    let args = ["lsp"];
+
+    let config = workspace.getConfiguration(NAME);
+    let config_db_path = config.get<string>('database.path');
+    if (config_db_path) {
+        let db_path = config_db_path.replace(/^~(?=$|\/|\\)/, homedir());
+        args.push("-D", db_path);
+    } else {
+        switch (config.get<string>('database.defaultLocation')) {
+            case "workspace":
+                let db_path = Uri.joinPath(storageUri, NAME + ".sqlite").fsPath;
+                args.push("-D", db_path);
+                break;
+            case "user":
+                // omit -D
+                break;
+        }
+    }
+
+    let max_folder_index_time = config.get<integer>('index.maxFolderTime');
+    if (max_folder_index_time && max_folder_index_time >= 0) {
+        args.push("--max-folder-index-time", max_folder_index_time.toString());
+    }
+    let max_file_index_time = config.get<integer>('index.maxFileTime');
+    if (max_file_index_time && max_file_index_time >= 0) {
+        args.push("--max-file-index-time", max_file_index_time.toString());
+    }
+    let max_query_time = config.get<integer>('query.maxTime');
+    if (max_query_time && max_query_time >= 0) {
+        args.push("--max-query-time", max_query_time.toString());
+    }
+
+    return args;
 }
 
 export function deactivate(): Thenable<void> | undefined {
+    if (!client) {
+        return undefined;
+    }
     if (status) {
         status.dispose();
     }
-    return client ? client.stop() : undefined;
+    let result = client.stop();
+    client = undefined;
+    return result;
 }

--- a/tree-sitter-stack-graphs/src/cli/lsp.rs
+++ b/tree-sitter-stack-graphs/src/cli/lsp.rs
@@ -90,6 +90,29 @@ impl LspArgs {
     }
 }
 
+impl std::fmt::Display for LspArgs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(max_folder_index_time) = self.max_folder_index_time {
+            write!(
+                f,
+                " --max-folder-index-time {}",
+                max_folder_index_time.as_secs()
+            )?;
+        }
+        if let Some(max_file_index_time) = self.max_file_index_time {
+            write!(
+                f,
+                " --max-file-index-time {}",
+                max_file_index_time.as_secs()
+            )?;
+        }
+        if let Some(max_query_time) = self.max_query_time {
+            write!(f, " --max-query-time {}", max_query_time.as_millis())?;
+        }
+        Ok(())
+    }
+}
+
 #[derive(Clone)]
 struct Backend {
     _client: Client,
@@ -282,7 +305,7 @@ impl Backend {
 #[tower_lsp::async_trait]
 impl LanguageServer for Backend {
     async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
-        self.logger.info("Initializing").await;
+        self.logger.info(format!("Initialize:{}", self.args)).await;
 
         self.ensure_compatible_database().await?;
 

--- a/tree-sitter-stack-graphs/src/cli/lsp.rs
+++ b/tree-sitter-stack-graphs/src/cli/lsp.rs
@@ -281,8 +281,13 @@ impl Backend {
             }
         };
 
-        let mut querier = Querier::new(&mut db);
+        let handle = Handle::current();
+        let logger = LspLogger {
+            handle: handle.clone(),
+            logger: self.logger.clone(),
+        };
         let result = {
+            let mut querier = Querier::new(&mut db, &logger);
             let cancellation_flag = CancelAfterDuration::from_option(self.args.max_query_time);
             querier.definitions(reference, cancellation_flag.as_ref())
         };

--- a/tree-sitter-stack-graphs/src/cli/lsp.rs
+++ b/tree-sitter-stack-graphs/src/cli/lsp.rs
@@ -588,69 +588,68 @@ impl Logger for LspLogger {
 
 impl FileLogger for LspFileLogger<'_> {
     fn default_failure(&mut self, status: &str, _details: Option<&dyn std::fmt::Display>) {
-        self.handle.block_on(capture!(
-            [logger = &self.logger, path = self.path],
-            async move {
-                logger
-                    .error(format!("{}: {}", path.display(), status))
-                    .await;
-            }
-        ));
+        let logger = self.logger.clone();
+        let path = self.path.to_owned();
+        let status = status.to_owned();
+        self.handle.spawn(async move {
+            logger
+                .error(format!("{}: {}", path.display(), status))
+                .await;
+        });
     }
 
     fn failure(&mut self, status: &str, _details: Option<&dyn std::fmt::Display>) {
-        self.handle.block_on(capture!(
-            [logger = &self.logger, path = self.path],
-            async move {
-                logger
-                    .error(format!("{}: {}", path.display(), status))
-                    .await;
-            }
-        ));
+        let logger = self.logger.clone();
+        let path = self.path.to_owned();
+        let status = status.to_owned();
+        self.handle.spawn(async move {
+            logger
+                .error(format!("{}: {}", path.display(), status))
+                .await;
+        });
     }
 
     fn skipped(&mut self, status: &str, _details: Option<&dyn std::fmt::Display>) {
-        self.handle.block_on(capture!(
-            [logger = &self.logger, path = self.path],
-            async move {
-                logger
-                    .info(format!("{}: skipped: {}", path.display(), status))
-                    .await;
-            }
-        ));
+        let logger = self.logger.clone();
+        let path = self.path.to_owned();
+        let status = status.to_owned();
+        self.handle.spawn(async move {
+            logger
+                .info(format!("{}: skipped: {}", path.display(), status))
+                .await;
+        });
     }
 
     fn warning(&mut self, status: &str, _details: Option<&dyn std::fmt::Display>) {
-        self.handle.block_on(capture!(
-            [logger = &self.logger, path = self.path],
-            async move {
-                logger
-                    .warning(format!("{}: {}", path.display(), status))
-                    .await;
-            }
-        ));
+        let logger = self.logger.clone();
+        let path = self.path.to_owned();
+        let status = status.to_owned();
+        self.handle.spawn(async move {
+            logger
+                .warning(format!("{}: {}", path.display(), status))
+                .await;
+        });
     }
 
     fn success(&mut self, status: &str, _details: Option<&dyn std::fmt::Display>) {
-        self.handle.block_on(capture!(
-            [logger = &self.logger, path = self.path],
-            async move {
-                logger
-                    .info(format!("{}: success: {}", path.display(), status))
-                    .await;
-            }
-        ));
+        let logger = self.logger.clone();
+        let path = self.path.to_owned();
+        let status = status.to_owned();
+        self.handle.spawn(async move {
+            logger
+                .info(format!("{}: success: {}", path.display(), status))
+                .await;
+        });
     }
 
     fn processing(&mut self) {
-        self.handle.block_on(capture!(
-            [logger = &self.logger, path = self.path],
-            async move {
-                logger
-                    .info(format!("{}: processing...", path.display()))
-                    .await;
-            }
-        ));
+        let logger = self.logger.clone();
+        let path = self.path.to_owned();
+        self.handle.spawn(async move {
+            logger
+                .info(format!("{}: processing...", path.display()))
+                .await;
+        });
     }
 }
 

--- a/tree-sitter-stack-graphs/src/cli/query.rs
+++ b/tree-sitter-stack-graphs/src/cli/query.rs
@@ -17,14 +17,17 @@ use stack_graphs::storage::SQLiteReader;
 use stack_graphs::storage::StorageError;
 use std::path::Path;
 use std::path::PathBuf;
+use thiserror::Error;
 
 use crate::loader::FileReader;
+use crate::CancellationFlag;
 
 use super::util::sha1;
 use super::util::wait_for_input;
 use super::util::ConsoleFileLogger;
 use super::util::FileLogger;
 use super::util::SourcePosition;
+use super::util::SourceSpan;
 
 /// Analyze sources
 #[derive(Args)]
@@ -177,3 +180,116 @@ impl Definition {
         Ok(())
     }
 }
+
+pub struct Querier<'a> {
+    db: &'a mut SQLiteReader,
+}
+
+impl<'a> Querier<'a> {
+    pub fn new(db: &'a mut SQLiteReader) -> Self {
+        Self { db }
+    }
+
+    pub fn definitions(
+        &mut self,
+        reference: SourcePosition,
+        cancellation_flag: &dyn CancellationFlag,
+    ) -> Result<Vec<SourceSpan>> {
+        let mut file_reader = FileReader::new();
+
+        let source = file_reader.get(&reference.path)?;
+        let tag = sha1(source);
+
+        match self
+            .db
+            .file_status(&reference.path.to_string_lossy(), Some(&tag))?
+        {
+            FileStatus::Indexed => {}
+            _ => return Ok(Vec::default()),
+        }
+
+        let lines = PositionedSubstring::lines_iter(source);
+        let mut span_calculator = SpanCalculator::new(source);
+
+        self.db
+            .load_graph_for_file(&reference.path.to_string_lossy())?;
+        let (graph, _, _) = self.db.get();
+
+        let reference = match reference.to_assertion_source(graph, lines, &mut span_calculator) {
+            Ok(result) => result,
+            Err(_) => {
+                return Ok(Vec::default());
+            }
+        };
+
+        if reference.references_iter(graph).next().is_none() {
+            return Ok(Vec::default());
+        }
+        let starting_nodes = reference.references_iter(graph).collect::<Vec<_>>();
+
+        let mut actual_paths = Vec::new();
+        let mut reference_paths = Vec::new();
+        match self.db.find_all_complete_partial_paths(
+            starting_nodes,
+            &cancellation_flag,
+            |_g, _ps, p| {
+                reference_paths.push(p.clone());
+            },
+        ) {
+            Ok(_) => {}
+            Err(StorageError::Cancelled(..)) => {
+                return Ok(Vec::default());
+            }
+            err => err?,
+        };
+
+        let (graph, partials, _) = self.db.get();
+        for reference_path in &reference_paths {
+            if reference_paths
+                .iter()
+                .all(|other| !other.shadows(partials, reference_path))
+            {
+                actual_paths.push(reference_path.clone());
+            }
+        }
+
+        if actual_paths.is_empty() {
+            return Ok(Vec::default());
+        }
+
+        let definitions = actual_paths
+            .into_iter()
+            .filter_map(|path| {
+                let span = match graph.source_info(path.end_node) {
+                    Some(p) => p.span.clone(),
+                    None => return None,
+                };
+                let path = match graph[path.end_node].id().file() {
+                    Some(f) => PathBuf::from(graph[f].name()),
+                    None => return None,
+                };
+                Some(SourceSpan { path, span })
+            })
+            .collect();
+
+        Ok(definitions)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum QueryError {
+    #[error("cancelled at {0}")]
+    Cancelled(&'static str),
+    #[error("failed to read file")]
+    ReadError(#[from] std::io::Error),
+    #[error(transparent)]
+    StorageError(#[from] stack_graphs::storage::StorageError),
+}
+
+impl From<crate::CancellationError> for QueryError {
+    fn from(value: crate::CancellationError) -> Self {
+        Self::Cancelled(value.0)
+    }
+}
+
+type Result<T> = std::result::Result<T, QueryError>;

--- a/tree-sitter-stack-graphs/src/cli/util.rs
+++ b/tree-sitter-stack-graphs/src/cli/util.rs
@@ -271,12 +271,16 @@ impl SourceSpan {
 }
 
 pub fn duration_from_seconds_str(s: &str) -> Result<Duration, anyhow::Error> {
-    Ok(Duration::new(s.parse()?, 0))
+    let seconds = s.parse::<u64>()?;
+    Ok(Duration::new(seconds, 0))
 }
 
 #[cfg(feature = "lsp")]
 pub fn duration_from_milliseconds_str(s: &str) -> Result<Duration, anyhow::Error> {
-    Ok(Duration::new(0, 1_000_000_u32 * s.parse::<u32>()?))
+    let milliseconds = s.parse::<u64>()?;
+    let seconds = milliseconds / 1000;
+    let nano_seconds = (milliseconds % 1000) as u32 * 1_000_000;
+    Ok(Duration::new(seconds, nano_seconds))
 }
 
 pub fn iter_files_and_directories<'a, P, IP>(

--- a/tree-sitter-stack-graphs/src/cli/util.rs
+++ b/tree-sitter-stack-graphs/src/cli/util.rs
@@ -9,6 +9,7 @@ use anyhow::anyhow;
 use base64::Engine;
 use colored::Colorize;
 use lsp_positions::PositionedSubstring;
+use lsp_positions::Span;
 use lsp_positions::SpanCalculator;
 use sha1::Digest;
 use sha1::Sha1;
@@ -237,8 +238,21 @@ impl std::str::FromStr for SourcePosition {
     }
 }
 
+#[derive(Clone, Debug)]
+/// A source span.
+pub struct SourceSpan {
+    /// File path
+    pub path: PathBuf,
+    /// Span
+    pub span: Span,
+}
+
 pub fn duration_from_seconds_str(s: &str) -> Result<Duration, anyhow::Error> {
     Ok(Duration::new(s.parse()?, 0))
+}
+
+pub fn duration_from_milliseconds_str(s: &str) -> Result<Duration, anyhow::Error> {
+    Ok(Duration::new(0, 1_000_000_u32 * s.parse::<u32>()?))
 }
 
 pub fn iter_files_and_directories<'a, P, IP>(

--- a/tree-sitter-stack-graphs/src/cli/util.rs
+++ b/tree-sitter-stack-graphs/src/cli/util.rs
@@ -274,6 +274,7 @@ pub fn duration_from_seconds_str(s: &str) -> Result<Duration, anyhow::Error> {
     Ok(Duration::new(s.parse()?, 0))
 }
 
+#[cfg(feature = "lsp")]
 pub fn duration_from_milliseconds_str(s: &str) -> Result<Duration, anyhow::Error> {
     Ok(Duration::new(0, 1_000_000_u32 * s.parse::<u32>()?))
 }


### PR DESCRIPTION
| ◀️ #255 | #257 ▶️ |
|-|-|

This PR is part of the work to implement an LSP server (#242). This implements LSP Go to Definition.

## Limitations

It is very slow. Too slow to be very useful at the moment.

The obvious thing to look at next would be some kind of caching. Each query will load everything fresh from disk. But the LSP server is persistent between queries, so we can keep the things we load around. This brings its own set of problems, of course. This cache can become (partially) invalid when files are changed, and the stack graph data structures are not built for removing information.

Preloading the data for a file when it is opened in an editor would also help, I expect.