### PR TITLE
Include edge debug information in visualization

### DIFF
--- a/languages/tree-sitter-stack-graphs-typescript/rust/util.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/util.rs
@@ -22,7 +22,7 @@ pub const PKG_M_NS: &str = "%PkgM";
 pub fn add_debug_name(graph: &mut StackGraph, node: Handle<Node>, name: &str) {
     let key = graph.add_string("name");
     let value = graph.add_string(name);
-    graph.debug_info_mut(node).add(key, value);
+    graph.node_debug_info_mut(node).add(key, value);
 }
 
 pub fn add_pop(

--- a/stack-graphs/src/graph.rs
+++ b/stack-graphs/src/graph.rs
@@ -1414,6 +1414,7 @@ pub struct StackGraph {
     node_id_handles: NodeIDHandles,
     outgoing_edges: SupplementalArena<Node, SmallVec<[OutgoingEdge; 8]>>,
     pub(crate) node_debug_info: SupplementalArena<Node, DebugInfo>,
+    pub(crate) edge_debug_info: SupplementalArena<Node, DebugInfo>,
 }
 
 impl StackGraph {
@@ -1592,6 +1593,7 @@ impl Default for StackGraph {
             node_id_handles: NodeIDHandles::new(),
             outgoing_edges: SupplementalArena::new(),
             node_debug_info: SupplementalArena::new(),
+            edge_debug_info: SupplementalArena::new(),
         }
     }
 }

--- a/stack-graphs/src/graph.rs
+++ b/stack-graphs/src/graph.rs
@@ -1387,13 +1387,13 @@ pub struct DebugEntry {
 
 impl StackGraph {
     /// Returns debug information about the stack graph node.
-    pub fn debug_info(&self, node: Handle<Node>) -> Option<&DebugInfo> {
-        self.debug_info.get(node)
+    pub fn node_debug_info(&self, node: Handle<Node>) -> Option<&DebugInfo> {
+        self.node_debug_info.get(node)
     }
 
     /// Returns a mutable reference to the debug info about the stack graph node.
-    pub fn debug_info_mut(&mut self, node: Handle<Node>) -> &mut DebugInfo {
-        &mut self.debug_info[node]
+    pub fn node_debug_info_mut(&mut self, node: Handle<Node>) -> &mut DebugInfo {
+        &mut self.node_debug_info[node]
     }
 }
 
@@ -1413,7 +1413,7 @@ pub struct StackGraph {
     pub(crate) source_info: SupplementalArena<Node, SourceInfo>,
     node_id_handles: NodeIDHandles,
     outgoing_edges: SupplementalArena<Node, SmallVec<[OutgoingEdge; 8]>>,
-    pub(crate) debug_info: SupplementalArena<Node, DebugInfo>,
+    pub(crate) node_debug_info: SupplementalArena<Node, DebugInfo>,
 }
 
 impl StackGraph {
@@ -1546,8 +1546,8 @@ impl StackGraph {
                         definiens_span: source_info.definiens_span.clone(),
                     };
                 }
-                if let Some(debug_info) = other.debug_info(other_node) {
-                    *self.debug_info_mut(node) = DebugInfo {
+                if let Some(debug_info) = other.node_debug_info(other_node) {
+                    *self.node_debug_info_mut(node) = DebugInfo {
                         entries: debug_info
                             .entries
                             .iter()
@@ -1591,7 +1591,7 @@ impl Default for StackGraph {
             source_info: SupplementalArena::new(),
             node_id_handles: NodeIDHandles::new(),
             outgoing_edges: SupplementalArena::new(),
-            debug_info: SupplementalArena::new(),
+            node_debug_info: SupplementalArena::new(),
         }
     }
 }

--- a/stack-graphs/src/serde/graph.rs
+++ b/stack-graphs/src/serde/graph.rs
@@ -12,6 +12,7 @@ use thiserror::Error;
 use crate::arena::Handle;
 
 use super::Filter;
+use super::ImplicationFilter;
 use super::NoFilter;
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
@@ -41,9 +42,10 @@ impl StackGraph {
     }
 
     pub fn from_graph_filter<'a>(graph: &crate::graph::StackGraph, filter: &'a dyn Filter) -> Self {
-        let files = graph.filter_files(filter);
-        let nodes = graph.filter_nodes(filter);
-        let edges = graph.filter_edges(filter);
+        let filter = ImplicationFilter(filter);
+        let files = graph.filter_files(&filter);
+        let nodes = graph.filter_nodes(&filter);
+        let edges = graph.filter_edges(&filter);
         Self {
             files,
             nodes,

--- a/stack-graphs/src/serde/graph.rs
+++ b/stack-graphs/src/serde/graph.rs
@@ -167,6 +167,7 @@ impl StackGraph {
             source,
             sink,
             precedence,
+            debug_info,
         } in &self.edges.data
         {
             let source_id = source.to_node_id(graph)?;
@@ -180,6 +181,19 @@ impl StackGraph {
                 .ok_or(Error::InvalidGlobalNodeID(sink.local_id))?;
 
             graph.add_edge(source_handle, sink_handle, *precedence);
+
+            // load debug-info of each node
+            if let Some(debug_info) = debug_info {
+                *graph.edge_debug_info_mut(source_handle, sink_handle) = debug_info
+                    .data
+                    .iter()
+                    .fold(crate::graph::DebugInfo::default(), |mut info, entry| {
+                        let key = graph.add_string(&entry.key);
+                        let value = graph.add_string(&entry.value);
+                        info.add(key, value);
+                        info
+                    });
+            }
         }
         Ok(())
     }
@@ -392,6 +406,8 @@ pub struct Edge {
     pub source: NodeID,
     pub sink: NodeID,
     pub precedence: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub debug_info: Option<DebugInfo>,
 }
 
 impl crate::graph::StackGraph {
@@ -430,7 +446,7 @@ impl crate::graph::StackGraph {
         })
     }
 
-    fn filter_debug_info<'a>(
+    fn filter_node_debug_info<'a>(
         &self,
         _filter: &'a dyn Filter,
         handle: Handle<crate::graph::Node>,
@@ -455,7 +471,7 @@ impl crate::graph::StackGraph {
                     let node = &self[handle];
                     let id = self.filter_node(filter, node.id());
                     let source_info = self.filter_source_info(filter, handle);
-                    let debug_info = self.filter_debug_info(filter, handle);
+                    let debug_info = self.filter_node_debug_info(filter, handle);
 
                     match node {
                         crate::graph::Node::DropScopes(_node) => Node::DropScopes {
@@ -525,10 +541,29 @@ impl crate::graph::StackGraph {
                             source: self.filter_node(filter, self[e.source].id()),
                             sink: self.filter_node(filter, self[e.sink].id()),
                             precedence: e.precedence,
+                            debug_info: self.filter_edge_debug_info(filter, e.source, e.sink),
                         })
                 })
                 .flatten()
                 .collect::<Vec<_>>(),
         }
+    }
+
+    fn filter_edge_debug_info<'a>(
+        &self,
+        _filter: &'a dyn Filter,
+        source_handle: Handle<crate::graph::Node>,
+        sink_handle: Handle<crate::graph::Node>,
+    ) -> Option<DebugInfo> {
+        self.edge_debug_info(source_handle, sink_handle)
+            .map(|info| DebugInfo {
+                data: info
+                    .iter()
+                    .map(|entry| DebugEntry {
+                        key: self[entry.key].to_owned(),
+                        value: self[entry.value].to_owned(),
+                    })
+                    .collect(),
+            })
     }
 }

--- a/stack-graphs/src/serde/graph.rs
+++ b/stack-graphs/src/serde/graph.rs
@@ -146,7 +146,7 @@ impl StackGraph {
 
                 // load debug-info of each node
                 if let Some(debug_info) = node.debug_info() {
-                    *graph.debug_info_mut(handle) = debug_info.data.iter().fold(
+                    *graph.node_debug_info_mut(handle) = debug_info.data.iter().fold(
                         crate::graph::DebugInfo::default(),
                         |mut info, entry| {
                             let key = graph.add_string(&entry.key);
@@ -435,7 +435,7 @@ impl crate::graph::StackGraph {
         _filter: &'a dyn Filter,
         handle: Handle<crate::graph::Node>,
     ) -> Option<DebugInfo> {
-        self.debug_info(handle).map(|info| DebugInfo {
+        self.node_debug_info(handle).map(|info| DebugInfo {
             data: info
                 .iter()
                 .map(|entry| DebugEntry {

--- a/stack-graphs/src/visualization.rs
+++ b/stack-graphs/src/visualization.rs
@@ -36,7 +36,7 @@ impl StackGraph {
         filter: &dyn Filter,
     ) -> Result<String, Error> {
         let filter = VisualizationFilter(filter);
-        let graph = serde_json::to_string(&self.to_serializable())?;
+        let graph = serde_json::to_string(&self.to_serializable_filter(&filter))?;
         let paths = serde_json::to_string(&db.to_serializable_filter(self, partials, &filter))?;
         let html = format!(
             r#"

--- a/stack-graphs/src/visualization/visualization.js
+++ b/stack-graphs/src/visualization/visualization.js
@@ -683,7 +683,6 @@ class StackGraph {
             tooltip.add_row("precedence", edge.precedence);
         }
 
-        // TODO: edge doesn't have debug info yet
         if (edge.hasOwnProperty("debug_info") && edge.debug_info.length > 0) {
             tooltip.add_header("debug info");
             for (let { key, value } of edge.debug_info) {

--- a/stack-graphs/src/visualization/visualization.js
+++ b/stack-graphs/src/visualization/visualization.js
@@ -683,6 +683,7 @@ class StackGraph {
             tooltip.add_row("precedence", edge.precedence);
         }
 
+        // TODO: edge doesn't have debug info yet
         if (edge.hasOwnProperty("debug_info") && edge.debug_info.length > 0) {
             tooltip.add_header("debug info");
             for (let { key, value } of edge.debug_info) {

--- a/stack-graphs/tests/it/serde.rs
+++ b/stack-graphs/tests/it/serde.rs
@@ -68,6 +68,7 @@ fn serde_json_stack_graph() {
                     local_id: 0,
                 },
                 precedence: 0,
+                debug_info: Some(serde::DebugInfo { data: vec![] }),
             }],
         },
     };
@@ -77,6 +78,7 @@ fn serde_json_stack_graph() {
         {
             "edges" : [
                 {
+                    "debug_info" : [],
                     "precedence" : 0,
                     "sink" : {
                         "file" : "index.ts",
@@ -376,6 +378,12 @@ fn can_serialize_graph() {
                     }
                 },
                 {
+                    "debug_info" : [
+                        {
+                            "key" : "dsl_position",
+                            "value" : "line 23 column 4"
+                        }
+                    ],
                     "precedence" : 0,
                     "sink" : {
                         "local_id" : 1

--- a/stack-graphs/tests/it/serde.rs
+++ b/stack-graphs/tests/it/serde.rs
@@ -320,7 +320,7 @@ fn can_load_serialized_stack_graph() {
         .find(|handle| matches!(sg[*handle], graph::Node::Scope(..)))
         .unwrap();
     assert!(sg.source_info(handle).is_some());
-    assert!(sg.debug_info(handle).is_some());
+    assert!(sg.node_debug_info(handle).is_some());
 }
 
 #[test]

--- a/stack-graphs/tests/it/test_graphs/simple.rs
+++ b/stack-graphs/tests/it/test_graphs/simple.rs
@@ -113,16 +113,16 @@ pub fn new() -> StackGraph {
     let str_pos_one = graph.add_string("line 31 column 20");
     let str_pos_two = graph.add_string("line 8 column 11");
     graph
-        .debug_info_mut(scope_x)
+        .node_debug_info_mut(scope_x)
         .add(str_dsl_var, str_arg_scope);
     graph
-        .debug_info_mut(scope_x)
+        .node_debug_info_mut(scope_x)
         .add(str_dsl_position, str_pos_one);
     graph
-        .debug_info_mut(scope)
+        .node_debug_info_mut(scope)
         .add(str_dsl_var, str_lexical_scope);
     graph
-        .debug_info_mut(scope)
+        .node_debug_info_mut(scope)
         .add(str_dsl_position, str_pos_two);
 
     graph

--- a/stack-graphs/tests/it/test_graphs/simple.rs
+++ b/stack-graphs/tests/it/test_graphs/simple.rs
@@ -112,6 +112,7 @@ pub fn new() -> StackGraph {
     let str_lexical_scope = graph.add_string("lexical_scope");
     let str_pos_one = graph.add_string("line 31 column 20");
     let str_pos_two = graph.add_string("line 8 column 11");
+    let str_pos_three = graph.add_string("line 23 column 4");
     graph
         .node_debug_info_mut(scope_x)
         .add(str_dsl_var, str_arg_scope);
@@ -124,6 +125,9 @@ pub fn new() -> StackGraph {
     graph
         .node_debug_info_mut(scope)
         .add(str_dsl_position, str_pos_two);
+    graph
+        .edge_debug_info_mut(scope, root)
+        .add(str_dsl_position, str_pos_three);
 
     graph
 }

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -881,7 +881,7 @@ impl<'a> Builder<'a> {
                 NodeType::Scope => self.load_scope(node_ref)?,
             };
             self.load_span(node_ref, handle)?;
-            self.load_debug_info(node_ref, handle)?;
+            self.load_node_debug_info(node_ref, handle)?;
         }
 
         for node in self.stack_graph.nodes_for_file(self.file) {
@@ -1105,7 +1105,7 @@ impl<'a> Builder<'a> {
         Ok(())
     }
 
-    fn load_debug_info(
+    fn load_node_debug_info(
         &mut self,
         node_ref: GraphNodeRef,
         node_handle: Handle<Node>,
@@ -1122,7 +1122,7 @@ impl<'a> Builder<'a> {
                     .stack_graph
                     .add_string(&name[DEBUG_ATTR_PREFIX.len()..]);
                 let value = self.stack_graph.add_string(&value);
-                self.stack_graph.debug_info_mut(node_handle).add(key, value);
+                self.stack_graph.node_debug_info_mut(node_handle).add(key, value);
             }
         }
         Ok(())


### PR DESCRIPTION
This PR adds support for edge debug information and loads debug attributes from the TSG graph. As a result, edges in the visualization will be annotated with the location of the `edge` statement that created it.

Additionally, a bug is fixed which caused too many nodes to be included in the generated visualization.
