### PR TITLE
Add `match` command to run stanza queries

### DIFF
--- a/tree-sitter-stack-graphs/CHANGELOG.md
+++ b/tree-sitter-stack-graphs/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 
 - A new `analyze` command that computes stack graphs and partial paths for all given source files and directories. The command does not produce any output at the moment. Analysis per file can be limited using the `--max-file-time` flag.
+- A new `match` command executes the query patterns from the TSG source and outputs the matches with captured nodes to the console. The `--stanza/-S` flag can be used to select specific stanzas to match by giving the line number where the stanza appears in the source. (Any line that is part of the stanza will work.)
 
 #### Changed
 

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -76,7 +76,7 @@ tokio = { version = "1.26", optional = true, features = ["io-std", "rt", "rt-mul
 tower-lsp = { version = "0.19", optional = true }
 tree-sitter = ">= 0.19"
 tree-sitter-config = { version = "0.19", optional = true }
-tree-sitter-graph = "0.10"
+tree-sitter-graph = "0.10.1"
 tree-sitter-loader = "0.20"
 walkdir = { version = "2.3", optional = true }
 

--- a/tree-sitter-stack-graphs/src/cli.rs
+++ b/tree-sitter-stack-graphs/src/cli.rs
@@ -64,6 +64,7 @@ pub mod init;
 pub mod load;
 #[cfg(feature = "lsp")]
 pub mod lsp;
+pub mod r#match;
 pub mod parse;
 pub mod query;
 pub mod status;
@@ -83,6 +84,7 @@ pub mod path_loading {
     use crate::cli::lsp::LspArgs;
     use crate::cli::parse::ParseArgs;
     use crate::cli::query::QueryArgs;
+    use crate::cli::r#match::MatchArgs;
     use crate::cli::status::StatusArgs;
     use crate::cli::test::TestArgs;
 
@@ -95,6 +97,7 @@ pub mod path_loading {
         Init(Init),
         #[cfg(feature = "lsp")]
         Lsp(Lsp),
+        Match(Match),
         Parse(Parse),
         Query(Query),
         Status(Status),
@@ -109,6 +112,7 @@ pub mod path_loading {
                 Self::Init(cmd) => cmd.run(),
                 #[cfg(feature = "lsp")]
                 Self::Lsp(cmd) => cmd.run(default_db_path),
+                Self::Match(cmd) => cmd.run(),
                 Self::Parse(cmd) => cmd.run(),
                 Self::Query(cmd) => cmd.run(default_db_path),
                 Self::Status(cmd) => cmd.run(default_db_path),
@@ -183,6 +187,22 @@ pub mod path_loading {
             let loader = self.load_args.get()?;
             let db_path = self.db_args.get_or(default_db_path);
             self.lsp_args.run(db_path, loader)
+        }
+    }
+
+    /// Match command
+    #[derive(clap::Parser)]
+    pub struct Match {
+        #[clap(flatten)]
+        load_args: PathLoaderArgs,
+        #[clap(flatten)]
+        match_args: MatchArgs,
+    }
+
+    impl Match {
+        pub fn run(self) -> anyhow::Result<()> {
+            let loader = self.load_args.get()?;
+            self.match_args.run(loader)
         }
     }
 
@@ -264,6 +284,7 @@ pub mod provided_languages {
     use crate::cli::lsp::LspArgs;
     use crate::cli::parse::ParseArgs;
     use crate::cli::query::QueryArgs;
+    use crate::cli::r#match::MatchArgs;
     use crate::cli::status::StatusArgs;
     use crate::cli::test::TestArgs;
     use crate::loader::LanguageConfiguration;
@@ -277,6 +298,7 @@ pub mod provided_languages {
         Init(Init),
         #[cfg(feature = "lsp")]
         Lsp(Lsp),
+        Match(Match),
         Parse(Parse),
         Query(Query),
         Status(Status),
@@ -295,6 +317,7 @@ pub mod provided_languages {
                 Self::Init(cmd) => cmd.run(),
                 #[cfg(feature = "lsp")]
                 Self::Lsp(cmd) => cmd.run(default_db_path, configurations),
+                Self::Match(cmd) => cmd.run(configurations),
                 Self::Parse(cmd) => cmd.run(configurations),
                 Self::Query(cmd) => cmd.run(default_db_path),
                 Self::Status(cmd) => cmd.run(default_db_path),
@@ -377,6 +400,22 @@ pub mod provided_languages {
             let loader = self.load_args.get(configurations)?;
             let db_path = self.db_args.get_or(default_db_path);
             self.lsp_args.run(db_path, loader)
+        }
+    }
+
+    /// Match command
+    #[derive(clap::Parser)]
+    pub struct Match {
+        #[clap(flatten)]
+        load_args: LanguageConfigurationsLoaderArgs,
+        #[clap(flatten)]
+        match_args: MatchArgs,
+    }
+
+    impl Match {
+        pub fn run(self, configurations: Vec<LanguageConfiguration>) -> anyhow::Result<()> {
+            let loader = self.load_args.get(configurations)?;
+            self.match_args.run(loader)
         }
     }
 

--- a/tree-sitter-stack-graphs/src/cli.rs
+++ b/tree-sitter-stack-graphs/src/cli.rs
@@ -190,7 +190,7 @@ pub mod path_loading {
         }
     }
 
-    /// Match command
+    /// Match stanza queries against a source file.
     #[derive(clap::Parser)]
     pub struct Match {
         #[clap(flatten)]
@@ -403,7 +403,7 @@ pub mod provided_languages {
         }
     }
 
-    /// Match command
+    /// Match stanza queries against a source file.
     #[derive(clap::Parser)]
     pub struct Match {
         #[clap(flatten)]

--- a/tree-sitter-stack-graphs/src/cli/match.rs
+++ b/tree-sitter-stack-graphs/src/cli/match.rs
@@ -28,12 +28,12 @@ const MAX_TEXT_LENGTH: usize = 16;
 pub struct MatchArgs {
     /// Input file path.
     #[clap(
-        value_name = "FILE_PATH",
+        value_name = "SOURCE_PATH",
         required = true,
         value_hint = ValueHint::AnyPath,
         value_parser = ExistingPathBufValueParser,
     )]
-    pub file_path: PathBuf,
+    pub source_path: PathBuf,
 
     /// Only match stanza on the given line.
     #[clap(long, value_name = "LINE_NUMBER", short = 'S')]
@@ -43,15 +43,15 @@ pub struct MatchArgs {
 impl MatchArgs {
     pub fn run(self, mut loader: Loader) -> anyhow::Result<()> {
         let mut file_reader = FileReader::new();
-        let lc = match loader.load_for_file(&self.file_path, &mut file_reader, &NoCancellation)? {
+        let lc = match loader.load_for_file(&self.source_path, &mut file_reader, &NoCancellation)? {
             Some(lc) => lc,
             None => return Err(anyhow!("No stack graph language found")),
         };
-        let source = file_reader.get(&self.file_path)?;
-        let tree = parse(lc.language, &self.file_path, source)?;
+        let source = file_reader.get(&self.source_path)?;
+        let tree = parse(lc.language, &self.source_path, source)?;
         if self.stanza.is_empty() {
             lc.sgl.tsg.try_visit_matches(&tree, source, true, |mat| {
-                print_matches(lc.sgl.tsg_path(), &self.file_path, source, mat)
+                print_matches(lc.sgl.tsg_path(), &self.source_path, source, mat)
             })?;
         } else {
             for line in &self.stanza {
@@ -65,7 +65,7 @@ impl MatchArgs {
                         anyhow!("No stanza on {}:{}", lc.sgl.tsg_path().display(), line)
                     })?;
                 stanza.try_visit_matches(&tree, source, |mat| {
-                    print_matches(lc.sgl.tsg_path(), &self.file_path, source, mat)
+                    print_matches(lc.sgl.tsg_path(), &self.source_path, source, mat)
                 })?;
             }
         }

--- a/tree-sitter-stack-graphs/src/cli/match.rs
+++ b/tree-sitter-stack-graphs/src/cli/match.rs
@@ -21,8 +21,6 @@ use crate::loader::FileReader;
 use crate::loader::Loader;
 use crate::NoCancellation;
 
-const MAX_TEXT_LENGTH: usize = 16;
-
 /// Match file
 #[derive(Args)]
 pub struct MatchArgs {
@@ -126,6 +124,8 @@ fn print_matches(
 }
 
 fn print_node_text(node: Node, source_path: &Path, source: &str) -> anyhow::Result<()> {
+    const MAX_TEXT_LENGTH: usize = 16;
+
     print!(", text: \"");
     let text = node.utf8_text(source.as_bytes())?;
     let summary: String = text

--- a/tree-sitter-stack-graphs/src/cli/match.rs
+++ b/tree-sitter-stack-graphs/src/cli/match.rs
@@ -1,0 +1,92 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use anyhow::anyhow;
+use clap::Args;
+use clap::ValueHint;
+use std::path::Path;
+use std::path::PathBuf;
+use tree_sitter::Tree;
+
+use crate::cli::parse::parse;
+use crate::cli::parse::print_node;
+use crate::cli::util::ExistingPathBufValueParser;
+use crate::loader::FileReader;
+use crate::loader::Loader;
+use crate::NoCancellation;
+
+/// Match file
+#[derive(Args)]
+pub struct MatchArgs {
+    /// Input file path.
+    #[clap(
+        value_name = "FILE_PATH",
+        required = true,
+        value_hint = ValueHint::AnyPath,
+        value_parser = ExistingPathBufValueParser,
+    )]
+    pub file_path: PathBuf,
+}
+
+impl MatchArgs {
+    pub fn run(self, mut loader: Loader) -> anyhow::Result<()> {
+        let mut file_reader = FileReader::new();
+        let lc = match loader.load_for_file(&self.file_path, &mut file_reader, &NoCancellation)? {
+            Some(lc) => lc,
+            None => return Err(anyhow!("No stack graph language found")),
+        };
+        let source = file_reader.get(&self.file_path)?;
+        let tree = parse(lc.language, &self.file_path, source)?;
+        print_matches(lc.sgl.tsg_path(), &lc.sgl.tsg, &tree, source)?;
+        Ok(())
+    }
+}
+
+fn print_matches(
+    tsg_path: &Path,
+    tsg: &tree_sitter_graph::ast::File,
+    tree: &Tree,
+    source: &str,
+) -> anyhow::Result<()> {
+    tsg.try_visit_matches(tree, source, true, |mat| {
+        println!(
+            "{}:{}:{}: stanza query",
+            tsg_path.display(),
+            mat.query_location().row + 1,
+            mat.query_location().column + 1,
+        );
+        {
+            let full_capture = mat.full_capture();
+            print!("  matched ");
+            print_node(full_capture, true);
+            println!();
+        }
+        let width = mat
+            .capture_names()
+            .map(|n| n.len())
+            .max()
+            .unwrap_or_default();
+        if width == 0 {
+            return Ok(());
+        }
+        println!("  captured");
+        for (name, _, nodes) in mat.named_captures() {
+            let mut first = true;
+            for node in nodes {
+                if first {
+                    first = false;
+                    print!("    @{}{} = ", name, " ".repeat(width - name.len()));
+                } else {
+                    print!("     {} | ", " ".repeat(width));
+                }
+                print_node(node, true);
+                println!();
+            }
+        }
+        Ok(())
+    })
+}

--- a/tree-sitter-stack-graphs/src/cli/match.rs
+++ b/tree-sitter-stack-graphs/src/cli/match.rs
@@ -135,7 +135,7 @@ fn print_node_text(node: Node, source_path: &Path, source: &str) -> anyhow::Resu
         .collect();
     print!("{}", summary.blue());
     if summary.len() < text.len() {
-        print!("{}", "...".dimmed());
+        print!("{}", "…".dimmed());
     }
     print!("\"");
     print!(

--- a/tree-sitter-stack-graphs/src/cli/match.rs
+++ b/tree-sitter-stack-graphs/src/cli/match.rs
@@ -106,10 +106,8 @@ fn print_matches(
     }
     println!("  and captured");
     for (name, quantifier, nodes) in mat.named_captures() {
-        let mut first = true;
-        for node in nodes {
-            if first {
-                first = false;
+        for (idx, node) in nodes.enumerate() {
+            if idx == 0 {
                 print!(
                     "    @{}{}{} = ",
                     name,


### PR DESCRIPTION
This PR adds a `match` command that runs stanza queries against a given source file and outputs the results to the console.

The output tries to strike a balance between giving enough information to quickly get an idea of what's going on, allow easy follow up, and not be too verbose. In particular:

- The stanza queries are identified only by their source position, but the source is not shown. This is the choice I'm least sure about. But queries are often spread over multiple lines and can be quite long, so I'm afraid showing them might result in very verbose output. In particular because queries are not matched in source order, but in AST traversal order. In other words, the same query can be part of the output many times.

- The top-level matched node, as well as all captures are shown as a node `(node_name)`, a bit of the source (up to 20 characters or so), and the source position.

- Optional `--stanza/-S` flags with a (TSG source) line number can be used to select only specific stanzas to match.

- All source positions are displayed in PATH:LINE:COL format, which at least in VS Code allows quick navigation to the relevant places in the TSG or source file by Ctrl/Cmd-clicking them.

## Example output

![image](https://github.com/github/stack-graphs/assets/999073/c4006d7b-e685-4435-9d7c-4be6f9294047)

