### PR TITLE
Add `fully_qualified_name` field to `SourceInfo`

### DIFF
--- a/stack-graphs/CHANGELOG.md
+++ b/stack-graphs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New `Defines` and `Refers` assertions test for the presence of definitions and references, respectively, without resolution.
 - A method `StackGraph::get_file` to look up an existing file.
+- A field named `fully_qualified_name` was added to `SourceInfo`.
 
 ### Changed
 

--- a/stack-graphs/include/stack-graphs.h
+++ b/stack-graphs/include/stack-graphs.h
@@ -259,6 +259,9 @@ struct sg_source_info {
     // If you need one of these to make the type checker happy, but you don't have one, just use
     // sg_span::default(), as this will correspond to the all-0s spans which mean "no definiens".
     struct sg_span definiens_span;
+    // The fully qualified name is a representation of the symbol that captures its name and its
+    // embedded context (e.g. `foo.bar` for the symbol `bar` defined in the module `foo`).
+    sg_string_handle fully_qualified_name;
 };
 
 // An array of all of the source information in a stack graph.  Source information is associated

--- a/stack-graphs/src/c.rs
+++ b/stack-graphs/src/c.rs
@@ -627,12 +627,14 @@ pub struct sg_source_info {
     pub syntax_type: sg_string_handle,
     /// The full content of the line containing this node in its source file.
     pub containing_line: sg_string_handle,
-
     /// The location in its containing file of the source code that this node's definiens represents.
     /// This is used for things like the bodies of functions, rather than the RHSes of equations.
     /// If you need one of these to make the type checker happy, but you don't have one, just use
     /// sg_span::default(), as this will correspond to the all-0s spans which mean "no definiens".
     pub definiens_span: sg_span,
+    /// The fully qualified name is a representation of the symbol that captures its name and its
+    /// embedded context (e.g. `foo.bar` for the symbol `bar` defined in the module `foo`).
+    pub fully_qualified_name: sg_string_handle,
 }
 
 /// All of the position information that we have about a range of content in a source file

--- a/stack-graphs/src/graph.rs
+++ b/stack-graphs/src/graph.rs
@@ -1337,7 +1337,7 @@ pub struct SourceInfo {
     /// The location in its containing file of the source code that this node represents.
     pub span: lsp_positions::Span,
     /// The kind of syntax entity this node represents (e.g. `function`, `class`, `method`, etc.).
-    pub syntax_type: Option<Handle<InternedString>>,
+    pub syntax_type: ControlledOption<Handle<InternedString>>,
     /// The full content of the line containing this node in its source file.
     pub containing_line: ControlledOption<Handle<InternedString>>,
     /// The location in its containing file of the source code that this node's definiens represents.
@@ -1347,7 +1347,7 @@ pub struct SourceInfo {
     pub definiens_span: lsp_positions::Span,
     /// The fully qualified name is a representation of the symbol that captures its name and its
     /// embedded context (e.g. `foo.bar` for the symbol `bar` defined in the module `foo`).
-    pub fully_qualified_name: Option<Handle<InternedString>>,
+    pub fully_qualified_name: ControlledOption<Handle<InternedString>>,
 }
 
 impl StackGraph {
@@ -1568,14 +1568,16 @@ impl StackGraph {
                         span: source_info.span.clone(),
                         syntax_type: source_info
                             .syntax_type
-                            .map(|st| self.add_string(&other[st])),
+                            .into_option()
+                            .map(|st| self.add_string(&other[st]))
+                            .into(),
                         containing_line: source_info
                             .containing_line
                             .into_option()
                             .map(|cl| self.add_string(&other[cl]))
                             .into(),
                         definiens_span: source_info.definiens_span.clone(),
-                        fully_qualified_name: None,
+                        fully_qualified_name: ControlledOption::default(),
                     };
                 }
                 if let Some(debug_info) = other.node_debug_info(other_node) {

--- a/stack-graphs/src/graph.rs
+++ b/stack-graphs/src/graph.rs
@@ -1345,6 +1345,9 @@ pub struct SourceInfo {
     /// If you need one of these to make the type checker happy, but you don't have one, just use
     /// lsp_positions::Span::default(), as this will correspond to the all-0s spans which mean "no definiens".
     pub definiens_span: lsp_positions::Span,
+    /// The fully qualified name is a representation of the symbol that captures its name and its
+    /// embedded context (e.g. `foo.bar` for the symbol `bar` defined in the module `foo`).
+    pub fully_qualified_name: Option<Handle<InternedString>>,
 }
 
 impl StackGraph {
@@ -1572,6 +1575,7 @@ impl StackGraph {
                             .map(|cl| self.add_string(&other[cl]))
                             .into(),
                         definiens_span: source_info.definiens_span.clone(),
+                        fully_qualified_name: None,
                     };
                 }
                 if let Some(debug_info) = other.node_debug_info(other_node) {

--- a/stack-graphs/src/serde/graph.rs
+++ b/stack-graphs/src/serde/graph.rs
@@ -141,7 +141,8 @@ impl StackGraph {
                         syntax_type: source_info
                             .syntax_type
                             .as_ref()
-                            .map(|st| graph.add_string(&st)),
+                            .map(|st| graph.add_string(&st))
+                            .into(),
                         ..Default::default()
                     };
                 }
@@ -444,7 +445,7 @@ impl crate::graph::StackGraph {
     ) -> Option<SourceInfo> {
         self.source_info(handle).map(|info| SourceInfo {
             span: info.span.clone(),
-            syntax_type: info.syntax_type.map(|ty| self[ty].to_owned()),
+            syntax_type: info.syntax_type.into_option().map(|ty| self[ty].to_owned()),
         })
     }
 

--- a/stack-graphs/tests/it/c/nodes.rs
+++ b/stack-graphs/tests/it/c/nodes.rs
@@ -674,6 +674,7 @@ fn can_create_source_info() {
 
     let syntax_type = add_string(graph, "function");
     let containing_line = add_string(graph, "def foo():");
+    let fully_qualified_name = add_string(graph, "bar.foo");
 
     let mut infos = [sg_node_source_info {
         node: handles[1],
@@ -682,6 +683,7 @@ fn can_create_source_info() {
             syntax_type,
             containing_line,
             definiens_span: sg_span::default(),
+            fully_qualified_name,
         },
     }];
     infos[0].source_info.span.start.line = 17;

--- a/stack-graphs/tests/it/test_graphs/simple.rs
+++ b/stack-graphs/tests/it/test_graphs/simple.rs
@@ -5,6 +5,7 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+use controlled_option::ControlledOption;
 use lsp_positions::Offset;
 use lsp_positions::Position;
 use lsp_positions::Span;
@@ -77,7 +78,7 @@ pub fn new() -> StackGraph {
         syntax_type: str_var.into(),
         containing_line: str_line0.into(),
         definiens_span: Span::default(),
-        fully_qualified_name: None,
+        fully_qualified_name: ControlledOption::default(),
     };
     *graph.source_info_mut(ref_x) = SourceInfo {
         span: Span {
@@ -105,7 +106,7 @@ pub fn new() -> StackGraph {
         syntax_type: str_var.into(),
         containing_line: str_line1.into(),
         definiens_span: Span::default(),
-        fully_qualified_name: None,
+        fully_qualified_name: ControlledOption::default(),
     };
 
     let str_dsl_var = graph.add_string("dsl_var");

--- a/stack-graphs/tests/it/test_graphs/simple.rs
+++ b/stack-graphs/tests/it/test_graphs/simple.rs
@@ -77,6 +77,7 @@ pub fn new() -> StackGraph {
         syntax_type: str_var.into(),
         containing_line: str_line0.into(),
         definiens_span: Span::default(),
+        fully_qualified_name: None,
     };
     *graph.source_info_mut(ref_x) = SourceInfo {
         span: Span {
@@ -104,6 +105,7 @@ pub fn new() -> StackGraph {
         syntax_type: str_var.into(),
         containing_line: str_line1.into(),
         definiens_span: Span::default(),
+        fully_qualified_name: None,
     };
 
     let str_dsl_var = graph.add_string("dsl_var");


### PR DESCRIPTION
This adds a `fully_qualified_name` field to `SourceInfo` to provide a convenient mechanism for labeling stack graph nodes with a fully qualified name. No facilities for generating a fully qualified name are provided in this change set, this only allows for tracking of fully qualified names via a stack graph node's associated `SourceInfo`.