### PR TITLE
Ensure special files are also indexed

### DIFF
--- a/tree-sitter-stack-graphs/src/cli/index.rs
+++ b/tree-sitter-stack-graphs/src/cli/index.rs
@@ -362,7 +362,7 @@ impl<'a> Indexer<'a> {
                 .and_then(|file_name| lc.special_files.get(&file_name.to_string_lossy()))
             {
                 Some(fa) => fa,
-                None => continue, // shouldn't really happen though
+                None => panic!("secondary language missing analyzer"),
             };
             fa.build_stack_graph_into(
                 graph,

--- a/tree-sitter-stack-graphs/src/cli/index.rs
+++ b/tree-sitter-stack-graphs/src/cli/index.rs
@@ -7,6 +7,8 @@
 
 use clap::Args;
 use clap::ValueHint;
+use stack_graphs::arena::Handle;
+use stack_graphs::graph::File;
 use stack_graphs::graph::StackGraph;
 use stack_graphs::partial::PartialPaths;
 use stack_graphs::storage::FileStatus;
@@ -18,6 +20,7 @@ use std::time::Duration;
 use thiserror::Error;
 use tree_sitter_graph::Variables;
 
+use crate::loader::FileLanguageConfigurations;
 use crate::loader::FileReader;
 use crate::loader::Loader;
 use crate::BuildError;
@@ -29,6 +32,7 @@ use super::util::duration_from_seconds_str;
 use super::util::iter_files_and_directories;
 use super::util::sha1;
 use super::util::wait_for_input;
+use super::util::BuildErrorWithSource;
 use super::util::ConsoleLogger;
 use super::util::ExistingPathBufValueParser;
 use super::util::FileLogger;
@@ -219,23 +223,24 @@ impl<'a> Indexer<'a> {
         }
 
         let mut file_reader = FileReader::new();
-        let lc = match self
+        let lcs = match self
             .loader
             .load_for_file(source_path, &mut file_reader, &NoCancellation)
         {
-            Ok(Some(sgl)) => sgl,
-            Ok(None) => {
+            Ok(lcs) if !lcs.has_some() => {
                 if missing_is_error {
                     file_status.failure("not supported", None);
                 }
                 return Ok(());
             }
+            Ok(lcs) => lcs,
             Err(crate::loader::LoadError::Cancelled(_)) => {
                 file_status.warning("language loading timed out", None);
                 return Ok(());
             }
             Err(e) => return Err(IndexError::LoadError(e)),
         };
+
         let source = file_reader.get(source_path)?;
         let tag = sha1(source);
 
@@ -264,64 +269,39 @@ impl<'a> Indexer<'a> {
         let mut graph = StackGraph::new();
         let file = graph
             .add_file(&source_path.to_string_lossy())
-            .expect("file not present in emtpy graph");
+            .expect("file not present in empty graph");
 
-        let relative_source_path = source_path.strip_prefix(source_root).unwrap();
-        let result = if let Some(fa) = source_path
-            .file_name()
-            .and_then(|f| lc.special_files.get(&f.to_string_lossy()))
-        {
-            fa.build_stack_graph_into(
-                &mut graph,
-                file,
-                &relative_source_path,
-                &source,
-                &mut std::iter::empty(),
-                &HashMap::new(),
-                &cancellation_flag,
-            )
-        } else {
-            let globals = Variables::new();
-            lc.sgl
-                .build_stack_graph_into(&mut graph, file, &source, &globals, &cancellation_flag)
-        };
-        match result {
-            Err(BuildError::Cancelled(_)) => {
-                file_status.warning("parsing timed out", None);
-                self.db
-                    .store_error_for_file(source_path, &tag, "parsing timed out")?;
-                return Ok(());
-            }
-            Err(err @ BuildError::ParseErrors(_)) => {
-                file_status.failure(
-                    "parsing failed",
-                    Some(&err.display_pretty(
+        let result = Self::build_stack_graph(
+            &mut graph,
+            file,
+            source_root,
+            source_path,
+            &source,
+            lcs,
+            &cancellation_flag,
+        );
+        if let Err(err) = result {
+            match err.inner {
+                BuildError::Cancelled(_) => {
+                    file_status.warning("parsing timed out", None);
+                    self.db
+                        .store_error_for_file(source_path, &tag, "parsing timed out")?;
+                    return Ok(());
+                }
+                BuildError::ParseErrors { .. } => {
+                    file_status.failure("parsing failed", Some(&err.display_pretty()));
+                    self.db.store_error_for_file(
                         source_path,
-                        source,
-                        lc.sgl.tsg_path(),
-                        lc.sgl.tsg_source(),
-                    )),
-                );
-                self.db.store_error_for_file(
-                    source_path,
-                    &tag,
-                    &format!("parsing failed: {}", err),
-                )?;
-                return Ok(());
+                        &tag,
+                        &format!("parsing failed: {}", err.inner),
+                    )?;
+                    return Ok(());
+                }
+                _ => {
+                    file_status.failure("failed to build stack graph", Some(&err.display_pretty()));
+                    return Err(IndexError::StackGraph);
+                }
             }
-            Err(err) => {
-                file_status.failure(
-                    "failed to build stack graph",
-                    Some(&err.display_pretty(
-                        source_path,
-                        source,
-                        lc.sgl.tsg_path(),
-                        lc.sgl.tsg_source(),
-                    )),
-                );
-                return Err(IndexError::StackGraph);
-            }
-            Ok(_) => true,
         };
 
         let mut partials = PartialPaths::new();
@@ -351,6 +331,56 @@ impl<'a> Indexer<'a> {
 
         file_status.success("success", None);
 
+        Ok(())
+    }
+
+    fn build_stack_graph<'b>(
+        graph: &mut StackGraph,
+        file: Handle<File>,
+        source_root: &Path,
+        source_path: &Path,
+        source: &'b str,
+        lcs: FileLanguageConfigurations<'b>,
+        cancellation_flag: &dyn CancellationFlag,
+    ) -> std::result::Result<(), BuildErrorWithSource<'b>> {
+        let relative_source_path = source_path.strip_prefix(source_root).unwrap();
+        if let Some(lc) = lcs.primary {
+            let globals = Variables::new();
+            lc.sgl
+                .build_stack_graph_into(graph, file, source, &globals, cancellation_flag)
+                .map_err(|inner| BuildErrorWithSource {
+                    inner,
+                    source_path: source_path.to_path_buf(),
+                    source_str: source,
+                    tsg_path: lc.sgl.tsg_path().to_path_buf(),
+                    tsg_str: &lc.sgl.tsg_source(),
+                })?;
+        }
+        for lc in lcs.secondary {
+            let fa = match source_path
+                .file_name()
+                .and_then(|file_name| lc.special_files.get(&file_name.to_string_lossy()))
+            {
+                Some(fa) => fa,
+                None => continue, // shouldn't really happen though
+            };
+            fa.build_stack_graph_into(
+                graph,
+                file,
+                &relative_source_path,
+                &source,
+                &mut std::iter::empty(),
+                &HashMap::new(),
+                cancellation_flag,
+            )
+            .map_err(|inner| BuildErrorWithSource {
+                inner,
+                source_path: source_path.to_path_buf(),
+                source_str: &source,
+                tsg_path: PathBuf::new(),
+                tsg_str: "",
+            })?;
+        }
         Ok(())
     }
 

--- a/tree-sitter-stack-graphs/src/cli/index.rs
+++ b/tree-sitter-stack-graphs/src/cli/index.rs
@@ -356,14 +356,7 @@ impl<'a> Indexer<'a> {
                     tsg_str: &lc.sgl.tsg_source(),
                 })?;
         }
-        for lc in lcs.secondary {
-            let fa = match source_path
-                .file_name()
-                .and_then(|file_name| lc.special_files.get(&file_name.to_string_lossy()))
-            {
-                Some(fa) => fa,
-                None => panic!("secondary language missing analyzer"),
-            };
+        for (_, fa) in lcs.secondary {
             fa.build_stack_graph_into(
                 graph,
                 file,

--- a/tree-sitter-stack-graphs/src/cli/match.rs
+++ b/tree-sitter-stack-graphs/src/cli/match.rs
@@ -41,7 +41,10 @@ pub struct MatchArgs {
 impl MatchArgs {
     pub fn run(self, mut loader: Loader) -> anyhow::Result<()> {
         let mut file_reader = FileReader::new();
-        let lc = match loader.load_for_file(&self.source_path, &mut file_reader, &NoCancellation)? {
+        let lc = match loader
+            .load_for_file(&self.source_path, &mut file_reader, &NoCancellation)?
+            .primary
+        {
             Some(lc) => lc,
             None => return Err(anyhow!("No stack graph language found")),
         };

--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -211,7 +211,7 @@ impl TestArgs {
             .load_for_file(&load_path, &mut file_reader, cancellation_flag)?
             .primary
         {
-            Some(sgl) => sgl,
+            Some(lc) => lc,
             None => return Ok(TestResult::new()),
         };
 

--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -33,6 +33,7 @@ use crate::CancellationFlag;
 use crate::NoCancellation;
 
 use super::util::iter_files_and_directories;
+use super::util::BuildErrorWithSource;
 use super::util::ConsoleFileLogger;
 use super::util::FileLogger;
 
@@ -206,7 +207,10 @@ impl TestArgs {
             test_path.to_path_buf()
         };
         let mut file_reader = MappingFileReader::new(&load_path, test_path);
-        let lc = match loader.load_for_file(&load_path, &mut file_reader, cancellation_flag)? {
+        let lc = match loader
+            .load_for_file(&load_path, &mut file_reader, cancellation_flag)?
+            .primary
+        {
             Some(sgl) => sgl,
             None => return Ok(TestResult::new()),
         };
@@ -236,7 +240,7 @@ impl TestArgs {
             let result = if let Some(fa) = test_fragment
                 .path
                 .file_name()
-                .and_then(|f| lc.special_files.get(&f.to_string_lossy()))
+                .and_then(|file_name| lc.special_files.get(&file_name.to_string_lossy()))
             {
                 let mut all_paths = test.fragments.iter().map(|f| f.path.as_path());
                 fa.build_stack_graph_into(
@@ -248,19 +252,34 @@ impl TestArgs {
                     &test_fragment.globals,
                     cancellation_flag,
                 )
+                .map_err(|inner| BuildErrorWithSource {
+                    inner,
+                    source_path: test_path.to_path_buf(),
+                    source_str: &test_fragment.source,
+                    tsg_path: PathBuf::new(),
+                    tsg_str: "",
+                })
             } else if lc.matches_file(
                 &test_fragment.path,
                 &mut Some(test_fragment.source.as_ref()),
             )? {
                 globals.clear();
                 test_fragment.add_globals_to(&mut globals);
-                lc.sgl.build_stack_graph_into(
-                    &mut test.graph,
-                    test_fragment.file,
-                    &test_fragment.source,
-                    &globals,
-                    cancellation_flag,
-                )
+                lc.sgl
+                    .build_stack_graph_into(
+                        &mut test.graph,
+                        test_fragment.file,
+                        &test_fragment.source,
+                        &globals,
+                        cancellation_flag,
+                    )
+                    .map_err(|inner| BuildErrorWithSource {
+                        inner,
+                        source_path: test_path.to_path_buf(),
+                        source_str: &test_fragment.source,
+                        tsg_path: lc.sgl.tsg_path().to_path_buf(),
+                        tsg_str: &lc.sgl.tsg_source(),
+                    })
             } else {
                 return Err(anyhow!(
                     "Test fragment {} not supported by language of test file {}",
@@ -270,15 +289,7 @@ impl TestArgs {
             };
             match result {
                 Err(err) => {
-                    file_status.failure(
-                        "failed to build stack graph",
-                        Some(&err.display_pretty(
-                            test_path,
-                            source,
-                            lc.sgl.tsg_path(),
-                            lc.sgl.tsg_source(),
-                        )),
-                    );
+                    file_status.failure("failed to build stack graph", Some(&err.display_pretty()));
                     return Err(anyhow!("Failed to build graph for {}", test_path.display()));
                 }
                 Ok(_) => {}

--- a/tree-sitter-stack-graphs/src/cli/util.rs
+++ b/tree-sitter-stack-graphs/src/cli/util.rs
@@ -546,3 +546,35 @@ pub fn wait_for_input() -> anyhow::Result<()> {
     std::io::stdin().read_line(&mut input)?;
     Ok(())
 }
+
+/// Wraps a build error with the relevant sources
+pub struct BuildErrorWithSource<'a> {
+    pub inner: crate::BuildError,
+    pub source_path: PathBuf,
+    pub source_str: &'a str,
+    pub tsg_path: PathBuf,
+    pub tsg_str: &'a str,
+}
+
+impl<'a> BuildErrorWithSource<'a> {
+    pub fn display_pretty(&'a self) -> impl std::fmt::Display + 'a {
+        DisplayBuildErrorPretty(self)
+    }
+}
+
+struct DisplayBuildErrorPretty<'a>(&'a BuildErrorWithSource<'a>);
+
+impl std::fmt::Display for DisplayBuildErrorPretty<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.0.inner.display_pretty(
+                &self.0.source_path,
+                self.0.source_str,
+                &self.0.tsg_path,
+                self.0.tsg_str,
+            )
+        )
+    }
+}

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -1148,6 +1148,9 @@ impl<'a> Builder<'a> {
 }
 
 pub trait FileAnalyzer {
+    /// Construct stack graph for the given file. Implementations must assume that nodes
+    /// for the given file may already exist, and make sure to prevent node id conflicts,
+    /// for example by using `StackGraph::new_node_id`.
     fn build_stack_graph_into<'a>(
         &self,
         stack_graph: &mut StackGraph,

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -101,6 +101,27 @@ impl LanguageConfiguration {
         })
     }
 
+    // Extracted from tree_sitter_loader::Loader::language_configuration_for_file_name
+    fn best_for_file<'a>(
+        languages: &'a Vec<LanguageConfiguration>,
+        path: &Path,
+        content: &mut dyn ContentProvider,
+    ) -> std::io::Result<Option<&'a LanguageConfiguration>> {
+        let mut best_score = -1isize;
+        let mut best = None;
+        for language in languages {
+            if let Some(score) =
+                matches_file(&language.file_types, &language.content_regex, path, content)?
+            {
+                if score > best_score {
+                    best_score = score;
+                    best = Some(language);
+                }
+            }
+        }
+        Ok(best)
+    }
+
     pub fn matches_file(
         &self,
         path: &Path,
@@ -239,12 +260,12 @@ impl Loader {
     }
 
     /// Load a stack graph language for the given file. Loading is based on the loader configuration and the given file path.
-    pub fn load_for_file(
-        &mut self,
+    pub fn load_for_file<'a>(
+        &'a mut self,
         path: &Path,
         content: &mut dyn ContentProvider,
         cancellation_flag: &dyn CancellationFlag,
-    ) -> Result<Option<&LanguageConfiguration>, LoadError<'static>> {
+    ) -> Result<FileLanguageConfigurations<'a>, LoadError<'static>> {
         match &mut self.0 {
             LoaderImpl::Paths(loader) => loader.load_for_file(path, content, cancellation_flag),
             LoaderImpl::Provided(loader) => loader.load_for_file(path, content),
@@ -321,6 +342,21 @@ impl Loader {
     }
 }
 
+/// Struct holding the language configurations for a file.
+#[derive(Default)]
+pub struct FileLanguageConfigurations<'a> {
+    /// The file's primary language. The language configuration's `StackGraphLanguage` should be used to process the file.
+    pub primary: Option<&'a LanguageConfiguration>,
+    /// Any secondary languages, which have special file analyzers for the file.
+    pub secondary: Vec<&'a LanguageConfiguration>,
+}
+
+impl FileLanguageConfigurations<'_> {
+    pub fn has_some(&self) -> bool {
+        self.primary.is_some() || !self.secondary.is_empty()
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum LoadError<'a> {
     #[error("{0}")]
@@ -353,7 +389,6 @@ pub enum LoadError<'a> {
     },
     #[error("{inner}")]
     TsgParse {
-        #[source]
         inner: tree_sitter_graph::ParseError,
         tsg_path: PathBuf,
         tsg: Cow<'a, str>,
@@ -427,17 +462,23 @@ impl LanguageConfigurationsLoader {
     }
 
     /// Load a stack graph language for the given file. Loading is based on the loader configuration and the given file path.
-    pub fn load_for_file(
-        &mut self,
+    pub fn load_for_file<'a>(
+        &'a mut self,
         path: &Path,
         content: &mut dyn ContentProvider,
-    ) -> Result<Option<&LanguageConfiguration>, LoadError<'static>> {
+    ) -> Result<FileLanguageConfigurations<'a>, LoadError<'static>> {
+        let primary = LanguageConfiguration::best_for_file(&self.configurations, path, content)?;
+        let mut secondary = Vec::new();
         for language in self.configurations.iter() {
-            if language.matches_file(path, content)? {
-                return Ok(Some(language));
+            if path
+                .file_name()
+                .and_then(|file_name| language.special_files.get(&file_name.to_string_lossy()))
+                .is_some()
+            {
+                secondary.push(language);
             }
         }
-        Ok(None)
+        Ok(FileLanguageConfigurations { primary, secondary })
     }
 }
 
@@ -490,16 +531,16 @@ impl PathLoader {
         Ok(None)
     }
 
-    pub fn load_for_file(
-        &mut self,
+    pub fn load_for_file<'a>(
+        &'a mut self,
         path: &Path,
         content: &mut dyn ContentProvider,
         cancellation_flag: &dyn CancellationFlag,
-    ) -> Result<Option<&LanguageConfiguration>, LoadError<'static>> {
+    ) -> Result<FileLanguageConfigurations<'a>, LoadError<'static>> {
         let selected_language = self.select_language_for_file(path, content)?;
         let language = match selected_language {
             Some(selected_language) => selected_language.clone(),
-            None => return Ok(None),
+            None => return Ok(FileLanguageConfigurations::default()),
         };
         // the borrow checker is a hard master...
         let index = self.cache.iter().position(|e| &e.0 == &language.language);
@@ -531,8 +572,11 @@ impl PathLoader {
                 self.cache.len() - 1
             }
         };
-        let sgl = &mut self.cache[index].1;
-        Ok(Some(sgl))
+        let lc = &self.cache[index].1;
+        Ok(FileLanguageConfigurations {
+            primary: Some(lc),
+            secondary: Vec::default(),
+        })
     }
 
     // Select language for the given file, considering paths and scope fields

--- a/tree-sitter-stack-graphs/tests/it/loader.rs
+++ b/tree-sitter-stack-graphs/tests/it/loader.rs
@@ -47,5 +47,5 @@ fn can_load_from_provided_language_configuration() {
     let lc = loader
         .load_for_file(&PATH, &mut None, &NoCancellation)
         .expect("Expected loading stack graph language to succeed");
-    assert_eq!(lc.map(|lc| lc.language), Some(language));
+    assert_eq!(lc.primary.map(|lc| lc.language), Some(language));
 }


### PR DESCRIPTION
| ◀️ #260 | #262 ▶️ |
|-|-|

This PR ensures that special files (those that are relevant for a language, but not written in that language, such as `tsconfig.json`) are always indexed.

Previously, the language loader only returned the primary language of a file (i.e., the language the file is written in). These changes return the primary, as well as any secondary languages (i.e., languages for which the file is special). The indexer makes sure that all languages get their change to generate stack graph for the file.

I have wondered (again) whether there should be a difference between primary and secondary languages at all. I think that still makes sense for the following reasons:

1. The contributions of a secondary language are typically not relevant when navigating the file. They are only useful for the effect they have on navigating the files of that secondary language.

2. When processed as a special file, more information is provided to the file analyzer, such as the list of paths in the project. This makes the results inherently less context-free. I kind of like to make this an explicit choice in the API (even though it could be left to convention).
