### PR TITLE
Storage: Add Indexes for common queries

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,5 @@
 Douglas Creager <dcreager@dcreager.net>
 Hendrik van Antwerpen <hendrikvanantwerpen@github.com>
 Akshay <nerdy@peppe.rs>
+blusk <bluskript@gmail.com>
+William Manley <will@stb-tester.com>

--- a/stack-graphs/src/storage.rs
+++ b/stack-graphs/src/storage.rs
@@ -59,9 +59,9 @@ const SCHEMA: &str = r#"
     "#;
 
 const INDEXES: &str = r#"
-        CREATE INDEX IF NOT EXISTS graph_file_value ON graph(file, value);
-        CREATE INDEX IF NOT EXISTS file_paths_file_local_id_value ON file_paths(file, local_id, value);
-        CREATE INDEX IF NOT EXISTS root_paths_symbol_stack_file_value ON root_paths(symbol_stack, file, value);
+        CREATE INDEX IF NOT EXISTS idx_graphs_file ON graphs(file);
+        CREATE INDEX IF NOT EXISTS idx_file_paths_local_id ON file_paths(file, local_id);
+        CREATE INDEX IF NOT EXISTS idx_root_paths_symbol_stack ON root_paths(symbol_stack);
     "#;
 
 const PRAGMAS: &str = r#"


### PR DESCRIPTION
In #306 it's reported that SQLite is slow.  This adds indexes so lookups will be faster.  The intention is to speed up the bottom 3 queries from https://github.com/github/stack-graphs/issues/306#issuecomment-1665402600 as they are "the ones to focus on".

Specifically this should speed up:

> * Load graph data for a file
>
>         SELECT value FROM graphs WHERE file = ?
>
>   Called many times during path stitching
>
> * Load paths for a file node
>
>         SELECT file,value from file_paths WHERE file = ? AND local_id = ?
>
>   Called many times during path stitching.
>
> * Load paths for root node
>
>         SELECT file, value from root_paths WHERE symbol_stack = ?
>
>   Called many times during path stitching.

If the data that you're fetching is in the index then SQLite won't even bother reading the row proper, just pulling the data streight from the index (good for data locality).  As such I've included not just the columns we're using in the `WHERE` clause, but also the ones from `SELECT` too.

I've not actually tested the performance impact as I'm not familiar with this project (this is more of a drive-by) and don't know what benchmarks to use.  The only testing I've done is `cargo test --features storage`.