### PR TITLE
Update tree-sitter-graph to v0.10

### DIFF
--- a/languages/tree-sitter-stack-graphs-java/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-java/src/stack-graphs.tsg
@@ -104,8 +104,8 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
 }
 
 [
-  (import_declaration                                            (identifier) @scope @name)
-  (import_declaration (scoped_identifier scope: (_) @scope name: (identifier) @name))
+  (import_declaration                                             (identifier) @_scope @name)
+  (import_declaration (scoped_identifier scope: (_) @_scope name: (identifier) @name))
 ] @import {
   node def
   attr (def) node_definition = @name
@@ -401,7 +401,7 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
   type_parameters: (type_parameters
     (type_parameter
       (type_identifier) @type_identifier))
-  body: (_) @body) @this {
+  body: (_) @body) @_this {
   node type_ident
   attr (type_ident) node_definition = @type_identifier
   edge @body.lexical_scope -> type_ident
@@ -421,7 +421,7 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
   (modifiers "static"?@is_static)?
   type: (_) @type
   name: (identifier) @name
-  body: (block) @block) @method
+  body: (block) @_block) @method
 {
   edge @type.lexical_scope -> @method.lexical_scope
 
@@ -554,7 +554,7 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
   edge @block.after_scope -> @last.after_scope
 }
 
-(break_statement (identifier) @name) @this {
+(break_statement (identifier) @_name) @this {
   edge @this.after_scope -> @this.before_scope
 }
 
@@ -586,7 +586,7 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
   edge ns -> @this.before_scope
 }
 
-(declaration) @decl {}
+(declaration) @_decl {}
 
 (do_statement body: (_) @body condition: (_) @cond) @stmt {
   edge @body.before_scope -> @stmt.before_scope
@@ -660,7 +660,7 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
 (local_variable_declaration
   type: (_) @type
   declarator: (variable_declarator) @var_decl
-) @local_var
+) @_local_var
 {
   edge @var_decl.def__typeof -> @type.type
 }
@@ -692,7 +692,7 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
   declarator: (_) @left
   .
   declarator: (_) @right
-  ) @local_var {
+  ) @_local_var {
   edge @right.before_scope -> @left.after_scope
 }
 
@@ -770,7 +770,7 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
   edge @first.before_scope -> @this.lexical_scope
 }
 
-(switch_block (switch_block_statement_group (switch_label)+ (statement) @a . (statement) @b)) @this {
+(switch_block (switch_block_statement_group (switch_label)+ (statement) @a . (statement) @b)) @_this {
   edge @b.before_scope -> @a.after_scope
 }
 
@@ -838,11 +838,11 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
   edge @first.before_scope -> @stmt.before_scope
 }
 
-(try_with_resources_statement resources: (resource_specification (resource) @a . (resource) @b)) @stmt {
+(try_with_resources_statement resources: (resource_specification (resource) @a . (resource) @b)) @_stmt {
   edge @b.before_scope -> @a.after_scope
 }
 
-(try_with_resources_statement resources: (resource_specification (resource) @last .) body: (_) @body) @stmt {
+(try_with_resources_statement resources: (resource_specification (resource) @last .) body: (_) @body) @_stmt {
   edge @body.before_scope -> @last.after_scope
 }
 
@@ -1066,7 +1066,7 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
   edge expr_ref__typeof -> expr_ref
 }
 
-(method_reference . (identifier) @lhs (identifier) @name) @this {
+(method_reference . (identifier) @lhs (identifier) @_name) @this {
   ; @lhs could be a type name
   node ref
   attr (ref) node_reference = @lhs

--- a/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
@@ -370,13 +370,13 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
 
 ;; hashbang
 
-(hash_bang_line)@hashbang {
+(hash_bang_line) {
 }
 
 
 ;; Comments
 
-(comment)@comment {
+(comment) {
 }
 
 
@@ -906,7 +906,7 @@ if none @is_default {
 ; )
 
 (export_statement
-  (namespace_export (identifier)@ns)
+  (namespace_export (identifier))
   source:(_)@name
 )@export_stmt {
   ; namespace definitions are specified together with (module) and (internal_module)
@@ -954,8 +954,8 @@ if none @is_default {
 (import_statement
   "type"?
   (import_clause)?@has_clause
-  source:(_)@from
-)@import_stmt {
+  source:(_)
+) {
 if none @has_clause {
   ; do nothing, imported for side-effect only
 }
@@ -1068,7 +1068,7 @@ if none @is_type {
 
 (import_statement
   "type"?
-  (import_clause (namespace_import (identifier)@name))
+  (import_clause (namespace_import (identifier)))
   source:(_)@from
 )@import_stmt {
   ; namespace definitions are specified together with (module) and (internal_module)
@@ -1094,7 +1094,7 @@ if none @is_type {
 ; debugger;
 ; debugger
 
-(debugger_statement)@debugger_stmt {
+(debugger_statement) {
 }
 
 
@@ -1205,7 +1205,7 @@ if none @is_type {
 (variable_declarator
   type:(_)@type
   value:(_)@value
-)@decl {
+) {
   ; match value cotype to type annotation
   edge @value.cotype -> @type.type
 }
@@ -1413,8 +1413,8 @@ if none @is_async {
   edge @class_decl.type_export -> @class_decl.generic_type
 }
 [
-  (abstract_class_declaration name:(_)@name)
-  (class_declaration          name:(_)@name)
+  (abstract_class_declaration name:(_))
+  (class_declaration          name:(_))
 ; NOTE not for interface_declaration as body is already a type with an endpoint of needed
 ]@class_decl {
   ; mark type scope as endpoint
@@ -1716,7 +1716,7 @@ if none @is_async {
 ; }
 
 (switch_statement
-  value:(_)@value
+  value:(_)
   body:(_)@body
 )@switch_stmt {
   ; propagate lexical scope
@@ -1747,7 +1747,7 @@ if none @is_async {
 }
 
 (switch_case
-  value:(_)@value
+  value:(_)
   body: (_)@stmt
 )@switch_case {
   ; propagate lexical scope
@@ -2097,7 +2097,7 @@ if none @is_async {
 
 ; break;
 
-(break_statement)@break_stmt {
+(break_statement) {
 }
 
 
@@ -2106,7 +2106,7 @@ if none @is_async {
 
 ; continue;
 
-(continue_statement)@continue_stmt {
+(continue_statement) {
 }
 
 
@@ -2144,7 +2144,7 @@ if none @is_async {
 ; if (true) { ; };;;
 ; if (true) {} else {}
 
-(empty_statement)@empty_stmt {
+(empty_statement) {
 }
 
 
@@ -2212,7 +2212,7 @@ if none @is_async {
 ; FIXME what is this? tsc doesn't recognize this syntax
 (ambient_declaration
   "module"
-  (property_identifier)@prop
+  (property_identifier)
   (_)@type
 )@amb_decl {
   ; propagate lexical scope
@@ -2704,7 +2704,7 @@ if none @is_async {
 ; "A double quoted string.";
 ; 'A single quoted string.';
 
-(string)@string {
+(string) {
 }
 
 
@@ -2728,7 +2728,7 @@ if none @is_async {
 
 ; 12345;
 
-(number)@number {
+(number) {
 }
 
 
@@ -2846,7 +2846,7 @@ if none @is_def {
 
 ; new.target
 
-(meta_property)@new_target {
+(meta_property) {
 }
 
 
@@ -2855,12 +2855,12 @@ if none @is_def {
 
 ;; true;
 
-(true)@true {
+(true) {
 }
 
 ;; false;
 
-(false)@false {
+(false) {
 }
 
 
@@ -2912,13 +2912,13 @@ if none @is_def {
 
 
 ; null;
-(null)@null {
+(null) {
 }
 
 
 
 ; undefined;
-(undefined)@undefined {
+(undefined) {
 }
 
 
@@ -2932,7 +2932,7 @@ if none @is_def {
 ; (regex (regex_pattern))
 ; (regex (regex_pattern) (regex_flags))
 
-(regex)@regex {
+(regex) {
 }
 
 
@@ -3429,14 +3429,14 @@ if none @is_async {
 ; type application is handled by the generics rules below
 
 (call_expression
-  function:(_)@fun arguments: (_)@args
+  function:(_) arguments: (_)@args
 )@call_expr {
   ; propagate lexical scope
   edge @args.lexical_scope -> @call_expr.lexical_scope
 }
 
 (call_expression
-  function:(_)@fun arguments: (arguments)@args
+  function:(_) arguments: (arguments)@args
 )@call_expr {
   ; connect cotype to function params
   edge @args.coargs -> @call_expr.callable__params ;; FIXME
@@ -3535,7 +3535,7 @@ if none @is_async {
 
 (subscript_expression
   object: (_)@object
-  index: (_)@index ; FIXME typeof index == number
+  index: (_) ; FIXME typeof index == number
 )@subscript_expr {
   node @subscript_expr.indexable
 
@@ -3547,7 +3547,7 @@ if none @is_async {
 }
 
 (subscript_expression
-  object: (_)@object
+  object: (_)
   index: (number)@index
 )@subscript_expr {
   node @subscript_expr.comp_index
@@ -4003,7 +4003,7 @@ if none @is_async {
 ; )
 
 (type_assertion
-  (type_arguments)@type_arguments
+  (type_arguments)
   (expression)@expr
 )@type_assert {
   ; propagate lexical scope
@@ -4081,7 +4081,7 @@ if none @is_async {
   (variable_declarator name:(identifier)@name)
   (pattern/identifier)@name
   (rest_pattern (_)@name)
-]@pat {
+] {
   node @name.cotype
   node @name.lexical_scope
 }
@@ -4091,7 +4091,7 @@ if none @is_async {
   (variable_declarator name:(identifier)@name)
   (pattern/identifier)@name
   (rest_pattern (_)@name)
-]@pat {
+] {
   node @name.defs
   node @name.expr_def
   node @name.expr_def__ns
@@ -4510,7 +4510,7 @@ if none @is_async {
   name:(_)@name
   !type ; opt
   value:(_)@value ; opt
-)@def {
+) {
   ; type of field is type of value
   edge @name.expr_def -> @name.expr_def__typeof
   ;

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -76,7 +76,7 @@ tokio = { version = "1.26", optional = true, features = ["io-std", "rt", "rt-mul
 tower-lsp = { version = "0.19", optional = true }
 tree-sitter = ">= 0.19"
 tree-sitter-config = { version = "0.19", optional = true }
-tree-sitter-graph = "0.9.2"
+tree-sitter-graph = "0.10"
 tree-sitter-loader = "0.20"
 walkdir = { version = "2.3", optional = true }
 

--- a/tree-sitter-stack-graphs/tests/it/nodes.rs
+++ b/tree-sitter-stack-graphs/tests/it/nodes.rs
@@ -50,7 +50,7 @@ fn can_create_definition_node() {
 #[test]
 fn cannot_create_definition_node_without_symbol() {
     let tsg = r#"
-      (identifier) @id {
+      (identifier) {
          node result
          attr (result) type = "pop_symbol", is_definition
       }
@@ -63,7 +63,7 @@ fn cannot_create_definition_node_without_symbol() {
 #[test]
 fn can_create_drop_node() {
     let tsg = r#"
-      (identifier) @id {
+      (identifier) {
          node result
          attr (result) type = "drop_scopes"
       }
@@ -75,7 +75,7 @@ fn can_create_drop_node() {
 #[test]
 fn can_create_exported_node() {
     let tsg = r#"
-      (identifier) @id {
+      (identifier) {
          node result
          attr (result) is_exported
       }
@@ -87,7 +87,7 @@ fn can_create_exported_node() {
 #[test]
 fn can_create_endpoint_node() {
     let tsg = r#"
-      (identifier) @id {
+      (identifier) {
          node result
          attr (result) is_endpoint
       }
@@ -99,7 +99,7 @@ fn can_create_endpoint_node() {
 #[test]
 fn can_create_implicit_internal_node() {
     let tsg = r#"
-      (identifier) @id {
+      (identifier) {
          node result
       }
     "#;
@@ -110,7 +110,7 @@ fn can_create_implicit_internal_node() {
 #[test]
 fn can_create_explicit_internal_node() {
     let tsg = r#"
-      (identifier) @id {
+      (identifier) {
          node result
          attr (result) type = "scope"
       }
@@ -134,7 +134,7 @@ fn can_create_pop_symbol_node() {
 #[test]
 fn cannot_create_pop_symbol_node_without_symbol() {
     let tsg = r#"
-      (identifier) @id {
+      (identifier) {
          node result
          attr (result) type = "pop_symbol"
       }
@@ -159,7 +159,7 @@ fn can_create_pop_scoped_symbol_node() {
 #[test]
 fn cannot_create_pop_scoped_symbol_node_without_symbol() {
     let tsg = r#"
-      (identifier) @id {
+      (identifier) {
          node result
          attr (result) type = "pop_scoped_symbol"
       }
@@ -184,7 +184,7 @@ fn can_create_push_node() {
 #[test]
 fn cannot_create_push_symbol_node_without_symbol() {
     let tsg = r#"
-      (identifier) @id {
+      (identifier) {
          node result
          attr (result) type = "push_symbol"
       }
@@ -218,7 +218,7 @@ fn can_create_push_scoped_node() {
 #[test]
 fn cannot_create_push_scoped_symbol_node_without_symbol() {
     let tsg = r#"
-      (identifier) @id {
+      (identifier) {
          node scope
          attr (scope) is_exported
          node result
@@ -245,7 +245,7 @@ fn can_create_reference_node() {
 #[test]
 fn cannot_create_reference_node_without_symbol() {
     let tsg = r#"
-      (identifier) @id {
+      (identifier) {
          node result
          attr (result) type = "push_symbol", is_reference
       }


### PR DESCRIPTION
Include goodies from the latest TSG release.

The TSG changes are renames of unused captures, so they are not considered errors.
