### PR TITLE
Fix empty range for num_args

### DIFF
--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -84,7 +84,7 @@ pub struct TestArgs {
         long,
         short = 'G',
         value_name = "PATH_SPEC",
-        num_args = 0..1,
+        num_args = 0..=1,
         require_equals = true,
         default_missing_value = "%n.graph.json"
     )]
@@ -97,7 +97,7 @@ pub struct TestArgs {
         long,
         short = 'P',
         value_name = "PATH_SPEC",
-        num_args = 0..1,
+        num_args = 0..=1,
         require_equals = true,
         default_missing_value = "%n.paths.json"
     )]
@@ -110,7 +110,7 @@ pub struct TestArgs {
         long,
         short = 'V',
         value_name = "PATH_SPEC",
-        num_args = 0..1,
+        num_args = 0..=1,
         require_equals = true,
         default_missing_value = "%n.html"
     )]


### PR DESCRIPTION
When upgrading `clap`, the range for `num_args` was accidentally set to the empty `0..1`. This changes this to `0..=1` which allows the indended zero or one arguments.
