### PR TITLE
Display stacks for each time a path crosses a node

### DIFF
--- a/stack-graphs/src/visualization/visualization.css
+++ b/stack-graphs/src/visualization/visualization.css
@@ -44,7 +44,7 @@
 
 .sg .node text {
     font-family: monospace;
-    font-size: 20px;
+    font-size: 16px;
 }
 
 /* --- drop scopes --- */
@@ -336,7 +336,6 @@
     list-style-type: none;
     padding: 0px;
     margin-left: 10px;
-    font-size: smaller;
 }
 
 .sg-tooltip-sublist-element {
@@ -371,7 +370,7 @@
     line-height: 30px;
     text-align: center;
     margin: 0px;
-    font-size: 18px;
+    font-size: 14px;
     cursor: pointer;
 }
 
@@ -388,6 +387,7 @@
     min-width: 18px;
     max-width: 300px;
     margin: 0px;
+    font-size: 14px;
 }
 
 #sg-help-toggle:checked ~ .sg-help-content {
@@ -395,7 +395,14 @@
 }
 
 .sg-help-content h1 {
+    font-variant: small-caps;
+    font-weight: bold;
     font-size: inherit;
+    border-bottom: solid 1px #777777;
+}
+
+.sg-help-content h1:first-child {
+    margin-top: 0px;
 }
 
 .sg-help-content kbd {

--- a/stack-graphs/src/visualization/visualization.css
+++ b/stack-graphs/src/visualization/visualization.css
@@ -292,6 +292,19 @@
     padding-top: 8px;
 }
 
+.sg-tooltip-sub-header {
+    font-variant: small-caps;
+    font-style: italic;
+    border-bottom: dashed 1px #555555;
+}
+
+.sg-tooltip-sub-header td {
+    column-span: all;
+}
+
+.sg-tooltip-sub-header:not(:first-child) td {
+    padding-top: 4px;
+}
 
 .sg-tooltip-label {
     font-variant: small-caps;


### PR DESCRIPTION
This PR fixes an issue where the visualization would only display the stacks for the current path for the last time the path crossed that node. If the node was used multiple times, the stacks for earlier uses would be lost.

Additionally, font sizes were a bit tweaked to allow for the display of more information.

## Example

<img width="542" alt="image" src="https://github.com/github/stack-graphs/assets/999073/936a6015-5f7d-42df-bb17-74638cb86e7d">

