### PR TITLE
Fix grammar versions

### DIFF
--- a/languages/tree-sitter-stack-graphs-java/Cargo.toml
+++ b/languages/tree-sitter-stack-graphs-java/Cargo.toml
@@ -37,4 +37,4 @@ harness = false # need to provide own main function to handle running tests
 anyhow = "1.0"
 clap = { version = "4", features = ["derive"] }
 tree-sitter-stack-graphs = { version = "0.7", path = "../../tree-sitter-stack-graphs", features=["cli"] }
-tree-sitter-java = { version = "~0.20.0" }
+tree-sitter-java = { version = "=0.20.0" }

--- a/languages/tree-sitter-stack-graphs-typescript/Cargo.toml
+++ b/languages/tree-sitter-stack-graphs-typescript/Cargo.toml
@@ -34,7 +34,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 stack-graphs = { version = ">=0.11, <=0.12", path = "../../stack-graphs" }
 tree-sitter-stack-graphs = { version = "0.7", path = "../../tree-sitter-stack-graphs" }
-tree-sitter-typescript = "0.20.2"
+tree-sitter-typescript = "=0.20.2"
 tsconfig = "0.1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Tree-sitter grammar versions are not semantic. Therefore, we depend on precise versions and don't allow e.g. a new patch version to break our code.

For example, the latest tree-sitter-typescript release (a patch bump) broke our build because the grammar nodes changed and queries became invalid.
