### PR TITLE
Storage fixes

### DIFF
--- a/stack-graphs/src/serde/partial.rs
+++ b/stack-graphs/src/serde/partial.rs
@@ -113,7 +113,12 @@ impl PartialScopeStack {
         graph: &mut crate::graph::StackGraph,
         partials: &mut PartialPaths,
     ) -> Result<crate::partial::PartialScopeStack, Error> {
-        let mut value = crate::partial::PartialScopeStack::empty();
+        let mut value = match &self.variable {
+            Some(variable) => crate::partial::PartialScopeStack::from_variable(
+                variable.to_scope_stack_variable()?,
+            ),
+            None => crate::partial::PartialScopeStack::empty(),
+        };
         for scope in &self.scopes {
             let scope = scope.to_node(graph)?;
             value.push_back(partials, scope);
@@ -170,7 +175,12 @@ impl PartialSymbolStack {
         graph: &mut crate::graph::StackGraph,
         partials: &mut PartialPaths,
     ) -> Result<crate::partial::PartialSymbolStack, Error> {
-        let mut value = crate::partial::PartialSymbolStack::empty();
+        let mut value = match &self.variable {
+            Some(variable) => crate::partial::PartialSymbolStack::from_variable(
+                variable.to_symbol_stack_variable()?,
+            ),
+            None => crate::partial::PartialSymbolStack::empty(),
+        };
         for symbol in &self.symbols {
             let symbol = symbol.to_partial_scoped_symbol(graph, partials)?;
             value.push_back(partials, symbol);

--- a/stack-graphs/src/storage.rs
+++ b/stack-graphs/src/storage.rs
@@ -547,9 +547,9 @@ impl SQLiteReader {
                 " * Load extensions from root with prefix symbol stack {}",
                 symbol_stack
             );
-            if !self.loaded_root_paths.insert(symbol_stack.to_string()) {
+            if !self.loaded_root_paths.insert(symbol_stack.clone()) {
                 copious_debugging!("   > Already loaded");
-                return Ok(());
+                continue;
             }
             let mut stmt = self
                 .conn

--- a/stack-graphs/src/storage.rs
+++ b/stack-graphs/src/storage.rs
@@ -503,12 +503,13 @@ impl SQLiteReader {
             copious_debugging!("   > Already loaded");
             return Ok(());
         }
-        let file = self.graph[node].file().expect("file node required");
+        let id = self.graph[node].id();
+        let file = id.file().expect("file node required");
         let file = self.graph[file].name();
         let mut stmt = self
             .conn
-            .prepare_cached("SELECT file,json from file_paths WHERE file = ?")?;
-        let paths = stmt.query_map([file], |row| {
+            .prepare_cached("SELECT file,json from file_paths WHERE file = ? AND local_id = ?")?;
+        let paths = stmt.query_map((file, id.local_id()), |row| {
             let file = row.get::<_, String>(0)?;
             let json = row.get::<_, Vec<u8>>(1)?;
             Ok((file, json))


### PR DESCRIPTION
| ◀️ #257 | #260 ▶️ |
|-|-|

This PR contains several fixes for the SQLite database storage:

- Include the node id to only load paths for a given node. Before paths were loaded multiple times.
- If a symbol stack prefix was already loaded, only skip that prefix, but still try the remaining prefixes.
- Swap path storage conditions, because `is_root` implies `is_in_file`, resulting in all files being stored in the `file_paths` table, and none in the `root_paths` table.
- Deserialize stack variables, which were completely ignored.
