### PR TITLE
Use canonical paths for CLI commands

### DIFF
--- a/tree-sitter-stack-graphs/src/cli/index.rs
+++ b/tree-sitter-stack-graphs/src/cli/index.rs
@@ -103,7 +103,13 @@ impl IndexArgs {
         let mut indexer = Indexer::new(&mut db, &mut loader, &logger);
         indexer.force = self.force;
         indexer.max_file_time = self.max_file_time;
-        indexer.index_all(self.source_paths, self.continue_from, &NoCancellation)?;
+
+        let source_paths = self
+            .source_paths
+            .into_iter()
+            .map(|p| p.canonicalize())
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        indexer.index_all(source_paths, self.continue_from, &NoCancellation)?;
         Ok(())
     }
 }

--- a/tree-sitter-stack-graphs/src/cli/query.rs
+++ b/tree-sitter-stack-graphs/src/cli/query.rs
@@ -79,7 +79,9 @@ impl Definition {
     pub fn run(self, querier: &mut Querier) -> anyhow::Result<()> {
         let cancellation_flag = NoCancellation;
         let mut file_reader = FileReader::new();
-        for reference in self.references {
+        for mut reference in self.references {
+            reference.canonicalize()?;
+
             let results = querier.definitions(reference.clone(), &cancellation_flag)?;
             let numbered = results.len() > 1;
             let indent = if numbered { 6 } else { 0 };
@@ -144,11 +146,9 @@ impl<'a> Querier<'a> {
 
     pub fn definitions(
         &mut self,
-        mut reference: SourcePosition,
+        reference: SourcePosition,
         cancellation_flag: &dyn CancellationFlag,
     ) -> Result<Vec<QueryResult>> {
-        reference.canonicalize()?;
-
         let log_path = PathBuf::from(reference.to_string());
         let mut logger = self.logger.file(&log_path);
 

--- a/tree-sitter-stack-graphs/src/cli/status.rs
+++ b/tree-sitter-stack-graphs/src/cli/status.rs
@@ -51,6 +51,7 @@ impl StatusArgs {
             self.status(&mut entries)?;
         } else {
             for source_path in &self.source_paths {
+                let source_path = source_path.canonicalize()?;
                 let mut files = db.list_file_or_directory(&source_path)?;
                 let mut entries = files.try_iter()?;
                 self.status(&mut entries)?;


### PR DESCRIPTION
| ◀️ #259 | #261 ▶️ |
|-|-|

This PR ensures that CLI commands always use canonical paths.
