### PR TITLE
Make TsConfigAnalyzer more resilient against invalid path mappings

### DIFF
--- a/languages/tree-sitter-stack-graphs-typescript/test/projects/invalid-paths-mappings.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/projects/invalid-paths-mappings.ts
@@ -1,0 +1,11 @@
+/* --- path: ./tsconfig.json --- */
+{
+    "compilerOptions": {
+        "paths": {
+            ".": ["."],
+            "a/": ["b/"],
+            "c/*": ["d"],
+            "e": ["f/*"],
+        }
+    }
+}


### PR DESCRIPTION
The `TsConfigAnalyzer` would panic on certain invalid path mappings. This PR makes the analyzer more resilient, and adds a test to check that these cases do not cause panics anymore.
