### PR TITLE
Allow skipping test directories

### DIFF
--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -23,6 +23,7 @@ use tree_sitter_graph::Variables;
 
 use crate::cli::util::ExistingPathBufValueParser;
 use crate::cli::util::PathSpec;
+use crate::loader::ContentProvider;
 use crate::loader::FileReader;
 use crate::loader::LanguageConfiguration;
 use crate::loader::Loader;
@@ -56,7 +57,7 @@ use super::util::FileLogger;
     placeholders are correctly subtituted for all paths.
 "#)]
 pub struct TestArgs {
-    /// Test file or directory paths.
+    /// Test file or directory paths. Files or files inside directories ending in .skip are excluded.
     #[clap(
         value_name = "TEST_PATH",
         required = true,
@@ -197,24 +198,37 @@ impl TestArgs {
         loader: &mut Loader,
         file_status: &mut ConsoleFileLogger,
     ) -> anyhow::Result<TestResult> {
-        if self.show_skipped && test_path.extension().map_or(false, |e| e == "skip") {
-            file_status.warning("skipped", None);
-            return Ok(TestResult::new());
-        }
-
         let cancellation_flag = &NoCancellation;
 
-        let mut file_reader = FileReader::new();
-        let lc = match loader.load_for_file(test_path, &mut file_reader, cancellation_flag)? {
+        // If the file is skipped (ending in .skip) we construct the non-skipped path to see if we would support it.
+        let load_path = if test_path.extension().map_or(false, |e| e == "skip") {
+            test_path.with_extension("")
+        } else {
+            test_path.to_path_buf()
+        };
+        let mut file_reader = MappingFileReader::new(&load_path, test_path);
+        let lc = match loader.load_for_file(&load_path, &mut file_reader, cancellation_flag)? {
             Some(sgl) => sgl,
             None => return Ok(TestResult::new()),
         };
-        let source = file_reader.get(test_path)?;
+
+        if test_path.components().any(|c| match c {
+            std::path::Component::Normal(name) => (name.as_ref() as &Path)
+                .extension()
+                .map_or(false, |e| e == "skip"),
+            _ => false,
+        }) {
+            if self.show_skipped {
+                file_status.warning("skipped", None);
+            }
+            return Ok(TestResult::new());
+        }
 
         file_status.processing();
 
+        let source = file_reader.get(test_path)?;
         let default_fragment_path = test_path.strip_prefix(test_root).unwrap();
-        let mut test = Test::from_source(&test_path, &source, default_fragment_path)?;
+        let mut test = Test::from_source(test_path, source, default_fragment_path)?;
         if !self.no_builtins {
             self.load_builtins_into(&lc, &mut test.graph)?;
         }
@@ -466,5 +480,36 @@ impl TestArgs {
         }
         std::fs::write(&path, html)?;
         Ok(())
+    }
+}
+
+struct MappingFileReader<'a> {
+    inner: FileReader,
+    instead_of: &'a Path,
+    load: &'a Path,
+}
+
+impl<'a> MappingFileReader<'a> {
+    fn new(instead_of: &'a Path, load: &'a Path) -> Self {
+        Self {
+            inner: FileReader::new(),
+            instead_of,
+            load,
+        }
+    }
+
+    fn get(&mut self, path: &Path) -> std::io::Result<&str> {
+        let path = if path == self.instead_of {
+            self.load
+        } else {
+            path
+        };
+        self.inner.get(path)
+    }
+}
+
+impl ContentProvider for MappingFileReader<'_> {
+    fn get(&mut self, path: &Path) -> std::io::Result<Option<&str>> {
+        self.get(path).map(Some)
     }
 }

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -823,7 +823,7 @@ impl FileReader {
 
 impl ContentProvider for FileReader {
     fn get(&mut self, path: &Path) -> std::io::Result<Option<&str>> {
-        self.get(path).map(|c| Some(c))
+        self.get(path).map(Some)
     }
 }
 


### PR DESCRIPTION
This PR adds support for skipping tests inside directories ending in `.skip`. It was already the case that test files ending in `.skip` were skipped. With this PR, tests inside `.skip` directory are skipped, even if the test file itself is not marked.

The `test` command supports a `--show-skipped` flag, to make it easier to see what tests are currently disabled. The logic for showing skipped tests has been reorganized to include tests insude `.skip` directories. It will also only show files as skipped if they would be supported without the `.skip` extension, where before any `.skip` file would be reported as skipped.

## Example output

![image](https://github.com/github/stack-graphs/assets/999073/de82b5a2-b257-422c-8b03-3a3f533b76bd)

Note that `unsupported.rb.skip` is not reported as skipped, because Ruby was not supported by the TypeScript CLI used for this test.