### PR TITLE
Store messagepack values in database instead of JSON

### DIFF
--- a/stack-graphs/CHANGELOG.md
+++ b/stack-graphs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `Appendable` trait has been simplified. Its `Ctx` type parameter is gone, in favor of a separate trait `ToAppendable` that is used to find appendables for a handle. The type itself moved from the `cycles` to the `stitching` module.
 - The `ForwardPartialPathStitcher` has been generalized so that it can be used to build paths from a database or from graph edges. It now takes a type parameter indicating the type of candidates it uses. Instead of a `Database` instance, it expects a value that implements the `Candidates` and `ToAppendable` traits. The `ForwardPartialPathStitcher::process_next_phase` expects an additional `extend_until` closure that controls whether the extended paths are considered for further extension or not (using `|_,_,_| true` retains old behavior).
+- The SQLite database implementation is using a new schema which stores binary instead of JSON values, resulting in faster write times and smaller databases.
 
 ### Fixed
 

--- a/stack-graphs/Cargo.toml
+++ b/stack-graphs/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 [features]
 copious-debugging = []
 serde = ["dep:serde", "lsp-positions/serde"]
-storage = ["rusqlite", "serde"]
+storage = ["rusqlite", "serde", "rmp-serde"]
 visualization = ["serde", "serde_json"]
 
 [lib]
@@ -30,19 +30,20 @@ enumset = "1.0"
 fxhash = "0.2"
 itertools = "0.10"
 libc = "0.2"
-lsp-positions = { version="0.3", path="../lsp-positions" }
-rusqlite = { version = "0.28", optional=true, features = ["bundled", "functions"] }
-serde = { version="1.0", optional=true, features = ["derive"] }
-serde_json = { version="1.0", optional=true }
-smallvec = { version="1.6", features=["union"] }
-thiserror = { version="1.0" }
+lsp-positions = { version = "0.3", path = "../lsp-positions" }
+rmp-serde = { version = "1.1", optional = true }
+rusqlite = { version = "0.28", optional = true, features = ["bundled", "functions"] }
+serde = { version = "1.0", optional = true, features = ["derive"] }
+serde_json = { version = "1.0", optional = true }
+smallvec = { version = "1.6", features = ["union"] }
+thiserror = { version = "1.0" }
 
 [dev-dependencies]
 assert-json-diff = "2"
 itertools = "0.10"
 maplit = "1.0"
 pretty_assertions = "0.7"
-serde_json = { version="1.0" }
+serde_json = { version = "1.0" }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Database access (particularly writing, it seems) is fairly slow. Currently the database is populated with JSON objects, which are pretty verbose. This PR changes that to use messagepack values, which are binary and optimized for small size, if I understand things correctly.

A rough comparison of index times shows a speedup of almost 2x for some files and a database size reduction of almost 3x. The time reduction is more pronounced for smaller files, probably because more of the index work is writing the data, compared to computing it.
