### PR TITLE
Unify path finding and path stitching

### DIFF
--- a/stack-graphs/CHANGELOG.md
+++ b/stack-graphs/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- The `Appendable` trait has been simplified. It's `Ctx` type parameter is gone, in favor of a separate trait `ToAppendable` that is used to find appendables for a handle. The type itself moved from the `cycles` to the `stitching` module.
+- The `ForwardPartialPathStitcher` has been generalized so that it can be used to build paths from a database or from graph edges. It now takes a type parameter indicating the type of candidates it uses. Instead of a `Database` instance, it expects a value that implements the `Candidates` and `ToAppendable` traits. The `ForwardPartialPathStitcher::process_next_phase` expects an additional `extend_until` closure that controls whether the extended paths are considered for further extension or not (using `|_,_,_| true` retains old behavior).
+
+### Fixed
+
+- A panic in `AppendingCycleDetector::is_cyclic` that occurred because variables were not always renamed before attempting to concatenate partial paths.
+- An inverted condition in `PartialSymbolStack::has_variable` that resulted in incorrect return values.
+- A bug in `Partial*Stack::unify` that resulted in recursive bindings (`$1 => SYMBOL,$1`). Any unification that would result in a recursive binding now returns an error.
+- A bug in `PartialPath::append` that would incorrectly allow appending edges that added symbols to the precondition symbol stack, even if that stack had no variable.
+
+### Removed
+
+- The `ForwardPartialPathStitcher::from_nodes` function has been removed. Callers are responsible for creating the right initial paths, which can be done using `PartialPath::from_node`.
+- The `PartialPaths::find_minimal_partial_path_set_in_file` method has been removed in favor of `ForwardPartialPathStitcher::find_minimal_partial_path_set_in_file`.
+- The `PartialPaths::find_all_complete_paths` method has been removed in favor of `ForwardPartialPathStitcher::find_all_complete_partial_paths` using `GraphEdges(None)` for the `db` argument.
+- The `OwnedOrDatabasePath` has been removed because it was obsolete with the changes to `Appendable`.
+
 ## v0.11.0 -- 2023-06-08
 
 ### Added

--- a/stack-graphs/CHANGELOG.md
+++ b/stack-graphs/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The `Appendable` trait has been simplified. It's `Ctx` type parameter is gone, in favor of a separate trait `ToAppendable` that is used to find appendables for a handle. The type itself moved from the `cycles` to the `stitching` module.
+- The `Appendable` trait has been simplified. Its `Ctx` type parameter is gone, in favor of a separate trait `ToAppendable` that is used to find appendables for a handle. The type itself moved from the `cycles` to the `stitching` module.
 - The `ForwardPartialPathStitcher` has been generalized so that it can be used to build paths from a database or from graph edges. It now takes a type parameter indicating the type of candidates it uses. Instead of a `Database` instance, it expects a value that implements the `Candidates` and `ToAppendable` traits. The `ForwardPartialPathStitcher::process_next_phase` expects an additional `extend_until` closure that controls whether the extended paths are considered for further extension or not (using `|_,_,_| true` retains old behavior).
 
 ### Fixed

--- a/stack-graphs/include/stack-graphs.h
+++ b/stack-graphs/include/stack-graphs.h
@@ -801,7 +801,7 @@ void sg_partial_path_database_mark_local_nodes(struct sg_partial_path_database *
 struct sg_node_handle_set sg_partial_path_database_local_nodes(const struct sg_partial_path_database *db);
 
 // Creates a new forward partial path stitcher that is "seeded" with a set of starting stack graph
-// nodes.
+// nodes. The path stitcher will be set up to find complete paths only.
 struct sg_forward_partial_path_stitcher *sg_forward_partial_path_stitcher_from_nodes(const struct sg_stack_graph *graph,
                                                                                      struct sg_partial_path_arena *partials,
                                                                                      size_t count,

--- a/stack-graphs/src/assert.rs
+++ b/stack-graphs/src/assert.rs
@@ -178,7 +178,7 @@ impl Assertion {
         let mut actual_paths = Vec::new();
         for reference in &references {
             let mut reference_paths = Vec::new();
-            ForwardPartialPathStitcher::<Handle<PartialPath>>::find_all_complete_partial_paths(
+            ForwardPartialPathStitcher::find_all_complete_partial_paths(
                 graph,
                 partials,
                 db,

--- a/stack-graphs/src/assert.rs
+++ b/stack-graphs/src/assert.rs
@@ -178,7 +178,7 @@ impl Assertion {
         let mut actual_paths = Vec::new();
         for reference in &references {
             let mut reference_paths = Vec::new();
-            ForwardPartialPathStitcher::find_all_complete_partial_paths(
+            ForwardPartialPathStitcher::<Handle<PartialPath>>::find_all_complete_partial_paths(
                 graph,
                 partials,
                 db,

--- a/stack-graphs/src/c.rs
+++ b/stack-graphs/src/c.rs
@@ -1404,12 +1404,12 @@ struct InternalForwardPartialPathStitcher {
     previous_phase_partial_paths: *const PartialPath,
     previous_phase_partial_paths_length: usize,
     is_complete: bool,
-    stitcher: ForwardPartialPathStitcher,
+    stitcher: ForwardPartialPathStitcher<Handle<PartialPath>>,
 }
 
 impl InternalForwardPartialPathStitcher {
     fn new(
-        stitcher: ForwardPartialPathStitcher,
+        stitcher: ForwardPartialPathStitcher<Handle<PartialPath>>,
         partials: &mut PartialPaths,
     ) -> InternalForwardPartialPathStitcher {
         let mut this = InternalForwardPartialPathStitcher {

--- a/stack-graphs/src/cycles.rs
+++ b/stack-graphs/src/cycles.rs
@@ -129,6 +129,9 @@ where
 // ----------------------------------------------------------------------------
 // Cycle detector
 
+/// An arena used by [`AppendingCycleDetector`][] to store the path component lists.
+/// The arena is shared between all cycle detectors in a path stitching run, so that
+/// the cycle detectors themselves can be small and cheaply cloned.
 pub struct Appendables<H> {
     /// List arena for appendable lists
     elements: ListArena<InternedPathOrHandle<H>>,

--- a/stack-graphs/src/cycles.rs
+++ b/stack-graphs/src/cycles.rs
@@ -265,8 +265,10 @@ where
             let cyclic_path = maybe_cyclic_path
                 .unwrap_or_else(|| PartialPath::from_node(graph, partials, end_node));
             cyclic_path.append_to(graph, partials, &mut prefix_path)?;
-            if let Some(cyclicity) = prefix_path.is_cyclic(graph, partials) {
-                cycles |= cyclicity;
+            if prefix_path.edges.len() > 0 {
+                if let Some(cyclicity) = prefix_path.is_cyclic(graph, partials) {
+                    cycles |= cyclicity;
+                }
             }
             maybe_cyclic_path = Some(prefix_path);
         }

--- a/stack-graphs/src/cycles.rs
+++ b/stack-graphs/src/cycles.rs
@@ -130,7 +130,7 @@ where
 
 pub trait Index<H, A>
 where
-    A: Appendable + Clone,
+    A: Appendable,
 {
     fn get<'a>(&'a self, handle: &'a H) -> &'a A;
 }
@@ -173,7 +173,7 @@ where
         path: &mut PartialPath,
     ) -> Result<(), PathResolutionError>
     where
-        A: Appendable + Clone + 'a,
+        A: Appendable + 'a,
         Db: Index<H, A>,
     {
         match self {
@@ -184,7 +184,7 @@ where
 
     fn start_node<'a, A, Db>(&self, db: &'a Db) -> Handle<Node>
     where
-        A: Appendable + Clone + 'a,
+        A: Appendable + 'a,
         Db: Index<H, A>,
     {
         match self {
@@ -195,7 +195,7 @@ where
 
     fn end_node<'a, A, Db>(&self, db: &'a Db) -> Handle<Node>
     where
-        A: Appendable + Clone + 'a,
+        A: Appendable + 'a,
         Db: Index<H, A>,
     {
         match self {
@@ -245,7 +245,7 @@ where
         appendables: &mut Appendables<H>,
     ) -> Result<EnumSet<Cyclicity>, PathResolutionError>
     where
-        A: Appendable + Clone + 'a,
+        A: Appendable + 'a,
         Db: Index<H, A>,
     {
         let mut cycles = EnumSet::new();

--- a/stack-graphs/src/cycles.rs
+++ b/stack-graphs/src/cycles.rs
@@ -31,7 +31,6 @@
 
 use enumset::EnumSet;
 use smallvec::SmallVec;
-use std::borrow::Cow;
 use std::collections::HashMap;
 
 use crate::arena::Handle;
@@ -129,22 +128,22 @@ where
 // ----------------------------------------------------------------------------
 // Cycle detector
 
-pub trait Index<'a, H, A>
+pub trait Index<H, A>
 where
-    A: Appendable + Clone + 'a,
+    A: Appendable + Clone,
 {
-    fn get(&'a self, handle: &H) -> Cow<'a, A>;
+    fn get<'a>(&'a self, handle: &'a H) -> &'a A;
 }
 
-impl<'a> Index<'a, Handle<PartialPath>, PartialPath> for Database {
-    fn get(&'a self, handle: &Handle<PartialPath>) -> Cow<'a, PartialPath> {
-        Cow::Borrowed(&self[*handle])
+impl Index<Handle<PartialPath>, PartialPath> for Database {
+    fn get<'a>(&'a self, handle: &'a Handle<PartialPath>) -> &'a PartialPath {
+        &self[*handle]
     }
 }
 
-impl<'a, A: Appendable + Clone + 'a> Index<'a, A, A> for () {
-    fn get(&self, value: &A) -> Cow<'a, A> {
-        Cow::Owned(value.clone())
+impl<A: Appendable + Clone> Index<A, A> for () {
+    fn get<'a>(&'a self, value: &'a A) -> &'a A {
+        value
     }
 }
 
@@ -175,7 +174,7 @@ where
     ) -> Result<(), PathResolutionError>
     where
         A: Appendable + Clone + 'a,
-        Db: Index<'a, H, A>,
+        Db: Index<H, A>,
     {
         match self {
             Self::Path(other) => other.append_to(graph, partials, path),
@@ -186,7 +185,7 @@ where
     fn start_node<'a, A, Db>(&self, db: &'a Db) -> Handle<Node>
     where
         A: Appendable + Clone + 'a,
-        Db: Index<'a, H, A>,
+        Db: Index<H, A>,
     {
         match self {
             Self::Path(path) => path.start_node,
@@ -197,7 +196,7 @@ where
     fn end_node<'a, A, Db>(&self, db: &'a Db) -> Handle<Node>
     where
         A: Appendable + Clone + 'a,
-        Db: Index<'a, H, A>,
+        Db: Index<H, A>,
     {
         match self {
             Self::Path(path) => path.end_node,
@@ -247,7 +246,7 @@ where
     ) -> Result<EnumSet<Cyclicity>, PathResolutionError>
     where
         A: Appendable + Clone + 'a,
-        Db: Index<'a, H, A>,
+        Db: Index<H, A>,
     {
         let mut cycles = EnumSet::new();
 

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -2225,13 +2225,13 @@ impl PartialPath {
     /// as a parameter, instead of building it up ourselves, so that you have control over which
     /// particular collection type to use, and so that you can reuse result collections across
     /// multiple calls.
-    fn extend<R: Extend<(PartialPath, AppendingCycleDetector<(), Edge>)>>(
+    fn extend<R: Extend<(PartialPath, AppendingCycleDetector<Edge>)>>(
         &self,
         graph: &StackGraph,
         partials: &mut PartialPaths,
         file: Option<Handle<File>>,
         edges: &mut Appendables<Edge>,
-        path_cycle_detector: AppendingCycleDetector<(), Edge>,
+        path_cycle_detector: AppendingCycleDetector<Edge>,
         result: &mut R,
     ) {
         let extensions = graph.outgoing_edges(self.end_node);
@@ -2533,7 +2533,7 @@ impl PartialPaths {
                 copious_debugging!("    * visit");
                 visit(graph, self, path);
             } else if !path_cycle_detector
-                .is_cyclic(graph, self, &mut (), &mut edges)
+                .is_cyclic(graph, self, &(), &mut edges)
                 .expect("cyclic test failed when finding partial paths")
                 .is_empty()
             {
@@ -2592,7 +2592,7 @@ impl PartialPaths {
                 visit(graph, self, path.clone());
             }
             if !path_cycle_detector
-                .is_cyclic(graph, &mut partials, &mut (), &mut edges)
+                .is_cyclic(graph, &mut partials, &(), &mut edges)
                 .expect("cyclic test failed when finding complete paths")
                 .into_iter()
                 .all(|c| c == Cyclicity::StrengthensPrecondition)

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -471,7 +471,7 @@ impl PartialSymbolStack {
     /// Returns whether this partial symbol stack has a symbol stack variable.
     #[inline(always)]
     pub fn has_variable(&self) -> bool {
-        !self.variable.is_some()
+        self.variable.is_some()
     }
 
     #[inline(always)]

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -724,15 +724,23 @@ impl PartialSymbolStack {
 
         // CASE 3:
         // One of the stacks contains symbols and the other doesn't, and the “empty” stack _does_
-        // have a variable.  That means the answer is YES, and the “empty” side's variable needs to
-        // capture the entirety of the non-empty side.
+        // have a variable.  If both sides have the same variable, the answer is NO. Otherwise,
+        // the answer is YES, and the “empty” side's variable needs to capture the entirety of the
+        // non-empty side.
         //
         //     lhs           rhs
         // ============  ============
+        //  (...) $1      (...) $1      => no
         //  () $1         (stuff)       => yes rhs,  $1 => rhs
         //  () $1         (stuff) $2    => yes rhs,  $1 => rhs
         //  (stuff)       () $2         => yes lhs,  $2 => lhs
         //  (stuff) $1    () $2         => yes lhs,  $2 => lhs
+        match (lhs.variable.into_option(), rhs.variable.into_option()) {
+            (Some(v1), Some(v2)) if v1 == v2 => {
+                return Err(PathResolutionError::ScopeStackUnsatisfied)
+            }
+            _ => {}
+        }
         if lhs.contains_symbols() {
             let rhs_variable = rhs.variable.into_option().unwrap();
             symbol_bindings.add(partials, rhs_variable, lhs, scope_bindings)?;
@@ -1095,15 +1103,23 @@ impl PartialScopeStack {
 
         // CASE 3:
         // One of the stacks contains scopes and the other doesn't, and the “empty” stack _does_
-        // have a variable.  That means the answer is YES, and the “empty” side's variable needs to
-        // capture the entirety of the non-empty side.
+        // have a variable.  If both sides have the same variable, the answer is NO. Otherwise,
+        // the answer is YES, and the “empty” side's variable needs to capture the entirety of the
+        // non-empty side.
         //
         //     lhs           rhs
         // ============  ============
+        //  (...) $1      (...) $1      => no
         //  () $1         (stuff)       => yes rhs,  $1 => rhs
         //  () $1         (stuff) $2    => yes rhs,  $1 => rhs
         //  (stuff)       () $2         => yes lhs,  $2 => lhs
         //  (stuff) $1    () $2         => yes lhs,  $2 => lhs
+        match (lhs.variable.into_option(), rhs.variable.into_option()) {
+            (Some(v1), Some(v2)) if v1 == v2 => {
+                return Err(PathResolutionError::ScopeStackUnsatisfied)
+            }
+            _ => {}
+        }
         if lhs.contains_scopes() {
             let rhs_variable = rhs.variable.into_option().unwrap();
             bindings.add(partials, rhs_variable, lhs)?;

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -56,6 +56,7 @@ use crate::graph::StackGraph;
 use crate::graph::Symbol;
 use crate::paths::Extend;
 use crate::paths::PathResolutionError;
+use crate::stitching::GraphEdges;
 use crate::utils::cmp_option;
 use crate::utils::equals_option;
 use crate::CancellationError;
@@ -2549,7 +2550,7 @@ impl PartialPaths {
                 copious_debugging!("    * visit");
                 visit(graph, self, path);
             } else if !path_cycle_detector
-                .is_cyclic(graph, self, &(), &mut edges)
+                .is_cyclic(graph, self, &GraphEdges(Some(file)), &mut edges)
                 .expect("cyclic test failed when finding partial paths")
                 .is_empty()
             {
@@ -2608,7 +2609,7 @@ impl PartialPaths {
                 visit(graph, self, path.clone());
             }
             if !path_cycle_detector
-                .is_cyclic(graph, &mut partials, &(), &mut edges)
+                .is_cyclic(graph, &mut partials, &GraphEdges(None), &mut edges)
                 .expect("cyclic test failed when finding complete paths")
                 .into_iter()
                 .all(|c| c == Cyclicity::StrengthensPrecondition)

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -2225,13 +2225,13 @@ impl PartialPath {
     /// as a parameter, instead of building it up ourselves, so that you have control over which
     /// particular collection type to use, and so that you can reuse result collections across
     /// multiple calls.
-    fn extend<R: Extend<(PartialPath, AppendingCycleDetector<Edge>)>>(
+    fn extend<R: Extend<(PartialPath, AppendingCycleDetector<(), Edge>)>>(
         &self,
         graph: &StackGraph,
         partials: &mut PartialPaths,
         file: Option<Handle<File>>,
         edges: &mut Appendables<Edge>,
-        path_cycle_detector: AppendingCycleDetector<Edge>,
+        path_cycle_detector: AppendingCycleDetector<(), Edge>,
         result: &mut R,
     ) {
         let extensions = graph.outgoing_edges(self.end_node);

--- a/stack-graphs/src/stitching.rs
+++ b/stack-graphs/src/stitching.rs
@@ -156,6 +156,12 @@ impl Appendable for PartialPath {
 //-------------------------------------------------------------------------------------------------
 // ToAppendable
 
+/// A trait to be implemented on types such as [`Database`][] that allow converting handles
+/// to appendables.
+///
+/// It is very similar to the [`std::ops::Index`] trait, but returns a reference instead
+/// of a value, such that an efficient identifity implementation is possible, that doesn't
+/// require cloning values.
 pub trait ToAppendable<H, A>
 where
     A: Appendable,
@@ -166,6 +172,8 @@ where
 //-------------------------------------------------------------------------------------------------
 // Candidates
 
+/// A trait to support finding candidates for partial path extension. Requires an accompanying
+/// [`ToAppendable`] implementation to convert the candidate handles into [`Appendable`]s.
 pub trait Candidates<H> {
     fn find_candidates<R>(
         &mut self,

--- a/stack-graphs/src/stitching.rs
+++ b/stack-graphs/src/stitching.rs
@@ -763,16 +763,16 @@ impl<H: Clone> ForwardPartialPathStitcher<H> {
             .is_cyclic(graph, partials, db, &mut self.appended_paths)
             .expect("cyclic test failed when stitching partial paths");
         let cyclic = match has_precondition_variables {
-            // If the precondition has no variables, we allow cycles that strenghten the
-            // precondition, because we know they cannot strenghten the precondition of
+            // If the precondition has no variables, we allow cycles that strengthen the
+            // precondition, because we know they cannot strengthen the precondition of
             // the overall path.
             false => !cycles
                 .into_iter()
                 .all(|c| c == Cyclicity::StrengthensPrecondition),
             // If the precondition has variables, do not allow any cycles, not even those
             // that strengthen the precondition. This is more strict than necessary. Better
-            // might be to disallow precondition strenghtening cycles only if they would
-            // strenghten the overall path precondition.
+            // might be to disallow precondition strengthening cycles only if they would
+            // strengthen the overall path precondition.
             true => !cycles.is_empty(),
         };
         if cyclic {

--- a/stack-graphs/src/stitching.rs
+++ b/stack-graphs/src/stitching.rs
@@ -733,7 +733,7 @@ impl<H: Clone> ForwardPartialPathStitcher<H> {
         cycle_detector: AppendingCycleDetector<H>,
     ) -> usize
     where
-        A: Appendable + Clone + 'a,
+        A: Appendable + 'a,
         Db: Candidates<H> + crate::cycles::Index<H, A>,
     {
         self.candidates.clear();
@@ -808,7 +808,7 @@ impl<H: Clone> ForwardPartialPathStitcher<H> {
         partials: &mut PartialPaths,
         db: &mut Db,
     ) where
-        A: Appendable + Clone + 'a,
+        A: Appendable + 'a,
         Db: Candidates<H> + crate::cycles::Index<H, A>,
     {
         copious_debugging!("==> Start phase {}", self.phase_number);

--- a/stack-graphs/src/stitching.rs
+++ b/stack-graphs/src/stitching.rs
@@ -463,12 +463,15 @@ impl<'a> Display for DisplaySymbolStackKey<'a> {
 /// [`find_all_complete_partial_paths`]: #method.find_all_complete_partial_paths
 pub struct ForwardPartialPathStitcher {
     candidate_partial_paths: Vec<Handle<PartialPath>>,
-    queue: VecDeque<(PartialPath, AppendingCycleDetector<OwnedOrDatabasePath>)>,
+    queue: VecDeque<(
+        PartialPath,
+        AppendingCycleDetector<Database, OwnedOrDatabasePath>,
+    )>,
     // next_iteration is a tuple of queues instead of an queue of tuples so that the path queue
     // can be cheaply exposed through the C API as a continuous memory block
     next_iteration: (
         VecDeque<PartialPath>,
-        VecDeque<AppendingCycleDetector<OwnedOrDatabasePath>>,
+        VecDeque<AppendingCycleDetector<Database, OwnedOrDatabasePath>>,
     ),
     appended_paths: Appendables<OwnedOrDatabasePath>,
     similar_path_detector: Option<SimilarPathDetector<PartialPath>>,
@@ -590,7 +593,7 @@ impl ForwardPartialPathStitcher {
         partials: &mut PartialPaths,
         db: &mut Database,
         partial_path: &PartialPath,
-        cycle_detector: AppendingCycleDetector<OwnedOrDatabasePath>,
+        cycle_detector: AppendingCycleDetector<Database, OwnedOrDatabasePath>,
     ) -> usize {
         self.candidate_partial_paths.clear();
         if graph[partial_path.end_node].is_root() {

--- a/stack-graphs/src/storage.rs
+++ b/stack-graphs/src/storage.rs
@@ -679,7 +679,12 @@ impl SQLiteReader {
             for path in stitcher.previous_phase_partial_paths() {
                 self.load_partial_path_extensions(path, cancellation_flag)?;
             }
-            stitcher.process_next_phase(&self.graph, &mut self.partials, &mut self.db);
+            stitcher.process_next_phase(
+                &self.graph,
+                &mut self.partials,
+                &mut self.db,
+                |_, _, _| true,
+            );
             for path in stitcher.previous_phase_partial_paths() {
                 if path.is_complete(&self.graph) {
                     visit(&self.graph, &mut self.partials, path);

--- a/stack-graphs/tests/it/can_find_local_nodes.rs
+++ b/stack-graphs/tests/it/can_find_local_nodes.rs
@@ -11,6 +11,7 @@ use pretty_assertions::assert_eq;
 use stack_graphs::graph::StackGraph;
 use stack_graphs::partial::PartialPaths;
 use stack_graphs::stitching::Database;
+use stack_graphs::stitching::ForwardPartialPathStitcher;
 use stack_graphs::NoCancellation;
 
 use crate::test_graphs;
@@ -19,16 +20,16 @@ fn check_local_nodes(graph: &StackGraph, file: &str, expected_local_nodes: &[&st
     let file = graph.get_file(file).expect("Missing file");
     let mut partials = PartialPaths::new();
     let mut database = Database::new();
-    partials
-        .find_minimal_partial_path_set_in_file(
-            graph,
-            file,
-            &NoCancellation,
-            |graph, partials, path| {
-                database.add_partial_path(graph, partials, path);
-            },
-        )
-        .expect("should never be cancelled");
+    ForwardPartialPathStitcher::find_minimal_partial_path_set_in_file(
+        graph,
+        &mut partials,
+        file,
+        &NoCancellation,
+        |graph, partials, path| {
+            database.add_partial_path(graph, partials, path.clone());
+        },
+    )
+    .expect("should never be cancelled");
 
     let mut results = BTreeSet::new();
     database.find_local_nodes();

--- a/stack-graphs/tests/it/can_find_node_partial_paths_in_database.rs
+++ b/stack-graphs/tests/it/can_find_node_partial_paths_in_database.rs
@@ -14,6 +14,7 @@ use stack_graphs::graph::StackGraph;
 use stack_graphs::partial::PartialPath;
 use stack_graphs::partial::PartialPaths;
 use stack_graphs::stitching::Database;
+use stack_graphs::stitching::ForwardPartialPathStitcher;
 use stack_graphs::NoCancellation;
 
 use crate::test_graphs;
@@ -28,16 +29,16 @@ fn check_node_partial_paths(
     let node = graph.node_for_id(id).expect("Cannot find node");
     let mut partials = PartialPaths::new();
     let mut db = Database::new();
-    partials
-        .find_minimal_partial_path_set_in_file(
-            graph,
-            file,
-            &NoCancellation,
-            |graph, partials, path| {
-                db.add_partial_path(graph, partials, path);
-            },
-        )
-        .expect("should never be cancelled");
+    ForwardPartialPathStitcher::find_minimal_partial_path_set_in_file(
+        graph,
+        &mut partials,
+        file,
+        &NoCancellation,
+        |graph, partials, path| {
+            db.add_partial_path(graph, partials, path.clone());
+        },
+    )
+    .expect("should never be cancelled");
 
     let mut results = Vec::<Handle<PartialPath>>::new();
     db.find_candidate_partial_paths_from_node(graph, &mut partials, node, &mut results);

--- a/stack-graphs/tests/it/can_find_partial_paths_in_file.rs
+++ b/stack-graphs/tests/it/can_find_partial_paths_in_file.rs
@@ -10,6 +10,7 @@ use std::collections::BTreeSet;
 use pretty_assertions::assert_eq;
 use stack_graphs::graph::StackGraph;
 use stack_graphs::partial::PartialPaths;
+use stack_graphs::stitching::ForwardPartialPathStitcher;
 use stack_graphs::NoCancellation;
 
 use crate::test_graphs;
@@ -18,16 +19,16 @@ fn check_partial_paths_in_file(graph: &StackGraph, file: &str, expected_paths: &
     let file = graph.get_file(file).expect("Missing file");
     let mut partials = PartialPaths::new();
     let mut results = BTreeSet::new();
-    partials
-        .find_minimal_partial_path_set_in_file(
-            graph,
-            file,
-            &NoCancellation,
-            |graph, partials, path| {
-                results.insert(path.display(graph, partials).to_string());
-            },
-        )
-        .expect("should never be cancelled");
+    ForwardPartialPathStitcher::find_minimal_partial_path_set_in_file(
+        graph,
+        &mut partials,
+        file,
+        &NoCancellation,
+        |graph, partials, path| {
+            results.insert(path.display(graph, partials).to_string());
+        },
+    )
+    .expect("should never be cancelled");
     let expected_paths = expected_paths
         .iter()
         .map(|s| s.to_string())

--- a/stack-graphs/tests/it/can_find_root_partial_paths_in_database.rs
+++ b/stack-graphs/tests/it/can_find_root_partial_paths_in_database.rs
@@ -16,6 +16,7 @@ use stack_graphs::partial::PartialPaths;
 use stack_graphs::partial::PartialScopedSymbol;
 use stack_graphs::partial::PartialSymbolStack;
 use stack_graphs::stitching::Database;
+use stack_graphs::stitching::ForwardPartialPathStitcher;
 use stack_graphs::stitching::SymbolStackKey;
 use stack_graphs::NoCancellation;
 
@@ -30,16 +31,16 @@ fn check_root_partial_paths(
     let file = graph.get_file(file).expect("Missing file");
     let mut partials = PartialPaths::new();
     let mut db = Database::new();
-    partials
-        .find_minimal_partial_path_set_in_file(
-            graph,
-            file,
-            &NoCancellation,
-            |graph, partials, path| {
-                db.add_partial_path(graph, partials, path);
-            },
-        )
-        .expect("should never be cancelled");
+    ForwardPartialPathStitcher::find_minimal_partial_path_set_in_file(
+        graph,
+        &mut partials,
+        file,
+        &NoCancellation,
+        |graph, partials, path| {
+            db.add_partial_path(graph, partials, path.clone());
+        },
+    )
+    .expect("should never be cancelled");
 
     let mut symbol_stack = PartialSymbolStack::empty();
     for symbol in precondition.iter().rev() {

--- a/stack-graphs/tests/it/can_jump_to_definition.rs
+++ b/stack-graphs/tests/it/can_jump_to_definition.rs
@@ -10,6 +10,7 @@ use std::collections::BTreeSet;
 use pretty_assertions::assert_eq;
 use stack_graphs::graph::StackGraph;
 use stack_graphs::partial::PartialPaths;
+use stack_graphs::stitching::{ForwardPartialPathStitcher, GraphEdges};
 use stack_graphs::NoCancellation;
 
 use crate::test_graphs;
@@ -20,11 +21,17 @@ fn check_jump_to_definition(graph: &StackGraph, expected_paths: &[&str]) {
     let references = graph
         .iter_nodes()
         .filter(|handle| graph[*handle].is_reference());
-    paths
-        .find_all_complete_paths(graph, references, &NoCancellation, |graph, paths, path| {
+    ForwardPartialPathStitcher::find_all_complete_partial_paths(
+        graph,
+        &mut paths,
+        &mut GraphEdges(None),
+        references,
+        &NoCancellation,
+        |graph, paths, path| {
             results.insert(path.display(graph, paths).to_string());
-        })
-        .expect("should never be cancelled");
+        },
+    )
+    .expect("should never be cancelled");
     let expected_paths = expected_paths
         .iter()
         .map(|s| s.to_string())

--- a/stack-graphs/tests/it/can_jump_to_definition_with_forward_partial_path_stitching.rs
+++ b/stack-graphs/tests/it/can_jump_to_definition_with_forward_partial_path_stitching.rs
@@ -8,9 +8,7 @@
 use std::collections::BTreeSet;
 
 use pretty_assertions::assert_eq;
-use stack_graphs::arena::Handle;
 use stack_graphs::graph::StackGraph;
-use stack_graphs::partial::PartialPath;
 use stack_graphs::partial::PartialPaths;
 use stack_graphs::stitching::Database;
 use stack_graphs::stitching::ForwardPartialPathStitcher;
@@ -24,23 +22,23 @@ fn check_jump_to_definition(graph: &StackGraph, expected_partial_paths: &[&str])
 
     // Generate partial paths for everything in the database.
     for file in graph.iter_files() {
-        partials
-            .find_minimal_partial_path_set_in_file(
-                graph,
-                file,
-                &NoCancellation,
-                |graph, partials, path| {
-                    db.add_partial_path(graph, partials, path);
-                },
-            )
-            .expect("should never be cancelled");
+        ForwardPartialPathStitcher::find_minimal_partial_path_set_in_file(
+            graph,
+            &mut partials,
+            file,
+            &NoCancellation,
+            |graph, partials, path| {
+                db.add_partial_path(graph, partials, path.clone());
+            },
+        )
+        .expect("should never be cancelled");
     }
 
     let references = graph
         .iter_nodes()
         .filter(|handle| graph[*handle].is_reference());
     let mut complete_partial_paths = Vec::new();
-    ForwardPartialPathStitcher::<Handle<PartialPath>>::find_all_complete_partial_paths(
+    ForwardPartialPathStitcher::find_all_complete_partial_paths(
         graph,
         &mut partials,
         &mut db,

--- a/stack-graphs/tests/it/can_jump_to_definition_with_forward_partial_path_stitching.rs
+++ b/stack-graphs/tests/it/can_jump_to_definition_with_forward_partial_path_stitching.rs
@@ -8,7 +8,9 @@
 use std::collections::BTreeSet;
 
 use pretty_assertions::assert_eq;
+use stack_graphs::arena::Handle;
 use stack_graphs::graph::StackGraph;
+use stack_graphs::partial::PartialPath;
 use stack_graphs::partial::PartialPaths;
 use stack_graphs::stitching::Database;
 use stack_graphs::stitching::ForwardPartialPathStitcher;
@@ -38,7 +40,7 @@ fn check_jump_to_definition(graph: &StackGraph, expected_partial_paths: &[&str])
         .iter_nodes()
         .filter(|handle| graph[*handle].is_reference());
     let mut complete_partial_paths = Vec::new();
-    ForwardPartialPathStitcher::find_all_complete_partial_paths(
+    ForwardPartialPathStitcher::<Handle<PartialPath>>::find_all_complete_partial_paths(
         graph,
         &mut partials,
         &mut db,

--- a/stack-graphs/tests/it/cycles.rs
+++ b/stack-graphs/tests/it/cycles.rs
@@ -224,7 +224,7 @@ fn stitching_simple_identity_cycle_is_detected() {
     // test partial path cycle detector
     {
         let mut paths = Appendables::new();
-        let mut cd: AppendingCycleDetector<OwnedOrDatabasePath> =
+        let mut cd: AppendingCycleDetector<Database, OwnedOrDatabasePath> =
             AppendingCycleDetector::from(&mut paths, p0.into());
         cd.append(&mut paths, p1.into());
         assert_eq!(
@@ -320,7 +320,7 @@ fn stitching_composite_identity_cycle_is_detected() {
     // test joining cycle detector
     {
         let mut paths = Appendables::new();
-        let mut cd: AppendingCycleDetector<OwnedOrDatabasePath> =
+        let mut cd: AppendingCycleDetector<Database, OwnedOrDatabasePath> =
             AppendingCycleDetector::from(&mut paths, p0.into());
         cd.append(&mut paths, p1.into());
         assert_eq!(

--- a/stack-graphs/tests/it/cycles.rs
+++ b/stack-graphs/tests/it/cycles.rs
@@ -14,6 +14,7 @@ use stack_graphs::partial::Cyclicity;
 use stack_graphs::partial::PartialPath;
 use stack_graphs::partial::PartialPaths;
 use stack_graphs::stitching::Database;
+use stack_graphs::stitching::GraphEdges;
 use stack_graphs::CancelAfterDuration;
 use std::time::Duration;
 
@@ -169,7 +170,7 @@ fn finding_simple_identity_cycle_is_detected() {
     {
         let mut edges = Appendables::new();
         let mut cd = AppendingCycleDetector::new();
-        let ctx = &mut ();
+        let db = &GraphEdges(None);
 
         for edge in &[
             edge(r, foo_ref, 0),
@@ -178,15 +179,14 @@ fn finding_simple_identity_cycle_is_detected() {
         ] {
             cd.append(&mut edges, *edge);
             assert!(cd
-                .is_cyclic(&graph, &mut partials, ctx, &mut edges)
+                .is_cyclic(&graph, &mut partials, db, &mut edges)
                 .unwrap()
                 .is_empty());
         }
         cd.append(&mut edges, edge(foo_def, r, 0));
         assert_eq!(
             enum_set![Cyclicity::StrengthensPostcondition],
-            cd.is_cyclic(&graph, &mut partials, ctx, &mut edges)
-                .unwrap()
+            cd.is_cyclic(&graph, &mut partials, db, &mut edges).unwrap()
         );
     }
 
@@ -259,7 +259,7 @@ fn finding_composite_identity_cycle_is_detected() {
     {
         let mut edges = Appendables::new();
         let mut cd = AppendingCycleDetector::new();
-        let ctx = &mut ();
+        let db = &GraphEdges(None);
         for edge in &[
             edge(r, s, 0),
             edge(r, s, 0),
@@ -271,15 +271,14 @@ fn finding_composite_identity_cycle_is_detected() {
         ] {
             cd.append(&mut edges, *edge);
             assert!(cd
-                .is_cyclic(&graph, &mut partials, ctx, &mut edges)
+                .is_cyclic(&graph, &mut partials, db, &mut edges)
                 .unwrap()
                 .is_empty());
         }
         cd.append(&mut edges, edge(bar_ref, s, 0));
         assert_eq!(
             enum_set![Cyclicity::StrengthensPostcondition],
-            cd.is_cyclic(&graph, &mut partials, ctx, &mut edges)
-                .unwrap()
+            cd.is_cyclic(&graph, &mut partials, db, &mut edges).unwrap()
         );
     }
 

--- a/stack-graphs/tests/it/cycles.rs
+++ b/stack-graphs/tests/it/cycles.rs
@@ -14,6 +14,7 @@ use stack_graphs::partial::Cyclicity;
 use stack_graphs::partial::PartialPath;
 use stack_graphs::partial::PartialPaths;
 use stack_graphs::stitching::Database;
+use stack_graphs::stitching::ForwardPartialPathStitcher;
 use stack_graphs::stitching::GraphEdges;
 use stack_graphs::CancelAfterDuration;
 use std::time::Duration;
@@ -194,8 +195,9 @@ fn finding_simple_identity_cycle_is_detected() {
     {
         let mut path_count = 0usize;
         let cancellation_flag = CancelAfterDuration::new(TEST_TIMEOUT);
-        let result = partials.find_minimal_partial_path_set_in_file(
+        let result = ForwardPartialPathStitcher::find_minimal_partial_path_set_in_file(
             &graph,
+            &mut partials,
             file,
             &cancellation_flag,
             |_, _, _| path_count += 1,
@@ -286,8 +288,9 @@ fn finding_composite_identity_cycle_is_detected() {
     {
         let mut path_count = 0usize;
         let cancellation_flag = CancelAfterDuration::new(TEST_TIMEOUT);
-        let result = partials.find_minimal_partial_path_set_in_file(
+        let result = ForwardPartialPathStitcher::find_minimal_partial_path_set_in_file(
             &graph,
+            &mut partials,
             file,
             &cancellation_flag,
             |_, _, _| path_count += 1,
@@ -346,8 +349,9 @@ fn appending_eliminating_cycle_terminates() {
     {
         let mut path_count = 0usize;
         let cancellation_flag = CancelAfterDuration::new(TEST_TIMEOUT);
-        let result = partials.find_minimal_partial_path_set_in_file(
+        let result = ForwardPartialPathStitcher::find_minimal_partial_path_set_in_file(
             &graph,
+            &mut partials,
             file,
             &cancellation_flag,
             |_, _, _| path_count += 1,

--- a/stack-graphs/tests/it/cycles.rs
+++ b/stack-graphs/tests/it/cycles.rs
@@ -6,13 +6,14 @@
 // ------------------------------------------------------------------------------------------------
 
 use enumset::enum_set;
+use stack_graphs::arena::Handle;
 use stack_graphs::cycles::Appendables;
 use stack_graphs::cycles::AppendingCycleDetector;
 use stack_graphs::graph::StackGraph;
 use stack_graphs::partial::Cyclicity;
+use stack_graphs::partial::PartialPath;
 use stack_graphs::partial::PartialPaths;
 use stack_graphs::stitching::Database;
-use stack_graphs::stitching::OwnedOrDatabasePath;
 use stack_graphs::CancelAfterDuration;
 use std::time::Duration;
 
@@ -224,8 +225,8 @@ fn stitching_simple_identity_cycle_is_detected() {
     // test partial path cycle detector
     {
         let mut paths = Appendables::new();
-        let mut cd: AppendingCycleDetector<Database, OwnedOrDatabasePath> =
-            AppendingCycleDetector::from(&mut paths, p0.into());
+        let mut cd: AppendingCycleDetector<Handle<PartialPath>> =
+            AppendingCycleDetector::from(&mut paths, db[p0].clone());
         cd.append(&mut paths, p1.into());
         assert_eq!(
             enum_set![Cyclicity::StrengthensPostcondition],
@@ -320,8 +321,8 @@ fn stitching_composite_identity_cycle_is_detected() {
     // test joining cycle detector
     {
         let mut paths = Appendables::new();
-        let mut cd: AppendingCycleDetector<Database, OwnedOrDatabasePath> =
-            AppendingCycleDetector::from(&mut paths, p0.into());
+        let mut cd: AppendingCycleDetector<Handle<PartialPath>> =
+            AppendingCycleDetector::from(&mut paths, db[p0].clone());
         cd.append(&mut paths, p1.into());
         assert_eq!(
             enum_set![Cyclicity::StrengthensPostcondition],

--- a/stack-graphs/tests/it/partial.rs
+++ b/stack-graphs/tests/it/partial.rs
@@ -238,6 +238,9 @@ fn can_unify_partial_symbol_stacks() -> Result<(), PathResolutionError> {
         "{}",
     )?;
 
+    verify_not((&[a], var1), (&[], var1))?;
+    verify_not((&[], var1), (&[a], var1))?;
+
     let dot = (".", None);
     let b = ("b", None);
 
@@ -429,6 +432,9 @@ fn can_unify_partial_scope_stacks() -> Result<(), PathResolutionError> {
         "[file(10)],$1",
         "{$2 => ($1)}",
     )?;
+
+    verify_not((&[10], var1), (&[], var1))?;
+    verify_not((&[], var1), (&[10], var1))?;
 
     Ok(())
 }

--- a/stack-graphs/tests/it/util.rs
+++ b/stack-graphs/tests/it/util.rs
@@ -25,6 +25,7 @@ pub(crate) type NiceSymbolStack<'a> = (&'a [NiceScopedSymbol<'a>], Option<Symbol
 pub(crate) type NiceScopedSymbol<'a> = (&'a str, Option<NiceScopeStack<'a>>);
 pub(crate) type NiceScopeStack<'a> = (&'a [u32], Option<ScopeStackVariable>);
 pub(crate) type NicePartialPath<'a> = &'a [Handle<Node>];
+pub(crate) type NiceEdge = (Handle<Node>, Handle<Node>);
 
 pub(crate) fn create_drop_scopes_node(graph: &mut StackGraph, file: Handle<File>) -> Handle<Node> {
     let id = graph.new_node_id(file);
@@ -162,6 +163,12 @@ pub(crate) fn create_partial_path_and_edges(
     }
 
     Ok(path)
+}
+
+pub(crate) fn create_edge(graph: &mut StackGraph, contents: NiceEdge) -> Edge {
+    let edge = edge(contents.0, contents.1, 0);
+    graph.add_edge(edge.source, edge.sink, edge.precedence);
+    edge
 }
 
 pub(crate) fn edge(source: Handle<Node>, sink: Handle<Node>, precedence: i32) -> Edge {

--- a/tree-sitter-stack-graphs/src/cli/index.rs
+++ b/tree-sitter-stack-graphs/src/cli/index.rs
@@ -11,6 +11,7 @@ use stack_graphs::arena::Handle;
 use stack_graphs::graph::File;
 use stack_graphs::graph::StackGraph;
 use stack_graphs::partial::PartialPaths;
+use stack_graphs::stitching::ForwardPartialPathStitcher;
 use stack_graphs::storage::FileStatus;
 use stack_graphs::storage::SQLiteWriter;
 use std::collections::HashMap;
@@ -306,12 +307,13 @@ impl<'a> Indexer<'a> {
 
         let mut partials = PartialPaths::new();
         let mut paths = Vec::new();
-        match partials.find_minimal_partial_path_set_in_file(
+        match ForwardPartialPathStitcher::find_minimal_partial_path_set_in_file(
             &graph,
+            &mut partials,
             file,
             &(&cancellation_flag as &dyn CancellationFlag),
             |_g, _ps, p| {
-                paths.push(p);
+                paths.push(p.clone());
             },
         ) {
             Ok(_) => {}

--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -13,6 +13,7 @@ use itertools::Itertools;
 use stack_graphs::arena::Handle;
 use stack_graphs::graph::File;
 use stack_graphs::graph::StackGraph;
+use stack_graphs::partial::PartialPath;
 use stack_graphs::partial::PartialPaths;
 use stack_graphs::serde::Filter;
 use stack_graphs::stitching::Database;
@@ -446,7 +447,7 @@ impl TestArgs {
             .filter(|n| filter.include_node(graph, n))
             .collect::<Vec<_>>();
         let mut paths = Vec::new();
-        ForwardPartialPathStitcher::find_all_complete_partial_paths(
+        ForwardPartialPathStitcher::<Handle<PartialPath>>::find_all_complete_partial_paths(
             graph,
             partials,
             db,

--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -13,7 +13,6 @@ use itertools::Itertools;
 use stack_graphs::arena::Handle;
 use stack_graphs::graph::File;
 use stack_graphs::graph::StackGraph;
-use stack_graphs::partial::PartialPath;
 use stack_graphs::partial::PartialPaths;
 use stack_graphs::serde::Filter;
 use stack_graphs::stitching::Database;
@@ -304,12 +303,13 @@ impl TestArgs {
         let mut partials = PartialPaths::new();
         let mut db = Database::new();
         for file in test.graph.iter_files() {
-            partials.find_minimal_partial_path_set_in_file(
+            ForwardPartialPathStitcher::find_minimal_partial_path_set_in_file(
                 &test.graph,
+                &mut partials,
                 file,
                 &cancellation_flag.as_ref(),
                 |g, ps, p| {
-                    db.add_partial_path(g, ps, p);
+                    db.add_partial_path(g, ps, p.clone());
                 },
             )?;
         }
@@ -447,7 +447,7 @@ impl TestArgs {
             .filter(|n| filter.include_node(graph, n))
             .collect::<Vec<_>>();
         let mut paths = Vec::new();
-        ForwardPartialPathStitcher::<Handle<PartialPath>>::find_all_complete_partial_paths(
+        ForwardPartialPathStitcher::find_all_complete_partial_paths(
             graph,
             partials,
             db,

--- a/tree-sitter-stack-graphs/tests/it/test.rs
+++ b/tree-sitter-stack-graphs/tests/it/test.rs
@@ -12,6 +12,7 @@ use stack_graphs::graph::File;
 use stack_graphs::graph::StackGraph;
 use stack_graphs::partial::PartialPaths;
 use stack_graphs::stitching::Database;
+use stack_graphs::stitching::ForwardPartialPathStitcher;
 use std::path::Path;
 use std::path::PathBuf;
 use tree_sitter_graph::Variables;
@@ -108,16 +109,16 @@ fn check_test(
     let mut partials = PartialPaths::new();
     let mut db = Database::new();
     for fragment in &test.fragments {
-        partials
-            .find_minimal_partial_path_set_in_file(
-                &test.graph,
-                fragment.file,
-                &stack_graphs::NoCancellation,
-                |graph, partials, path| {
-                    db.add_partial_path(graph, partials, path);
-                },
-            )
-            .expect("should nopt be cancelled");
+        ForwardPartialPathStitcher::find_minimal_partial_path_set_in_file(
+            &test.graph,
+            &mut partials,
+            fragment.file,
+            &stack_graphs::NoCancellation,
+            |graph, partials, path| {
+                db.add_partial_path(graph, partials, path.clone());
+            },
+        )
+        .expect("should nopt be cancelled");
     }
 
     let results = test


### PR DESCRIPTION
Path finding (`PartialPath::find_minimal_path_set`) and path stitching (`ForwardPartialPathSticher::find_all_complete_partial_paths`) have very similar structures, only they append edges and partial paths respectively.  This PR aims to unify these two implementations to get something that is easier to maintain, and allows more flexibility and how path building is set up.

## Implementation

- The `Appendable<Ctx>` trait dealt with two concerns: (1) abstracting over things that could be appended to a partial path, and (2) keep track of the context where we could convert handles into these things. In the new setup, `Appendable` only deals with (1), while a new `ToAppendable` trait is responsible for (2).
- The `ForwardPartialPathStitcher` is now abstract in the database and the concrete appendable that is used to build the path. A `GraphEdges` type works as a marker to indicate that the graph's edges are to be used as the database.

## Performance

Memory usage has decreased a little for the benchmark compared to `main`.