### PR TITLE
Mark sg_stack_graph_free function as unsafe

### DIFF
--- a/stack-graphs/src/c.rs
+++ b/stack-graphs/src/c.rs
@@ -48,7 +48,7 @@ pub extern "C" fn sg_stack_graph_new() -> *mut sg_stack_graph {
 
 /// Frees a stack graph, and all of its contents.
 #[no_mangle]
-pub extern "C" fn sg_stack_graph_free(graph: *mut sg_stack_graph) {
+pub unsafe extern "C" fn sg_stack_graph_free(graph: *mut sg_stack_graph) {
     drop(unsafe { Box::from_raw(graph) })
 }
 
@@ -67,7 +67,7 @@ pub extern "C" fn sg_partial_path_arena_new() -> *mut sg_partial_path_arena {
 
 /// Frees a path arena, and all of its contents.
 #[no_mangle]
-pub extern "C" fn sg_partial_path_arena_free(partials: *mut sg_partial_path_arena) {
+pub unsafe extern "C" fn sg_partial_path_arena_free(partials: *mut sg_partial_path_arena) {
     drop(unsafe { Box::from_raw(partials) })
 }
 
@@ -94,7 +94,7 @@ pub extern "C" fn sg_partial_path_database_new() -> *mut sg_partial_path_databas
 
 /// Frees a partial path database, and all of its contents.
 #[no_mangle]
-pub extern "C" fn sg_partial_path_database_free(db: *mut sg_partial_path_database) {
+pub unsafe extern "C" fn sg_partial_path_database_free(db: *mut sg_partial_path_database) {
     drop(unsafe { Box::from_raw(db) })
 }
 

--- a/stack-graphs/tests/it/c/can_find_local_nodes.rs
+++ b/stack-graphs/tests/it/c/can_find_local_nodes.rs
@@ -83,9 +83,9 @@ fn check_local_nodes(graph: &TestGraph, file: &str, expected_local_nodes: &[&str
         .collect::<BTreeSet<_>>();
     assert_eq!(expected_local_nodes, results);
 
-    sg_partial_path_database_free(db);
+    unsafe { sg_partial_path_database_free(db) };
     sg_partial_path_list_free(path_list);
-    sg_partial_path_arena_free(partials);
+    unsafe { sg_partial_path_arena_free(partials) };
 }
 
 #[test]

--- a/stack-graphs/tests/it/c/can_find_partial_paths_in_file.rs
+++ b/stack-graphs/tests/it/c/can_find_partial_paths_in_file.rs
@@ -133,7 +133,7 @@ fn check_partial_paths_in_file(graph: &TestGraph, file: &str, expected_paths: &[
     assert_eq!(expected_paths, results);
 
     sg_partial_path_list_free(path_list);
-    sg_partial_path_arena_free(partials);
+    unsafe { sg_partial_path_arena_free(partials) };
 }
 
 #[test]

--- a/stack-graphs/tests/it/c/can_find_qualified_definitions_with_phased_partial_path_stitching.rs
+++ b/stack-graphs/tests/it/c/can_find_qualified_definitions_with_phased_partial_path_stitching.rs
@@ -244,8 +244,8 @@ fn check_find_qualified_definitions(
     assert_eq!(expected_partial_paths, results);
 
     sg_forward_partial_path_stitcher_free(stitcher);
-    sg_partial_path_database_free(db);
-    sg_partial_path_arena_free(partials);
+    unsafe { sg_partial_path_database_free(db) };
+    unsafe { sg_partial_path_arena_free(partials) };
 }
 
 #[test]

--- a/stack-graphs/tests/it/c/can_jump_to_definition.rs
+++ b/stack-graphs/tests/it/c/can_jump_to_definition.rs
@@ -55,7 +55,7 @@ fn check_jump_to_definition(graph: &TestGraph, expected_paths: &[&str]) {
     assert_eq!(expected_paths, results);
 
     sg_partial_path_list_free(path_list);
-    sg_partial_path_arena_free(paths);
+    unsafe { sg_partial_path_arena_free(paths) };
 }
 
 #[test]

--- a/stack-graphs/tests/it/c/can_jump_to_definition_with_phased_partial_path_stitching.rs
+++ b/stack-graphs/tests/it/c/can_jump_to_definition_with_phased_partial_path_stitching.rs
@@ -229,8 +229,8 @@ fn check_jump_to_definition(graph: &TestGraph, file: &str, expected_partial_path
     assert_eq!(expected_partial_paths, results);
 
     sg_forward_partial_path_stitcher_free(stitcher);
-    sg_partial_path_database_free(db);
-    sg_partial_path_arena_free(partials);
+    unsafe { sg_partial_path_database_free(db) };
+    unsafe { sg_partial_path_arena_free(partials) };
 }
 
 #[test]

--- a/stack-graphs/tests/it/c/files.rs
+++ b/stack-graphs/tests/it/c/files.rs
@@ -66,7 +66,7 @@ fn can_create_files() {
     assert_eq!(get_file(&file_arena, b), "b.py");
     assert_eq!(get_file(&file_arena, c), "c.py");
 
-    sg_stack_graph_free(graph);
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 #[test]

--- a/stack-graphs/tests/it/c/nodes.rs
+++ b/stack-graphs/tests/it/c/nodes.rs
@@ -138,7 +138,7 @@ fn cannot_add_singleton_nodes() {
     let mut handles: [sg_node_handle; 2] = [SG_NULL_HANDLE; 2];
     sg_stack_graph_get_or_create_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     assert!(handles.iter().all(|h| *h == SG_NULL_HANDLE));
-    sg_stack_graph_free(graph);
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 #[test]
@@ -147,7 +147,7 @@ fn can_dereference_singleton_nodes() {
     let node_arena = sg_stack_graph_nodes(graph);
     assert!(get_node(&node_arena, SG_ROOT_NODE_HANDLE).is_root());
     assert!(get_node(&node_arena, SG_JUMP_TO_NODE_HANDLE).is_jump_to());
-    sg_stack_graph_free(graph);
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 #[test]
@@ -164,7 +164,7 @@ fn singleton_nodes_have_correct_ids() {
     assert!(jump_to.id.file == SG_NULL_HANDLE);
     assert!(jump_to.id.local_id == SG_JUMP_TO_NODE_ID);
 
-    sg_stack_graph_free(graph);
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -201,7 +201,7 @@ fn can_add_drop_scopes_node() {
         new_handles.as_mut_ptr(),
     );
     assert!(handles == new_handles);
-    sg_stack_graph_free(graph);
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 #[test]
@@ -214,7 +214,7 @@ fn drop_scopes_cannot_have_symbol() {
     let mut handles: [sg_node_handle; 1] = [SG_NULL_HANDLE; 1];
     sg_stack_graph_get_or_create_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     assert!(handles[0] == SG_NULL_HANDLE);
-    sg_stack_graph_free(graph);
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 #[test]
@@ -229,7 +229,7 @@ fn drop_scopes_cannot_have_scope() {
     let mut handles: [sg_node_handle; 1] = [SG_NULL_HANDLE; 1];
     sg_stack_graph_get_or_create_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     assert!(handles[0] == SG_NULL_HANDLE);
-    sg_stack_graph_free(graph);
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -267,7 +267,7 @@ fn can_add_exported_scope_node() {
         new_handles.as_mut_ptr(),
     );
     assert!(handles == new_handles);
-    sg_stack_graph_free(graph);
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 #[test]
@@ -280,7 +280,7 @@ fn exported_scope_cannot_have_symbol() {
     let mut handles: [sg_node_handle; 1] = [SG_NULL_HANDLE; 1];
     sg_stack_graph_get_or_create_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     assert!(handles[0] == SG_NULL_HANDLE);
-    sg_stack_graph_free(graph);
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 #[test]
@@ -295,7 +295,7 @@ fn exported_scope_cannot_have_scope() {
     let mut handles: [sg_node_handle; 1] = [SG_NULL_HANDLE; 1];
     sg_stack_graph_get_or_create_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     assert!(handles[0] == SG_NULL_HANDLE);
-    sg_stack_graph_free(graph);
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -333,7 +333,7 @@ fn can_add_internal_scope_node() {
         new_handles.as_mut_ptr(),
     );
     assert!(handles == new_handles);
-    sg_stack_graph_free(graph);
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 #[test]
@@ -346,7 +346,7 @@ fn internal_scope_cannot_have_symbol() {
     let mut handles: [sg_node_handle; 1] = [SG_NULL_HANDLE; 1];
     sg_stack_graph_get_or_create_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     assert!(handles[0] == SG_NULL_HANDLE);
-    sg_stack_graph_free(graph);
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 #[test]
@@ -361,7 +361,7 @@ fn internal_scope_cannot_have_scope() {
     let mut handles: [sg_node_handle; 1] = [SG_NULL_HANDLE; 1];
     sg_stack_graph_get_or_create_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     assert!(handles[0] == SG_NULL_HANDLE);
-    sg_stack_graph_free(graph);
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -401,7 +401,7 @@ fn can_add_pop_scoped_symbol_node() {
         new_handles.as_mut_ptr(),
     );
     assert!(handles == new_handles);
-    sg_stack_graph_free(graph);
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 #[test]
@@ -412,7 +412,7 @@ fn pop_scoped_symbol_must_have_symbol() {
     let mut handles: [sg_node_handle; 1] = [SG_NULL_HANDLE; 1];
     sg_stack_graph_get_or_create_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     assert!(handles[0] == SG_NULL_HANDLE);
-    sg_stack_graph_free(graph);
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 #[test]
@@ -428,7 +428,7 @@ fn pop_scoped_symbol_cannot_have_scope() {
     let mut handles: [sg_node_handle; 1] = [SG_NULL_HANDLE; 1];
     sg_stack_graph_get_or_create_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     assert!(handles[0] == SG_NULL_HANDLE);
-    sg_stack_graph_free(graph);
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -468,7 +468,7 @@ fn can_add_pop_symbol_node() {
         new_handles.as_mut_ptr(),
     );
     assert!(handles == new_handles);
-    sg_stack_graph_free(graph);
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 #[test]
@@ -479,7 +479,7 @@ fn pop_symbol_must_have_symbol() {
     let mut handles: [sg_node_handle; 1] = [SG_NULL_HANDLE; 1];
     sg_stack_graph_get_or_create_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     assert!(handles[0] == SG_NULL_HANDLE);
-    sg_stack_graph_free(graph);
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 #[test]
@@ -495,7 +495,7 @@ fn pop_symbol_cannot_have_scope() {
     let mut handles: [sg_node_handle; 1] = [SG_NULL_HANDLE; 1];
     sg_stack_graph_get_or_create_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     assert!(handles[0] == SG_NULL_HANDLE);
-    sg_stack_graph_free(graph);
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -546,7 +546,7 @@ fn can_add_push_scoped_symbol_node() {
         new_handles.as_mut_ptr(),
     );
     assert!(handles == new_handles);
-    sg_stack_graph_free(graph);
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 #[test]
@@ -563,7 +563,7 @@ fn push_scoped_symbol_must_have_symbol() {
     let mut handles: [sg_node_handle; 1] = [SG_NULL_HANDLE; 1];
     sg_stack_graph_get_or_create_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     assert!(handles[0] == SG_NULL_HANDLE);
-    sg_stack_graph_free(graph);
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 #[test]
@@ -581,7 +581,7 @@ fn push_scoped_symbol_must_have_scope() {
     let mut handles: [sg_node_handle; 1] = [SG_NULL_HANDLE; 1];
     sg_stack_graph_get_or_create_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     assert!(handles[0] == SG_NULL_HANDLE);
-    sg_stack_graph_free(graph);
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -621,7 +621,7 @@ fn can_add_push_symbol_node() {
         new_handles.as_mut_ptr(),
     );
     assert!(handles == new_handles);
-    sg_stack_graph_free(graph);
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 #[test]
@@ -632,7 +632,7 @@ fn push_symbol_must_have_symbol() {
     let mut handles: [sg_node_handle; 1] = [SG_NULL_HANDLE; 1];
     sg_stack_graph_get_or_create_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     assert!(handles[0] == SG_NULL_HANDLE);
-    sg_stack_graph_free(graph);
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 #[test]
@@ -648,7 +648,7 @@ fn push_symbol_cannot_have_scope() {
     let mut handles: [sg_node_handle; 1] = [SG_NULL_HANDLE; 1];
     sg_stack_graph_get_or_create_nodes(graph, nodes.len(), nodes.as_ptr(), handles.as_mut_ptr());
     assert!(handles[0] == SG_NULL_HANDLE);
-    sg_stack_graph_free(graph);
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -698,5 +698,5 @@ fn can_create_source_info() {
     assert_eq!(actual.span.start.line, 17);
     assert_eq!(actual.span.end.column.utf8_offset, 23);
 
-    sg_stack_graph_free(graph);
+    unsafe { sg_stack_graph_free(graph) };
 }

--- a/stack-graphs/tests/it/c/partial.rs
+++ b/stack-graphs/tests/it/c/partial.rs
@@ -217,8 +217,8 @@ fn can_create_partial_symbol_stacks() {
         &cells, &stacks[2]
     ));
 
-    sg_partial_path_arena_free(partials);
-    sg_stack_graph_free(graph);
+    unsafe { sg_partial_path_arena_free(partials) };
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 #[test]
@@ -323,8 +323,8 @@ fn can_create_partial_scope_stacks() {
         &cells, &stacks[2]
     ));
 
-    sg_partial_path_arena_free(partials);
-    sg_stack_graph_free(graph);
+    unsafe { sg_partial_path_arena_free(partials) };
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 #[test]
@@ -431,8 +431,8 @@ fn can_create_partial_path_edge_lists() {
         &cells, &lists[2]
     ));
 
-    sg_partial_path_arena_free(partials);
-    sg_stack_graph_free(graph);
+    unsafe { sg_partial_path_arena_free(partials) };
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 #[test]

--- a/stack-graphs/tests/it/c/symbols.rs
+++ b/stack-graphs/tests/it/c/symbols.rs
@@ -66,7 +66,7 @@ fn can_create_symbols() {
     assert_eq!(get_symbol(&symbol_arena, b), "b");
     assert_eq!(get_symbol(&symbol_arena, c), "c");
 
-    sg_stack_graph_free(graph);
+    unsafe { sg_stack_graph_free(graph) };
 }
 
 #[test]

--- a/stack-graphs/tests/it/c/test_graph.rs
+++ b/stack-graphs/tests/it/c/test_graph.rs
@@ -39,7 +39,7 @@ impl Default for TestGraph {
 
 impl Drop for TestGraph {
     fn drop(&mut self) {
-        sg_stack_graph_free(self.graph);
+        unsafe { sg_stack_graph_free(self.graph) };
     }
 }
 


### PR DESCRIPTION
https://github.com/github/stack-graphs/blob/ed017a591105b903e69b334db761a732fc0e83a3/stack-graphs/src/c.rs#L51-L53
hello, if a function's entire body is unsafe, the function is itself unsafe and should be marked appropriately. Marking them unsafe also means that callers must make sure they know what they're doing.