### PR TITLE
Show source excerpts for resolved definitions

### DIFF
--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -76,7 +76,7 @@ tokio = { version = "1.26", optional = true, features = ["io-std", "rt", "rt-mul
 tower-lsp = { version = "0.19", optional = true }
 tree-sitter = ">= 0.19"
 tree-sitter-config = { version = "0.19", optional = true }
-tree-sitter-graph = "0.9.1"
+tree-sitter-graph = "0.9.2"
 tree-sitter-loader = "0.20"
 walkdir = { version = "2.3", optional = true }
 

--- a/tree-sitter-stack-graphs/src/cli/lsp.rs
+++ b/tree-sitter-stack-graphs/src/cli/lsp.rs
@@ -293,7 +293,7 @@ impl Backend {
             querier.definitions(reference, cancellation_flag.as_ref())
         };
         match result {
-            Ok(result) => result,
+            Ok(result) => result.into_iter().flat_map(|r| r.targets).collect(),
             Err(QueryError::Cancelled(at)) => {
                 self.logger
                     .error(format!("query timed out at {}", at,))

--- a/tree-sitter-stack-graphs/src/cli/util.rs
+++ b/tree-sitter-stack-graphs/src/cli/util.rs
@@ -17,6 +17,7 @@ use stack_graphs::graph::StackGraph;
 use std::ffi::OsStr;
 use std::ffi::OsString;
 use std::io::Write;
+use std::ops::Range;
 use std::path::Path;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -253,20 +254,16 @@ pub struct SourceSpan {
 }
 
 impl SourceSpan {
-    pub fn to_start_position(&self) -> SourcePosition {
-        SourcePosition {
-            path: self.path.clone(),
-            line: self.span.start.line,
-            column: self.span.start.column.grapheme_offset,
-        }
-    }
-
-    pub fn into_start_position(self) -> SourcePosition {
-        SourcePosition {
-            path: self.path,
-            line: self.span.start.line,
-            column: self.span.start.column.grapheme_offset,
-        }
+    /// Returns a range for the first line of this span. If multiple lines are spanned, it
+    /// will use usize::MAX for the range's end.
+    pub fn to_first_line_column_range(&self) -> Range<usize> {
+        let start = self.span.start.column.grapheme_offset;
+        let end = if self.span.start.line == self.span.end.line {
+            self.span.end.column.grapheme_offset
+        } else {
+            usize::MAX
+        };
+        start..end
     }
 }
 

--- a/tree-sitter-stack-graphs/src/cli/util.rs
+++ b/tree-sitter-stack-graphs/src/cli/util.rs
@@ -148,17 +148,23 @@ impl SourcePosition {
     pub fn iter_references<'a>(
         &'a self,
         graph: &'a StackGraph,
-    ) -> impl Iterator<Item = Handle<Node>> + 'a {
+    ) -> impl Iterator<Item = (Handle<Node>, Span)> + 'a {
         graph
             .get_file(&self.path.to_string_lossy())
             .into_iter()
             .flat_map(move |file| {
-                graph.nodes_for_file(file).filter(move |n| {
-                    graph[*n].is_reference()
-                        && graph
-                            .source_info(*n)
-                            .map(|si| self.within_span(&si.span))
-                            .unwrap_or(false)
+                graph.nodes_for_file(file).filter_map(move |node| {
+                    if !graph[node].is_reference() {
+                        return None;
+                    }
+                    let source_info = match graph.source_info(node) {
+                        Some(source_info) => source_info,
+                        None => return None,
+                    };
+                    if !self.within_span(&source_info.span) {
+                        return None;
+                    }
+                    Some((node, source_info.span.clone()))
                 })
             })
     }
@@ -254,9 +260,13 @@ pub struct SourceSpan {
 }
 
 impl SourceSpan {
+    pub fn first_line(&self) -> usize {
+        self.span.start.line
+    }
+
     /// Returns a range for the first line of this span. If multiple lines are spanned, it
     /// will use usize::MAX for the range's end.
-    pub fn to_first_line_column_range(&self) -> Range<usize> {
+    pub fn first_line_column_range(&self) -> Range<usize> {
         let start = self.span.start.column.grapheme_offset;
         let end = if self.span.start.line == self.span.end.line {
             self.span.end.column.grapheme_offset


### PR DESCRIPTION
| ◀️ #256 | #259 ▶️ |
|-|-|

This PR improves the console output for the `query` command by displaying source excerpts when possible.

## Demo

Before:

<img width="907" alt="image" src="https://github.com/github/stack-graphs/assets/999073/c0200570-5a38-416d-86c5-068bc8ed517d">

After, for a single reference at the given location:

<img width="1120" alt="image" src="https://github.com/github/stack-graphs/assets/999073/4da3b4e6-044a-4a9f-8f68-291631231f3e">

After, for multiple references at the given location:

<img width="1112" alt="image" src="https://github.com/github/stack-graphs/assets/999073/8a311491-53ca-48fa-bb45-d78b363781ae">

