### PR TITLE
Improve SQLite storage

### DIFF
--- a/stack-graphs/CHANGELOG.md
+++ b/stack-graphs/CHANGELOG.md
@@ -10,12 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - New `SQLiteReader::clear` and `SQLiteReader::clear_paths` methods that make it easier to reuse instances.
+- The method `SQLiteReader::load_graph_for_file` now returns the file handle for the loaded file.
 
 ### Changed
 
 - The `Appendable` trait has been simplified. Its `Ctx` type parameter is gone, in favor of a separate trait `ToAppendable` that is used to find appendables for a handle. The type itself moved from the `cycles` to the `stitching` module.
 - The `ForwardPartialPathStitcher` has been generalized so that it can be used to build paths from a database or from graph edges. It now takes a type parameter indicating the type of candidates it uses. Instead of a `Database` instance, it expects a value that implements the `Candidates` and `ToAppendable` traits. The `ForwardPartialPathStitcher::process_next_phase` expects an additional `extend_until` closure that controls whether the extended paths are considered for further extension or not (using `|_,_,_| true` retains old behavior).
 - The SQLite database implementation is using a new schema which stores binary instead of JSON values, resulting in faster write times and smaller databases.
+- Renamed method `SQLiteReader::load_graph_for_file_or_directory` to `SQLiteReader::load_graphs_for_file_or_directory`.
 
 ### Fixed
 

--- a/stack-graphs/CHANGELOG.md
+++ b/stack-graphs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- New `SQLiteReader::clear` and `SQLiteReader::clear_paths` methods that make it easier to reuse instances.
+
 ### Changed
 
 - The `Appendable` trait has been simplified. Its `Ctx` type parameter is gone, in favor of a separate trait `ToAppendable` that is used to find appendables for a handle. The type itself moved from the `cycles` to the `stitching` module.

--- a/stack-graphs/src/arena.rs
+++ b/stack-graphs/src/arena.rs
@@ -181,6 +181,13 @@ impl<T> Arena<T> {
         }
     }
 
+    /// Clear the arena, keeping underlying allocated capacity.  After this, all previous handles into
+    /// the arena are invalid.
+    #[inline(always)]
+    pub(crate) fn clear(&mut self) {
+        self.items.clear();
+    }
+
     /// Adds a new instance to this arena, returning a stable handle to it.
     ///
     /// Note that we do not deduplicate instances of `T` in any way.  If you add two instances that
@@ -278,6 +285,13 @@ impl<H, T> SupplementalArena<H, T> {
             items: vec![MaybeUninit::uninit()],
             _phantom: PhantomData,
         }
+    }
+
+    /// Clear the supplemantal arena, keeping underlying allocated capacity.  After this,
+    /// all previous handles into the arena are invalid.
+    #[inline(always)]
+    pub(crate) fn clear(&mut self) {
+        self.items.clear();
     }
 
     /// Creates a new, empty supplemental arena, preallocating enough space to store supplemental

--- a/stack-graphs/src/arena.rs
+++ b/stack-graphs/src/arena.rs
@@ -183,6 +183,7 @@ impl<T> Arena<T> {
 
     /// Clear the arena, keeping underlying allocated capacity.  After this, all previous handles into
     /// the arena are invalid.
+    #[cfg_attr(not(feature = "storage"), allow(dead_code))]
     #[inline(always)]
     pub(crate) fn clear(&mut self) {
         self.items.clear();
@@ -289,6 +290,7 @@ impl<H, T> SupplementalArena<H, T> {
 
     /// Clear the supplemantal arena, keeping underlying allocated capacity.  After this,
     /// all previous handles into the arena are invalid.
+    #[cfg_attr(not(feature = "storage"), allow(dead_code))]
     #[inline(always)]
     pub(crate) fn clear(&mut self) {
         self.items.clear();

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -2625,6 +2625,7 @@ impl PartialPaths {
         }
     }
 
+    #[cfg_attr(not(feature = "storage"), allow(dead_code))]
     pub(crate) fn clear(&mut self) {
         self.partial_symbol_stacks.clear();
         self.partial_scope_stacks.clear();

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -2624,4 +2624,10 @@ impl PartialPaths {
             partial_path_edges: Deque::new_arena(),
         }
     }
+
+    pub(crate) fn clear(&mut self) {
+        self.partial_symbol_stacks.clear();
+        self.partial_scope_stacks.clear();
+        self.partial_path_edges.clear();
+    }
 }

--- a/stack-graphs/src/stitching.rs
+++ b/stack-graphs/src/stitching.rs
@@ -249,6 +249,17 @@ impl Database {
         }
     }
 
+    /// Clear the database.  After this, all previous handles into the database are
+    /// invalid.
+    pub(crate) fn clear(&mut self) {
+        self.partial_paths.clear();
+        self.local_nodes.clear();
+        self.symbol_stack_keys.clear();
+        self.symbol_stack_key_cache.clear();
+        self.paths_by_start_node.clear();
+        self.root_paths_by_precondition.clear();
+    }
+
     /// Adds a partial path to this database.  We do not deduplicate partial paths in any way; it's
     /// your responsibility to only add each partial path once.
     pub fn add_partial_path(

--- a/stack-graphs/src/stitching.rs
+++ b/stack-graphs/src/stitching.rs
@@ -251,6 +251,7 @@ impl Database {
 
     /// Clear the database.  After this, all previous handles into the database are
     /// invalid.
+    #[cfg_attr(not(feature = "storage"), allow(dead_code))]
     pub(crate) fn clear(&mut self) {
         self.partial_paths.clear();
         self.local_nodes.clear();

--- a/stack-graphs/src/storage.rs
+++ b/stack-graphs/src/storage.rs
@@ -447,6 +447,28 @@ impl SQLiteReader {
         })
     }
 
+    /// Clear all data that has been loaded into this reader instance.
+    /// After this call, all existing handles from this reader are invalid.
+    pub fn clear(&mut self) {
+        self.loaded_graphs.clear();
+        self.graph = StackGraph::new();
+
+        self.loaded_node_paths.clear();
+        self.loaded_root_paths.clear();
+        self.partials.clear();
+        self.db.clear();
+    }
+
+    /// Clear path data that has been loaded into this reader instance.
+    /// After this call, all node handles remain valid, but all path data
+    /// is invalid.
+    pub fn clear_paths(&mut self) {
+        self.loaded_node_paths.clear();
+        self.loaded_root_paths.clear();
+        self.partials.clear();
+        self.db.clear();
+    }
+
     /// Get the file's status in the database. If a tag is provided, it must match or the file
     /// is reported missing.
     pub fn status_for_file<T: AsRef<str>>(

--- a/stack-graphs/src/storage.rs
+++ b/stack-graphs/src/storage.rs
@@ -523,7 +523,7 @@ impl SQLiteReader {
             return Ok(());
         }
         copious_debugging!(" * Load from database");
-        let mut stmt = conn.prepare_cached("SELECT json FROM graphs WHERE file = ?")?;
+        let mut stmt = conn.prepare_cached("SELECT value FROM graphs WHERE file = ?")?;
         let value = stmt.query_row([file], |row| row.get::<_, Vec<u8>>(0))?;
         let file_graph = rmp_serde::from_slice::<serde::StackGraph>(&value)?;
         file_graph.load_into(graph)?;

--- a/stack-graphs/src/storage.rs
+++ b/stack-graphs/src/storage.rs
@@ -283,7 +283,7 @@ impl SQLiteWriter {
             &file.to_string_lossy(),
             tag,
             error,
-            &rmp_serde::to_vec(&graph)?,
+            &rmp_serde::to_vec_named(&graph)?,
         ))?;
         Ok(())
     }
@@ -323,7 +323,7 @@ impl SQLiteWriter {
         let mut stmt =
             conn.prepare_cached("INSERT INTO graphs (file, tag, value) VALUES (?, ?, ?)")?;
         let graph = serde::StackGraph::from_graph_filter(graph, &FileFilter(file));
-        stmt.execute((file_str, tag, &rmp_serde::to_vec(&graph)?))?;
+        stmt.execute((file_str, tag, &rmp_serde::to_vec_named(&graph)?))?;
         Ok(())
     }
 
@@ -364,7 +364,7 @@ impl SQLiteWriter {
                 );
                 let symbol_stack = path.symbol_stack_precondition.storage_key(graph, partials);
                 let path = serde::PartialPath::from_partial_path(graph, partials, path);
-                root_stmt.execute((file_str, symbol_stack, &rmp_serde::to_vec(&path)?))?;
+                root_stmt.execute((file_str, symbol_stack, &rmp_serde::to_vec_named(&path)?))?;
                 root_path_count += 1;
             } else if start_node.is_in_file(file) {
                 copious_debugging!(
@@ -375,7 +375,7 @@ impl SQLiteWriter {
                 node_stmt.execute((
                     file_str,
                     path.start_node.local_id,
-                    &rmp_serde::to_vec(&path)?,
+                    &rmp_serde::to_vec_named(&path)?,
                 ))?;
                 node_path_count += 1;
             } else {

--- a/tree-sitter-stack-graphs/src/cli/visualize.rs
+++ b/tree-sitter-stack-graphs/src/cli/visualize.rs
@@ -45,7 +45,7 @@ impl VisualizeArgs {
         let mut db = SQLiteReader::open(&db_path)?;
         for source_path in &self.source_paths {
             let source_path = source_path.canonicalize()?;
-            db.load_graph_for_file_or_directory(&source_path, cancellation_flag)?;
+            db.load_graphs_for_file_or_directory(&source_path, cancellation_flag)?;
         }
         let (graph, _, _) = db.get();
         let starting_nodes = graph


### PR DESCRIPTION
- Add methods to clear `SQLiteReader` instances
- Fix column name in SQL statement
- Small tweaks to the storage API
- Fix deserialization errors by using a different serialization method
