### PR TITLE
fix: update tree-sitter-stack-graphs-java homepage in manifest

### DIFF
--- a/languages/tree-sitter-stack-graphs-java/Cargo.toml
+++ b/languages/tree-sitter-stack-graphs-java/Cargo.toml
@@ -3,7 +3,7 @@ name = "tree-sitter-stack-graphs-java"
 version = "0.2.0"
 description = "Stack graphs for the Java programming language"
 
-homepage = "https://github.com/github/stack-graphs/tree/main/stack-graphs/languages/tree-sitter-stack-graphs-java"
+homepage = "https://github.com/github/stack-graphs/tree/main/languages/tree-sitter-stack-graphs-java"
 repository = "https://github.com/github/stack-graphs"
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
**PR Summary**:
PR simply updates the homepage of `tree-sitter-stack-graphs-java`. Current location is [broken](https://github.com/github/stack-graphs/tree/main/stack-graphs/languages/tree-sitter-stack-graphs-java). Relevant Crates page can be found [here](https://crates.io/crates/tree-sitter-stack-graphs-java).