### PR TITLE
Add support for stitcher configuration

### DIFF
--- a/languages/tree-sitter-stack-graphs-java/Cargo.toml
+++ b/languages/tree-sitter-stack-graphs-java/Cargo.toml
@@ -36,6 +36,5 @@ harness = false # need to provide own main function to handle running tests
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4", features = ["derive"] }
-stack-graphs = { version = "0.12", path = "../../stack-graphs" }
 tree-sitter-stack-graphs = { version = "0.7", path = "../../tree-sitter-stack-graphs", features=["cli"] }
 tree-sitter-java = { version = "=0.20.0" }

--- a/languages/tree-sitter-stack-graphs-java/Cargo.toml
+++ b/languages/tree-sitter-stack-graphs-java/Cargo.toml
@@ -36,5 +36,6 @@ harness = false # need to provide own main function to handle running tests
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4", features = ["derive"] }
+stack-graphs = { version = "0.12", path = "../../stack-graphs" }
 tree-sitter-stack-graphs = { version = "0.7", path = "../../tree-sitter-stack-graphs", features=["cli"] }
 tree-sitter-java = { version = "=0.20.0" }

--- a/languages/tree-sitter-stack-graphs-java/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-java/rust/lib.rs
@@ -1,4 +1,3 @@
-use tree_sitter_stack_graphs::loader::FileAnalyzers;
 use tree_sitter_stack_graphs::loader::LanguageConfiguration;
 use tree_sitter_stack_graphs::loader::LoadError;
 use tree_sitter_stack_graphs::CancellationFlag;
@@ -39,7 +38,6 @@ pub fn try_language_configuration(
             STACK_GRAPHS_BUILTINS_SOURCE,
         )),
         Some(STACK_GRAPHS_BUILTINS_CONFIG),
-        FileAnalyzers::new(),
         cancellation_flag,
     )
 }

--- a/languages/tree-sitter-stack-graphs-java/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-java/rust/lib.rs
@@ -1,7 +1,6 @@
 use tree_sitter_stack_graphs::loader::FileAnalyzers;
 use tree_sitter_stack_graphs::loader::LanguageConfiguration;
 use tree_sitter_stack_graphs::loader::LoadError;
-use tree_sitter_stack_graphs::loader::StitcherConfig;
 use tree_sitter_stack_graphs::CancellationFlag;
 
 /// The stacks graphs tsg path for this language.
@@ -41,9 +40,6 @@ pub fn try_language_configuration(
         )),
         Some(STACK_GRAPHS_BUILTINS_CONFIG),
         FileAnalyzers::new(),
-        StitcherConfig {
-            detect_similar_paths: true,
-        },
         cancellation_flag,
     )
 }

--- a/languages/tree-sitter-stack-graphs-java/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-java/rust/lib.rs
@@ -1,6 +1,7 @@
 use tree_sitter_stack_graphs::loader::FileAnalyzers;
 use tree_sitter_stack_graphs::loader::LanguageConfiguration;
 use tree_sitter_stack_graphs::loader::LoadError;
+use tree_sitter_stack_graphs::loader::StitcherConfig;
 use tree_sitter_stack_graphs::CancellationFlag;
 
 /// The stacks graphs tsg path for this language.
@@ -40,6 +41,9 @@ pub fn try_language_configuration(
         )),
         Some(STACK_GRAPHS_BUILTINS_CONFIG),
         FileAnalyzers::new(),
+        StitcherConfig {
+            detect_similar_paths: true,
+        },
         cancellation_flag,
     )
 }

--- a/languages/tree-sitter-stack-graphs-javascript/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-javascript/rust/lib.rs
@@ -5,7 +5,6 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-use tree_sitter_stack_graphs::loader::FileAnalyzers;
 use tree_sitter_stack_graphs::loader::LanguageConfiguration;
 use tree_sitter_stack_graphs::loader::LoadError;
 use tree_sitter_stack_graphs::CancellationFlag;
@@ -38,7 +37,7 @@ pub fn language_configuration(cancellation_flag: &dyn CancellationFlag) -> Langu
 pub fn try_language_configuration(
     cancellation_flag: &dyn CancellationFlag,
 ) -> Result<LanguageConfiguration, LoadError> {
-    LanguageConfiguration::from_sources(
+    let mut lc = LanguageConfiguration::from_sources(
         tree_sitter_javascript::language(),
         Some(String::from("source.js")),
         None,
@@ -50,7 +49,9 @@ pub fn try_language_configuration(
             STACK_GRAPHS_BUILTINS_SOURCE,
         )),
         Some(STACK_GRAPHS_BUILTINS_CONFIG),
-        FileAnalyzers::new().add("package.json".to_string(), NpmPackageAnalyzer {}),
         cancellation_flag,
-    )
+    )?;
+    lc.special_files
+        .add("package.json".to_string(), NpmPackageAnalyzer {});
+    Ok(lc)
 }

--- a/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
@@ -8,7 +8,6 @@
 use tree_sitter_stack_graphs::loader::FileAnalyzers;
 use tree_sitter_stack_graphs::loader::LanguageConfiguration;
 use tree_sitter_stack_graphs::loader::LoadError;
-use tree_sitter_stack_graphs::loader::StitcherConfig;
 use tree_sitter_stack_graphs::CancellationFlag;
 
 use crate::npm_package::NpmPackageAnalyzer;
@@ -57,7 +56,6 @@ pub fn try_language_configuration(
         FileAnalyzers::new()
             .add("tsconfig.json".to_string(), TsConfigAnalyzer {})
             .add("package.json".to_string(), NpmPackageAnalyzer {}),
-        StitcherConfig::default(),
         cancellation_flag,
     )
 }

--- a/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
@@ -5,7 +5,6 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
-use tree_sitter_stack_graphs::loader::FileAnalyzers;
 use tree_sitter_stack_graphs::loader::LanguageConfiguration;
 use tree_sitter_stack_graphs::loader::LoadError;
 use tree_sitter_stack_graphs::CancellationFlag;
@@ -41,7 +40,7 @@ pub fn language_configuration(cancellation_flag: &dyn CancellationFlag) -> Langu
 pub fn try_language_configuration(
     cancellation_flag: &dyn CancellationFlag,
 ) -> Result<LanguageConfiguration, LoadError> {
-    LanguageConfiguration::from_sources(
+    let mut lc = LanguageConfiguration::from_sources(
         tree_sitter_typescript::language_typescript(),
         Some(String::from("source.ts")),
         None,
@@ -53,9 +52,11 @@ pub fn try_language_configuration(
             STACK_GRAPHS_BUILTINS_SOURCE,
         )),
         Some(STACK_GRAPHS_BUILTINS_CONFIG),
-        FileAnalyzers::new()
-            .add("tsconfig.json".to_string(), TsConfigAnalyzer {})
-            .add("package.json".to_string(), NpmPackageAnalyzer {}),
         cancellation_flag,
-    )
+    )?;
+    lc.special_files
+        .add("tsconfig.json".to_string(), TsConfigAnalyzer {})
+        .add("package.json".to_string(), NpmPackageAnalyzer {});
+    lc.has_similar_paths = false;
+    Ok(lc)
 }

--- a/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
@@ -57,6 +57,6 @@ pub fn try_language_configuration(
     lc.special_files
         .add("tsconfig.json".to_string(), TsConfigAnalyzer {})
         .add("package.json".to_string(), NpmPackageAnalyzer {});
-    lc.has_similar_paths = false;
+    lc.no_similar_paths_in_file = true;
     Ok(lc)
 }

--- a/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
@@ -8,6 +8,7 @@
 use tree_sitter_stack_graphs::loader::FileAnalyzers;
 use tree_sitter_stack_graphs::loader::LanguageConfiguration;
 use tree_sitter_stack_graphs::loader::LoadError;
+use tree_sitter_stack_graphs::loader::StitcherConfig;
 use tree_sitter_stack_graphs::CancellationFlag;
 
 use crate::npm_package::NpmPackageAnalyzer;
@@ -56,6 +57,7 @@ pub fn try_language_configuration(
         FileAnalyzers::new()
             .add("tsconfig.json".to_string(), TsConfigAnalyzer {})
             .add("package.json".to_string(), NpmPackageAnalyzer {}),
+        StitcherConfig::default(),
         cancellation_flag,
     )
 }

--- a/stack-graphs/include/stack-graphs.h
+++ b/stack-graphs/include/stack-graphs.h
@@ -437,6 +437,11 @@ struct sg_partial_path {
     struct sg_partial_path_edge_list edges;
 };
 
+struct sg_stitcher_config {
+    // Enables similar path detection during stiching.
+    bool detect_similar_paths;
+};
+
 // An array of all of the partial paths in a partial path database.  Partial path handles are
 // indices into this array.  There will never be a valid partial path at index 0; a handle with
 // the value 0 represents a missing partial path.
@@ -733,6 +738,7 @@ enum sg_result sg_partial_path_arena_find_partial_paths_in_file(const struct sg_
                                                                 struct sg_partial_path_arena *partials,
                                                                 sg_file_handle file,
                                                                 struct sg_partial_path_list *partial_path_list,
+                                                                struct sg_stitcher_config config,
                                                                 const size_t *cancellation_flag);
 
 // Finds all complete paths reachable from a set of starting nodes, placing the result into the
@@ -748,6 +754,7 @@ enum sg_result sg_partial_path_arena_find_all_complete_paths(const struct sg_sta
                                                              size_t starting_node_count,
                                                              const sg_node_handle *starting_nodes,
                                                              struct sg_partial_path_list *path_list,
+                                                             struct sg_stitcher_config config,
                                                              const size_t *cancellation_flag);
 
 // Returns a reference to the array of partial path data in this partial path database.  The
@@ -805,14 +812,16 @@ struct sg_node_handle_set sg_partial_path_database_local_nodes(const struct sg_p
 struct sg_forward_partial_path_stitcher *sg_forward_partial_path_stitcher_from_nodes(const struct sg_stack_graph *graph,
                                                                                      struct sg_partial_path_arena *partials,
                                                                                      size_t count,
-                                                                                     const sg_node_handle *starting_nodes);
+                                                                                     const sg_node_handle *starting_nodes,
+                                                                                     struct sg_stitcher_config config);
 
 // Creates a new forward partial path stitcher that is "seeded" with a set of initial partial
 // paths.
 struct sg_forward_partial_path_stitcher *sg_forward_partial_path_stitcher_from_partial_paths(const struct sg_stack_graph *graph,
                                                                                              struct sg_partial_path_arena *partials,
                                                                                              size_t count,
-                                                                                             const struct sg_partial_path *initial_partial_paths);
+                                                                                             const struct sg_partial_path *initial_partial_paths,
+                                                                                             struct sg_stitcher_config config);
 
 // Sets whether similar path detection should be enabled during path stitching. Paths are similar
 // if start and end node, and pre- and postconditions are the same. The presence of similar paths

--- a/stack-graphs/include/stack-graphs.h
+++ b/stack-graphs/include/stack-graphs.h
@@ -738,7 +738,7 @@ enum sg_result sg_partial_path_arena_find_partial_paths_in_file(const struct sg_
                                                                 struct sg_partial_path_arena *partials,
                                                                 sg_file_handle file,
                                                                 struct sg_partial_path_list *partial_path_list,
-                                                                struct sg_stitcher_config config,
+                                                                const struct sg_stitcher_config *stitcher_config,
                                                                 const size_t *cancellation_flag);
 
 // Finds all complete paths reachable from a set of starting nodes, placing the result into the
@@ -754,7 +754,7 @@ enum sg_result sg_partial_path_arena_find_all_complete_paths(const struct sg_sta
                                                              size_t starting_node_count,
                                                              const sg_node_handle *starting_nodes,
                                                              struct sg_partial_path_list *path_list,
-                                                             struct sg_stitcher_config config,
+                                                             const struct sg_stitcher_config *stitcher_config,
                                                              const size_t *cancellation_flag);
 
 // Returns a reference to the array of partial path data in this partial path database.  The
@@ -812,16 +812,14 @@ struct sg_node_handle_set sg_partial_path_database_local_nodes(const struct sg_p
 struct sg_forward_partial_path_stitcher *sg_forward_partial_path_stitcher_from_nodes(const struct sg_stack_graph *graph,
                                                                                      struct sg_partial_path_arena *partials,
                                                                                      size_t count,
-                                                                                     const sg_node_handle *starting_nodes,
-                                                                                     struct sg_stitcher_config config);
+                                                                                     const sg_node_handle *starting_nodes);
 
 // Creates a new forward partial path stitcher that is "seeded" with a set of initial partial
 // paths.
 struct sg_forward_partial_path_stitcher *sg_forward_partial_path_stitcher_from_partial_paths(const struct sg_stack_graph *graph,
                                                                                              struct sg_partial_path_arena *partials,
                                                                                              size_t count,
-                                                                                             const struct sg_partial_path *initial_partial_paths,
-                                                                                             struct sg_stitcher_config config);
+                                                                                             const struct sg_partial_path *initial_partial_paths);
 
 // Sets whether similar path detection should be enabled during path stitching. Paths are similar
 // if start and end node, and pre- and postconditions are the same. The presence of similar paths

--- a/stack-graphs/src/assert.rs
+++ b/stack-graphs/src/assert.rs
@@ -20,6 +20,7 @@ use crate::partial::PartialPaths;
 use crate::stitching::Database;
 use crate::stitching::DatabaseCandidates;
 use crate::stitching::ForwardPartialPathStitcher;
+use crate::stitching::StitcherConfig;
 use crate::CancellationError;
 use crate::CancellationFlag;
 
@@ -149,12 +150,19 @@ impl Assertion {
         graph: &StackGraph,
         partials: &mut PartialPaths,
         db: &mut Database,
+        stitcher_config: &StitcherConfig,
         cancellation_flag: &dyn CancellationFlag,
     ) -> Result<(), AssertionError> {
         match self {
-            Self::Defined { source, targets } => {
-                self.run_defined(graph, partials, db, source, targets, cancellation_flag)
-            }
+            Self::Defined { source, targets } => self.run_defined(
+                graph,
+                partials,
+                db,
+                source,
+                targets,
+                stitcher_config,
+                cancellation_flag,
+            ),
             Self::Defines { source, symbols } => self.run_defines(graph, source, symbols),
             Self::Refers { source, symbols } => self.run_refers(graph, source, symbols),
         }
@@ -167,6 +175,7 @@ impl Assertion {
         db: &mut Database,
         source: &AssertionSource,
         expected_targets: &Vec<AssertionTarget>,
+        stitcher_config: &StitcherConfig,
         cancellation_flag: &dyn CancellationFlag,
     ) -> Result<(), AssertionError> {
         let references = source.iter_references(graph).collect::<Vec<_>>();
@@ -182,6 +191,7 @@ impl Assertion {
             ForwardPartialPathStitcher::find_all_complete_partial_paths(
                 &mut DatabaseCandidates::new(graph, partials, db),
                 vec![*reference],
+                stitcher_config,
                 cancellation_flag,
                 |_, _, p| {
                     reference_paths.push(p.clone());

--- a/stack-graphs/src/assert.rs
+++ b/stack-graphs/src/assert.rs
@@ -150,7 +150,7 @@ impl Assertion {
         graph: &StackGraph,
         partials: &mut PartialPaths,
         db: &mut Database,
-        stitcher_config: &StitcherConfig,
+        stitcher_config: StitcherConfig,
         cancellation_flag: &dyn CancellationFlag,
     ) -> Result<(), AssertionError> {
         match self {
@@ -175,7 +175,7 @@ impl Assertion {
         db: &mut Database,
         source: &AssertionSource,
         expected_targets: &Vec<AssertionTarget>,
-        stitcher_config: &StitcherConfig,
+        stitcher_config: StitcherConfig,
         cancellation_flag: &dyn CancellationFlag,
     ) -> Result<(), AssertionError> {
         let references = source.iter_references(graph).collect::<Vec<_>>();

--- a/stack-graphs/src/c.rs
+++ b/stack-graphs/src/c.rs
@@ -1408,7 +1408,7 @@ pub struct sg_stitcher_config {
 
 impl Into<StitcherConfig> for sg_stitcher_config {
     fn into(self) -> StitcherConfig {
-        unsafe { std::mem::transmute(self) }
+        StitcherConfig::default().with_detect_similar_paths(self.detect_similar_paths)
     }
 }
 

--- a/stack-graphs/src/stitching.rs
+++ b/stack-graphs/src/stitching.rs
@@ -1246,7 +1246,18 @@ impl<H: Clone> ForwardPartialPathStitcher<H> {
 #[derive(Clone, Copy, Debug)]
 pub struct StitcherConfig {
     /// Enables similar path detection during path stitching.
-    pub detect_similar_paths: bool,
+    detect_similar_paths: bool,
+}
+
+impl StitcherConfig {
+    pub fn detect_similar_paths(&self) -> bool {
+        self.detect_similar_paths
+    }
+
+    pub fn with_detect_similar_paths(mut self, detect_similar_paths: bool) -> Self {
+        self.detect_similar_paths = detect_similar_paths;
+        self
+    }
 }
 
 impl StitcherConfig {

--- a/stack-graphs/src/stitching.rs
+++ b/stack-graphs/src/stitching.rs
@@ -870,6 +870,7 @@ impl<H> ForwardPartialPathStitcher<H> {
             initial_paths: next_iteration.0.len(),
             next_iteration,
             appended_paths,
+            // By default, all paths are checked for similarity
             similar_path_detector: Some(SimilarPathDetector::new()),
             // By default, all nodes are checked for cycles and (if enabled) similarity
             check_only_join_nodes: false,

--- a/stack-graphs/src/stitching.rs
+++ b/stack-graphs/src/stitching.rs
@@ -1242,7 +1242,6 @@ impl<H: Clone> ForwardPartialPathStitcher<H> {
 }
 
 /// Configuration for partial path stitchers.
-#[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub struct StitcherConfig {
     /// Enables similar path detection during path stitching.

--- a/stack-graphs/tests/it/c/can_find_local_nodes.rs
+++ b/stack-graphs/tests/it/c/can_find_local_nodes.rs
@@ -22,6 +22,7 @@ use stack_graphs::c::sg_partial_path_list_free;
 use stack_graphs::c::sg_partial_path_list_new;
 use stack_graphs::c::sg_partial_path_list_paths;
 use stack_graphs::c::sg_stack_graph_nodes;
+use stack_graphs::c::sg_stitcher_config;
 use stack_graphs::graph::Node;
 
 use crate::c::test_graph::TestGraph;
@@ -33,11 +34,15 @@ fn check_local_nodes(graph: &TestGraph, file: &str, expected_local_nodes: &[&str
 
     let partials = sg_partial_path_arena_new();
     let path_list = sg_partial_path_list_new();
+    let config = sg_stitcher_config {
+        detect_similar_paths: false,
+    };
     sg_partial_path_arena_find_partial_paths_in_file(
         graph.graph,
         partials,
         file.as_u32(),
         path_list,
+        config,
         std::ptr::null(),
     );
 

--- a/stack-graphs/tests/it/c/can_find_local_nodes.rs
+++ b/stack-graphs/tests/it/c/can_find_local_nodes.rs
@@ -34,7 +34,7 @@ fn check_local_nodes(graph: &TestGraph, file: &str, expected_local_nodes: &[&str
 
     let partials = sg_partial_path_arena_new();
     let path_list = sg_partial_path_list_new();
-    let config = sg_stitcher_config {
+    let stitcher_config = sg_stitcher_config {
         detect_similar_paths: false,
     };
     sg_partial_path_arena_find_partial_paths_in_file(
@@ -42,7 +42,7 @@ fn check_local_nodes(graph: &TestGraph, file: &str, expected_local_nodes: &[&str
         partials,
         file.as_u32(),
         path_list,
-        config,
+        &stitcher_config,
         std::ptr::null(),
     );
 

--- a/stack-graphs/tests/it/c/can_find_partial_paths_in_file.rs
+++ b/stack-graphs/tests/it/c/can_find_partial_paths_in_file.rs
@@ -78,7 +78,7 @@ fn check_partial_paths_in_file(graph: &TestGraph, file: &str, expected_paths: &[
 
     let partials = sg_partial_path_arena_new();
     let path_list = sg_partial_path_list_new();
-    let config = sg_stitcher_config {
+    let stitcher_config = sg_stitcher_config {
         detect_similar_paths: false,
     };
     sg_partial_path_arena_find_partial_paths_in_file(
@@ -86,7 +86,7 @@ fn check_partial_paths_in_file(graph: &TestGraph, file: &str, expected_paths: &[
         partials,
         file.as_u32(),
         path_list,
-        config,
+        &stitcher_config,
         std::ptr::null(),
     );
 

--- a/stack-graphs/tests/it/c/can_find_partial_paths_in_file.rs
+++ b/stack-graphs/tests/it/c/can_find_partial_paths_in_file.rs
@@ -22,6 +22,7 @@ use stack_graphs::c::sg_partial_path_list_new;
 use stack_graphs::c::sg_partial_path_list_paths;
 use stack_graphs::c::sg_partial_scope_stack;
 use stack_graphs::c::sg_partial_symbol_stack;
+use stack_graphs::c::sg_stitcher_config;
 use stack_graphs::c::SG_LIST_EMPTY_HANDLE;
 use stack_graphs::c::SG_NULL_HANDLE;
 use stack_graphs::partial::PartialPath;
@@ -77,11 +78,15 @@ fn check_partial_paths_in_file(graph: &TestGraph, file: &str, expected_paths: &[
 
     let partials = sg_partial_path_arena_new();
     let path_list = sg_partial_path_list_new();
+    let config = sg_stitcher_config {
+        detect_similar_paths: false,
+    };
     sg_partial_path_arena_find_partial_paths_in_file(
         graph.graph,
         partials,
         file.as_u32(),
         path_list,
+        config,
         std::ptr::null(),
     );
 

--- a/stack-graphs/tests/it/c/can_find_qualified_definitions_with_phased_partial_path_stitching.rs
+++ b/stack-graphs/tests/it/c/can_find_qualified_definitions_with_phased_partial_path_stitching.rs
@@ -56,7 +56,7 @@ impl StorageLayer {
         let rust_graph = unsafe { &(*graph).inner };
         let path_list = sg_partial_path_list_new();
         for file in rust_graph.iter_files() {
-            let config = sg_stitcher_config {
+            let stitcher_config = sg_stitcher_config {
                 detect_similar_paths: false,
             };
             sg_partial_path_arena_find_partial_paths_in_file(
@@ -64,7 +64,7 @@ impl StorageLayer {
                 partials,
                 file.as_u32(),
                 path_list,
-                config,
+                &stitcher_config,
                 std::ptr::null(),
             );
         }
@@ -122,9 +122,6 @@ fn check_find_qualified_definitions(
     let partials = sg_partial_path_arena_new();
     let rust_partials = unsafe { &mut (*partials).inner };
     let db = sg_partial_path_database_new();
-    let config = sg_stitcher_config {
-        detect_similar_paths: false,
-    };
 
     // Create a new external storage layer holding _all_ of the partial paths in the stack graph.
     let mut storage_layer = StorageLayer::new(graph.graph, partials);
@@ -157,7 +154,6 @@ fn check_find_qualified_definitions(
         partials,
         1,
         &initial_partial_path as *const PartialPath as *const _,
-        config,
     );
     sg_forward_partial_path_stitcher_set_max_work_per_phase(stitcher, 1);
     let rust_stitcher = unsafe { &mut *stitcher };

--- a/stack-graphs/tests/it/c/can_find_qualified_definitions_with_phased_partial_path_stitching.rs
+++ b/stack-graphs/tests/it/c/can_find_qualified_definitions_with_phased_partial_path_stitching.rs
@@ -28,6 +28,7 @@ use stack_graphs::c::sg_partial_path_list_free;
 use stack_graphs::c::sg_partial_path_list_new;
 use stack_graphs::c::sg_partial_path_list_paths;
 use stack_graphs::c::sg_stack_graph;
+use stack_graphs::c::sg_stitcher_config;
 use stack_graphs::copious_debugging;
 use stack_graphs::graph::StackGraph;
 use stack_graphs::partial::PartialPath;
@@ -55,11 +56,15 @@ impl StorageLayer {
         let rust_graph = unsafe { &(*graph).inner };
         let path_list = sg_partial_path_list_new();
         for file in rust_graph.iter_files() {
+            let config = sg_stitcher_config {
+                detect_similar_paths: false,
+            };
             sg_partial_path_arena_find_partial_paths_in_file(
                 graph,
                 partials,
                 file.as_u32(),
                 path_list,
+                config,
                 std::ptr::null(),
             );
         }
@@ -117,6 +122,9 @@ fn check_find_qualified_definitions(
     let partials = sg_partial_path_arena_new();
     let rust_partials = unsafe { &mut (*partials).inner };
     let db = sg_partial_path_database_new();
+    let config = sg_stitcher_config {
+        detect_similar_paths: false,
+    };
 
     // Create a new external storage layer holding _all_ of the partial paths in the stack graph.
     let mut storage_layer = StorageLayer::new(graph.graph, partials);
@@ -149,6 +157,7 @@ fn check_find_qualified_definitions(
         partials,
         1,
         &initial_partial_path as *const PartialPath as *const _,
+        config,
     );
     sg_forward_partial_path_stitcher_set_max_work_per_phase(stitcher, 1);
     let rust_stitcher = unsafe { &mut *stitcher };

--- a/stack-graphs/tests/it/c/can_jump_to_definition.rs
+++ b/stack-graphs/tests/it/c/can_jump_to_definition.rs
@@ -29,7 +29,7 @@ fn check_jump_to_definition(graph: &TestGraph, expected_paths: &[&str]) {
         .iter_nodes()
         .filter(|handle| rust_graph[*handle].is_reference())
         .collect::<Vec<_>>();
-    let config = sg_stitcher_config {
+    let stitcher_config = sg_stitcher_config {
         detect_similar_paths: false,
     };
     sg_partial_path_arena_find_all_complete_paths(
@@ -38,7 +38,7 @@ fn check_jump_to_definition(graph: &TestGraph, expected_paths: &[&str]) {
         references.len(),
         references.as_ptr() as *const _,
         path_list,
-        config,
+        &stitcher_config,
         std::ptr::null(),
     );
 

--- a/stack-graphs/tests/it/c/can_jump_to_definition.rs
+++ b/stack-graphs/tests/it/c/can_jump_to_definition.rs
@@ -15,6 +15,7 @@ use stack_graphs::c::sg_partial_path_list_count;
 use stack_graphs::c::sg_partial_path_list_free;
 use stack_graphs::c::sg_partial_path_list_new;
 use stack_graphs::c::sg_partial_path_list_paths;
+use stack_graphs::c::sg_stitcher_config;
 use stack_graphs::partial::PartialPath;
 
 use crate::c::test_graph::TestGraph;
@@ -28,12 +29,16 @@ fn check_jump_to_definition(graph: &TestGraph, expected_paths: &[&str]) {
         .iter_nodes()
         .filter(|handle| rust_graph[*handle].is_reference())
         .collect::<Vec<_>>();
+    let config = sg_stitcher_config {
+        detect_similar_paths: false,
+    };
     sg_partial_path_arena_find_all_complete_paths(
         graph.graph,
         paths,
         references.len(),
         references.as_ptr() as *const _,
         path_list,
+        config,
         std::ptr::null(),
     );
 

--- a/stack-graphs/tests/it/c/can_jump_to_definition_with_phased_partial_path_stitching.rs
+++ b/stack-graphs/tests/it/c/can_jump_to_definition_with_phased_partial_path_stitching.rs
@@ -27,6 +27,7 @@ use stack_graphs::c::sg_partial_path_list_free;
 use stack_graphs::c::sg_partial_path_list_new;
 use stack_graphs::c::sg_partial_path_list_paths;
 use stack_graphs::c::sg_stack_graph;
+use stack_graphs::c::sg_stitcher_config;
 use stack_graphs::copious_debugging;
 use stack_graphs::partial::PartialPath;
 use stack_graphs::partial::PartialScopeStackBindings;
@@ -49,11 +50,15 @@ impl StorageLayer {
         let rust_graph = unsafe { &(*graph).inner };
         let path_list = sg_partial_path_list_new();
         for file in rust_graph.iter_files() {
+            let config = sg_stitcher_config {
+                detect_similar_paths: false,
+            };
             sg_partial_path_arena_find_partial_paths_in_file(
                 graph,
                 partials,
                 file.as_u32(),
                 path_list,
+                config,
                 std::ptr::null(),
             );
         }
@@ -129,11 +134,15 @@ fn check_jump_to_definition(graph: &TestGraph, file: &str, expected_partial_path
     });
 
     // Create the forward partial path stitcher.
+    let config = sg_stitcher_config {
+        detect_similar_paths: false,
+    };
     let stitcher = sg_forward_partial_path_stitcher_from_nodes(
         graph.graph,
         partials,
         references.len(),
         references.as_ptr() as *const _,
+        config,
     );
     sg_forward_partial_path_stitcher_set_max_work_per_phase(stitcher, 1);
     let rust_stitcher = unsafe { &mut *stitcher };

--- a/stack-graphs/tests/it/c/can_jump_to_definition_with_phased_partial_path_stitching.rs
+++ b/stack-graphs/tests/it/c/can_jump_to_definition_with_phased_partial_path_stitching.rs
@@ -50,7 +50,7 @@ impl StorageLayer {
         let rust_graph = unsafe { &(*graph).inner };
         let path_list = sg_partial_path_list_new();
         for file in rust_graph.iter_files() {
-            let config = sg_stitcher_config {
+            let stitcher_config = sg_stitcher_config {
                 detect_similar_paths: false,
             };
             sg_partial_path_arena_find_partial_paths_in_file(
@@ -58,7 +58,7 @@ impl StorageLayer {
                 partials,
                 file.as_u32(),
                 path_list,
-                config,
+                &stitcher_config,
                 std::ptr::null(),
             );
         }
@@ -134,15 +134,11 @@ fn check_jump_to_definition(graph: &TestGraph, file: &str, expected_partial_path
     });
 
     // Create the forward partial path stitcher.
-    let config = sg_stitcher_config {
-        detect_similar_paths: false,
-    };
     let stitcher = sg_forward_partial_path_stitcher_from_nodes(
         graph.graph,
         partials,
         references.len(),
         references.as_ptr() as *const _,
-        config,
     );
     sg_forward_partial_path_stitcher_set_max_work_per_phase(stitcher, 1);
     let rust_stitcher = unsafe { &mut *stitcher };

--- a/stack-graphs/tests/it/can_find_local_nodes.rs
+++ b/stack-graphs/tests/it/can_find_local_nodes.rs
@@ -25,7 +25,7 @@ fn check_local_nodes(graph: &StackGraph, file: &str, expected_local_nodes: &[&st
         graph,
         &mut partials,
         file,
-        &StitcherConfig::default(),
+        StitcherConfig::default(),
         &NoCancellation,
         |graph, partials, path| {
             database.add_partial_path(graph, partials, path.clone());

--- a/stack-graphs/tests/it/can_find_local_nodes.rs
+++ b/stack-graphs/tests/it/can_find_local_nodes.rs
@@ -12,6 +12,7 @@ use stack_graphs::graph::StackGraph;
 use stack_graphs::partial::PartialPaths;
 use stack_graphs::stitching::Database;
 use stack_graphs::stitching::ForwardPartialPathStitcher;
+use stack_graphs::stitching::StitcherConfig;
 use stack_graphs::NoCancellation;
 
 use crate::test_graphs;
@@ -24,6 +25,7 @@ fn check_local_nodes(graph: &StackGraph, file: &str, expected_local_nodes: &[&st
         graph,
         &mut partials,
         file,
+        &StitcherConfig::default(),
         &NoCancellation,
         |graph, partials, path| {
             database.add_partial_path(graph, partials, path.clone());

--- a/stack-graphs/tests/it/can_find_node_partial_paths_in_database.rs
+++ b/stack-graphs/tests/it/can_find_node_partial_paths_in_database.rs
@@ -15,6 +15,7 @@ use stack_graphs::partial::PartialPath;
 use stack_graphs::partial::PartialPaths;
 use stack_graphs::stitching::Database;
 use stack_graphs::stitching::ForwardPartialPathStitcher;
+use stack_graphs::stitching::StitcherConfig;
 use stack_graphs::NoCancellation;
 
 use crate::test_graphs;
@@ -33,6 +34,7 @@ fn check_node_partial_paths(
         graph,
         &mut partials,
         file,
+        &StitcherConfig::default(),
         &NoCancellation,
         |graph, partials, path| {
             db.add_partial_path(graph, partials, path.clone());

--- a/stack-graphs/tests/it/can_find_node_partial_paths_in_database.rs
+++ b/stack-graphs/tests/it/can_find_node_partial_paths_in_database.rs
@@ -34,7 +34,7 @@ fn check_node_partial_paths(
         graph,
         &mut partials,
         file,
-        &StitcherConfig::default(),
+        StitcherConfig::default(),
         &NoCancellation,
         |graph, partials, path| {
             db.add_partial_path(graph, partials, path.clone());

--- a/stack-graphs/tests/it/can_find_partial_paths_in_file.rs
+++ b/stack-graphs/tests/it/can_find_partial_paths_in_file.rs
@@ -23,7 +23,7 @@ fn check_partial_paths_in_file(graph: &StackGraph, file: &str, expected_paths: &
         graph,
         &mut partials,
         file,
-        &StitcherConfig::default(),
+        StitcherConfig::default(),
         &NoCancellation,
         |graph, partials, path| {
             results.insert(path.display(graph, partials).to_string());

--- a/stack-graphs/tests/it/can_find_partial_paths_in_file.rs
+++ b/stack-graphs/tests/it/can_find_partial_paths_in_file.rs
@@ -10,7 +10,7 @@ use std::collections::BTreeSet;
 use pretty_assertions::assert_eq;
 use stack_graphs::graph::StackGraph;
 use stack_graphs::partial::PartialPaths;
-use stack_graphs::stitching::ForwardPartialPathStitcher;
+use stack_graphs::stitching::{ForwardPartialPathStitcher, StitcherConfig};
 use stack_graphs::NoCancellation;
 
 use crate::test_graphs;
@@ -23,6 +23,7 @@ fn check_partial_paths_in_file(graph: &StackGraph, file: &str, expected_paths: &
         graph,
         &mut partials,
         file,
+        &StitcherConfig::default(),
         &NoCancellation,
         |graph, partials, path| {
             results.insert(path.display(graph, partials).to_string());

--- a/stack-graphs/tests/it/can_find_root_partial_paths_in_database.rs
+++ b/stack-graphs/tests/it/can_find_root_partial_paths_in_database.rs
@@ -17,6 +17,7 @@ use stack_graphs::partial::PartialScopedSymbol;
 use stack_graphs::partial::PartialSymbolStack;
 use stack_graphs::stitching::Database;
 use stack_graphs::stitching::ForwardPartialPathStitcher;
+use stack_graphs::stitching::StitcherConfig;
 use stack_graphs::NoCancellation;
 
 use crate::test_graphs;
@@ -34,6 +35,7 @@ fn check_root_partial_paths(
         graph,
         &mut partials,
         file,
+        &StitcherConfig::default(),
         &NoCancellation,
         |graph, partials, path| {
             db.add_partial_path(graph, partials, path.clone());

--- a/stack-graphs/tests/it/can_find_root_partial_paths_in_database.rs
+++ b/stack-graphs/tests/it/can_find_root_partial_paths_in_database.rs
@@ -35,7 +35,7 @@ fn check_root_partial_paths(
         graph,
         &mut partials,
         file,
-        &StitcherConfig::default(),
+        StitcherConfig::default(),
         &NoCancellation,
         |graph, partials, path| {
             db.add_partial_path(graph, partials, path.clone());

--- a/stack-graphs/tests/it/can_jump_to_definition.rs
+++ b/stack-graphs/tests/it/can_jump_to_definition.rs
@@ -12,6 +12,7 @@ use stack_graphs::graph::StackGraph;
 use stack_graphs::partial::PartialPaths;
 use stack_graphs::stitching::ForwardPartialPathStitcher;
 use stack_graphs::stitching::GraphEdgeCandidates;
+use stack_graphs::stitching::StitcherConfig;
 use stack_graphs::NoCancellation;
 
 use crate::test_graphs;
@@ -25,6 +26,7 @@ fn check_jump_to_definition(graph: &StackGraph, expected_paths: &[&str]) {
     ForwardPartialPathStitcher::find_all_complete_partial_paths(
         &mut GraphEdgeCandidates::new(graph, &mut paths, None),
         references,
+        &StitcherConfig::default(),
         &NoCancellation,
         |graph, paths, path| {
             results.insert(path.display(graph, paths).to_string());

--- a/stack-graphs/tests/it/can_jump_to_definition.rs
+++ b/stack-graphs/tests/it/can_jump_to_definition.rs
@@ -26,7 +26,7 @@ fn check_jump_to_definition(graph: &StackGraph, expected_paths: &[&str]) {
     ForwardPartialPathStitcher::find_all_complete_partial_paths(
         &mut GraphEdgeCandidates::new(graph, &mut paths, None),
         references,
-        &StitcherConfig::default(),
+        StitcherConfig::default(),
         &NoCancellation,
         |graph, paths, path| {
             results.insert(path.display(graph, paths).to_string());

--- a/stack-graphs/tests/it/can_jump_to_definition_with_forward_partial_path_stitching.rs
+++ b/stack-graphs/tests/it/can_jump_to_definition_with_forward_partial_path_stitching.rs
@@ -13,6 +13,7 @@ use stack_graphs::partial::PartialPaths;
 use stack_graphs::stitching::Database;
 use stack_graphs::stitching::DatabaseCandidates;
 use stack_graphs::stitching::ForwardPartialPathStitcher;
+use stack_graphs::stitching::StitcherConfig;
 use stack_graphs::NoCancellation;
 
 use crate::test_graphs;
@@ -27,6 +28,7 @@ fn check_jump_to_definition(graph: &StackGraph, expected_partial_paths: &[&str])
             graph,
             &mut partials,
             file,
+            &StitcherConfig::default(),
             &NoCancellation,
             |graph, partials, path| {
                 db.add_partial_path(graph, partials, path.clone());
@@ -42,6 +44,7 @@ fn check_jump_to_definition(graph: &StackGraph, expected_partial_paths: &[&str])
     ForwardPartialPathStitcher::find_all_complete_partial_paths(
         &mut DatabaseCandidates::new(graph, &mut partials, &mut db),
         references,
+        &StitcherConfig::default(),
         &NoCancellation,
         |_, _, p| {
             complete_partial_paths.push(p.clone());

--- a/stack-graphs/tests/it/can_jump_to_definition_with_forward_partial_path_stitching.rs
+++ b/stack-graphs/tests/it/can_jump_to_definition_with_forward_partial_path_stitching.rs
@@ -28,7 +28,7 @@ fn check_jump_to_definition(graph: &StackGraph, expected_partial_paths: &[&str])
             graph,
             &mut partials,
             file,
-            &StitcherConfig::default(),
+            StitcherConfig::default(),
             &NoCancellation,
             |graph, partials, path| {
                 db.add_partial_path(graph, partials, path.clone());
@@ -44,7 +44,7 @@ fn check_jump_to_definition(graph: &StackGraph, expected_partial_paths: &[&str])
     ForwardPartialPathStitcher::find_all_complete_partial_paths(
         &mut DatabaseCandidates::new(graph, &mut partials, &mut db),
         references,
-        &StitcherConfig::default(),
+        StitcherConfig::default(),
         &NoCancellation,
         |_, _, p| {
             complete_partial_paths.push(p.clone());

--- a/stack-graphs/tests/it/cycles.rs
+++ b/stack-graphs/tests/it/cycles.rs
@@ -16,6 +16,7 @@ use stack_graphs::partial::PartialPaths;
 use stack_graphs::stitching::Database;
 use stack_graphs::stitching::ForwardPartialPathStitcher;
 use stack_graphs::stitching::GraphEdges;
+use stack_graphs::stitching::StitcherConfig;
 use stack_graphs::CancelAfterDuration;
 use std::time::Duration;
 
@@ -199,6 +200,7 @@ fn finding_simple_identity_cycle_is_detected() {
             &graph,
             &mut partials,
             file,
+            &StitcherConfig::default(),
             &cancellation_flag,
             |_, _, _| path_count += 1,
         );
@@ -292,6 +294,7 @@ fn finding_composite_identity_cycle_is_detected() {
             &graph,
             &mut partials,
             file,
+            &StitcherConfig::default(),
             &cancellation_flag,
             |_, _, _| path_count += 1,
         );
@@ -353,6 +356,7 @@ fn appending_eliminating_cycle_terminates() {
             &graph,
             &mut partials,
             file,
+            &StitcherConfig::default(),
             &cancellation_flag,
             |_, _, _| path_count += 1,
         );

--- a/stack-graphs/tests/it/cycles.rs
+++ b/stack-graphs/tests/it/cycles.rs
@@ -200,7 +200,7 @@ fn finding_simple_identity_cycle_is_detected() {
             &graph,
             &mut partials,
             file,
-            &StitcherConfig::default(),
+            StitcherConfig::default(),
             &cancellation_flag,
             |_, _, _| path_count += 1,
         );
@@ -294,7 +294,7 @@ fn finding_composite_identity_cycle_is_detected() {
             &graph,
             &mut partials,
             file,
-            &StitcherConfig::default(),
+            StitcherConfig::default(),
             &cancellation_flag,
             |_, _, _| path_count += 1,
         );
@@ -356,7 +356,7 @@ fn appending_eliminating_cycle_terminates() {
             &graph,
             &mut partials,
             file,
-            &StitcherConfig::default(),
+            StitcherConfig::default(),
             &cancellation_flag,
             |_, _, _| path_count += 1,
         );

--- a/stack-graphs/tests/it/serde.rs
+++ b/stack-graphs/tests/it/serde.rs
@@ -984,7 +984,7 @@ fn can_serialize_partial_paths() {
             &graph,
             &mut partials,
             file,
-            &StitcherConfig::default(),
+            StitcherConfig::default(),
             &NoCancellation,
             |g, ps, p| {
                 db.add_partial_path(g, ps, p.clone());

--- a/stack-graphs/tests/it/serde.rs
+++ b/stack-graphs/tests/it/serde.rs
@@ -12,7 +12,7 @@ use stack_graphs::graph;
 use stack_graphs::graph::StackGraph;
 use stack_graphs::partial::PartialPaths;
 use stack_graphs::serde;
-use stack_graphs::stitching::{Database, ForwardPartialPathStitcher};
+use stack_graphs::stitching::{Database, ForwardPartialPathStitcher, StitcherConfig};
 use stack_graphs::NoCancellation;
 
 use crate::test_graphs;
@@ -984,6 +984,7 @@ fn can_serialize_partial_paths() {
             &graph,
             &mut partials,
             file,
+            &StitcherConfig::default(),
             &NoCancellation,
             |g, ps, p| {
                 db.add_partial_path(g, ps, p.clone());

--- a/tree-sitter-stack-graphs/src/cli/index.rs
+++ b/tree-sitter-stack-graphs/src/cli/index.rs
@@ -12,6 +12,7 @@ use stack_graphs::graph::File;
 use stack_graphs::graph::StackGraph;
 use stack_graphs::partial::PartialPaths;
 use stack_graphs::stitching::ForwardPartialPathStitcher;
+use stack_graphs::stitching::StitcherConfig;
 use stack_graphs::storage::FileStatus;
 use stack_graphs::storage::SQLiteWriter;
 use std::collections::HashMap;
@@ -316,16 +317,6 @@ impl<'a> Indexer<'a> {
             .add_file(&source_path.to_string_lossy())
             .expect("file not present in empty graph");
 
-        // FIXME We use the stitching config of the primary language here, which is not quite right.
-        //       Ideally we'd use the primary language's stitcher config for computing the paths in
-        //       the primary graph, and similarly for the secondary languages. However, that is not
-        //       much use at the moment, since we use paths from all languages when reading from the
-        //       database. Fixing this properly requires more isolation of graph and paths per language.
-        let stitcher_config = lcs
-            .primary
-            .map(|lc| lc.stitcher_config.clone())
-            .unwrap_or_default();
-
         let result = Self::build_stack_graph(
             &mut graph,
             file,
@@ -365,7 +356,7 @@ impl<'a> Indexer<'a> {
             &graph,
             &mut partials,
             file,
-            &stitcher_config,
+            StitcherConfig::default(),
             &(&cancellation_flag as &dyn CancellationFlag),
             |_g, _ps, p| {
                 paths.push(p.clone());

--- a/tree-sitter-stack-graphs/src/cli/index.rs
+++ b/tree-sitter-stack-graphs/src/cli/index.rs
@@ -316,6 +316,16 @@ impl<'a> Indexer<'a> {
             .add_file(&source_path.to_string_lossy())
             .expect("file not present in empty graph");
 
+        // FIXME We use the stitching config of the primary language here, which is not quite right.
+        //       Ideally we'd use the primary language's stitcher config for computing the paths in
+        //       the primary graph, and similarly for the secondary languages. However, that is not
+        //       much use at the moment, since we use paths from all languages when reading from the
+        //       database. Fixing this properly requires more isolation of graph and paths per language.
+        let stitcher_config = lcs
+            .primary
+            .map(|lc| lc.stitcher_config.clone())
+            .unwrap_or_default();
+
         let result = Self::build_stack_graph(
             &mut graph,
             file,
@@ -355,6 +365,7 @@ impl<'a> Indexer<'a> {
             &graph,
             &mut partials,
             file,
+            &stitcher_config,
             &(&cancellation_flag as &dyn CancellationFlag),
             |_g, _ps, p| {
                 paths.push(p.clone());

--- a/tree-sitter-stack-graphs/src/cli/index.rs
+++ b/tree-sitter-stack-graphs/src/cli/index.rs
@@ -280,6 +280,8 @@ impl<'a> Indexer<'a> {
             }
             Err(e) => return Err(IndexError::LoadError(e)),
         };
+        let stitcher_config =
+            StitcherConfig::default().with_detect_similar_paths(lcs.has_similar_paths());
 
         let source = file_reader.get(source_path)?;
         let tag = sha1(source);
@@ -356,7 +358,7 @@ impl<'a> Indexer<'a> {
             &graph,
             &mut partials,
             file,
-            StitcherConfig::default(),
+            stitcher_config,
             &(&cancellation_flag as &dyn CancellationFlag),
             |_g, _ps, p| {
                 paths.push(p.clone());

--- a/tree-sitter-stack-graphs/src/cli/index.rs
+++ b/tree-sitter-stack-graphs/src/cli/index.rs
@@ -281,7 +281,7 @@ impl<'a> Indexer<'a> {
             Err(e) => return Err(IndexError::LoadError(e)),
         };
         let stitcher_config =
-            StitcherConfig::default().with_detect_similar_paths(lcs.has_similar_paths());
+            StitcherConfig::default().with_detect_similar_paths(!lcs.no_similar_paths_in_file());
 
         let source = file_reader.get(source_path)?;
         let tag = sha1(source);

--- a/tree-sitter-stack-graphs/src/cli/init.rs
+++ b/tree-sitter-stack-graphs/src/cli/init.rs
@@ -758,8 +758,6 @@ impl ProjectSettings<'_> {
                         STACK_GRAPHS_BUILTINS_SOURCE,
                     )),
                     Some(STACK_GRAPHS_BUILTINS_CONFIG),
-                    FileAnalyzers::new(),
-                    StitcherConfig::default(),
                     cancellation_flag,
                 )
             }}

--- a/tree-sitter-stack-graphs/src/cli/init.rs
+++ b/tree-sitter-stack-graphs/src/cli/init.rs
@@ -721,6 +721,7 @@ impl ProjectSettings<'_> {
             use tree_sitter_stack_graphs::loader::FileAnalyzers;
             use tree_sitter_stack_graphs::loader::LanguageConfiguration;
             use tree_sitter_stack_graphs::loader::LoadError;
+            use tree_sitter_stack_graphs::loader::StitcherConfig;
             use tree_sitter_stack_graphs::CancellationFlag;
 
             /// The stack graphs tsg source for this language.
@@ -758,6 +759,7 @@ impl ProjectSettings<'_> {
                     )),
                     Some(STACK_GRAPHS_BUILTINS_CONFIG),
                     FileAnalyzers::new(),
+                    StitcherConfig::default(),
                     cancellation_flag,
                 )
             }}

--- a/tree-sitter-stack-graphs/src/cli/init.rs
+++ b/tree-sitter-stack-graphs/src/cli/init.rs
@@ -718,10 +718,8 @@ impl ProjectSettings<'_> {
         let mut file = File::create(project_path.join("rust/lib.rs"))?;
         self.write_license_header(&mut file, "// ")?;
         writedoc! {file, r#"
-            use tree_sitter_stack_graphs::loader::FileAnalyzers;
             use tree_sitter_stack_graphs::loader::LanguageConfiguration;
             use tree_sitter_stack_graphs::loader::LoadError;
-            use tree_sitter_stack_graphs::loader::StitcherConfig;
             use tree_sitter_stack_graphs::CancellationFlag;
 
             /// The stack graphs tsg source for this language.

--- a/tree-sitter-stack-graphs/src/cli/query.rs
+++ b/tree-sitter-stack-graphs/src/cli/query.rs
@@ -186,16 +186,10 @@ impl<'a> Querier<'a> {
             };
 
             let mut reference_paths = Vec::new();
-            // FIXME We use the default stitcher config here, because we currently do not retrieve language
-            //       configurations during querying. A first step to fixing this would be to lookup the language
-            //       corresponding to the file that is queried. However, to solve this properly we would need to
-            //       isolate graphs and paths per language so we don't accidently mix different languages that
-            //       require different stitcher settings.
-            let config = StitcherConfig::default();
             if let Err(err) = ForwardPartialPathStitcher::find_all_complete_partial_paths(
                 self.db,
                 std::iter::once(node),
-                &config,
+                StitcherConfig::default(),
                 &cancellation_flag,
                 |_g, _ps, p| {
                     reference_paths.push(p.clone());

--- a/tree-sitter-stack-graphs/src/cli/query.rs
+++ b/tree-sitter-stack-graphs/src/cli/query.rs
@@ -186,10 +186,13 @@ impl<'a> Querier<'a> {
             };
 
             let mut reference_paths = Vec::new();
+            let stitcher_config = StitcherConfig::default()
+                // always detect similar paths, we don't know the language configurations for the data in the database
+                .with_detect_similar_paths(true);
             if let Err(err) = ForwardPartialPathStitcher::find_all_complete_partial_paths(
                 self.db,
                 std::iter::once(node),
-                StitcherConfig::default(),
+                stitcher_config,
                 &cancellation_flag,
                 |_g, _ps, p| {
                     reference_paths.push(p.clone());

--- a/tree-sitter-stack-graphs/src/cli/query.rs
+++ b/tree-sitter-stack-graphs/src/cli/query.rs
@@ -10,6 +10,7 @@ use clap::Parser;
 use clap::Subcommand;
 use clap::ValueHint;
 use stack_graphs::stitching::ForwardPartialPathStitcher;
+use stack_graphs::stitching::StitcherConfig;
 use stack_graphs::storage::FileStatus;
 use stack_graphs::storage::SQLiteReader;
 use std::path::Path;
@@ -185,9 +186,16 @@ impl<'a> Querier<'a> {
             };
 
             let mut reference_paths = Vec::new();
+            // FIXME We use the default stitcher config here, because we currently do not retrieve language
+            //       configurations during querying. A first step to fixing this would be to lookup the language
+            //       corresponding to the file that is queried. However, to solve this properly we would need to
+            //       isolate graphs and paths per language so we don't accidently mix different languages that
+            //       require different stitcher settings.
+            let config = StitcherConfig::default();
             if let Err(err) = ForwardPartialPathStitcher::find_all_complete_partial_paths(
                 self.db,
                 std::iter::once(node),
+                &config,
                 &cancellation_flag,
                 |_g, _ps, p| {
                     reference_paths.push(p.clone());

--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -18,6 +18,7 @@ use stack_graphs::serde::Filter;
 use stack_graphs::stitching::Database;
 use stack_graphs::stitching::DatabaseCandidates;
 use stack_graphs::stitching::ForwardPartialPathStitcher;
+use stack_graphs::stitching::StitcherConfig;
 use std::path::Path;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -331,13 +332,19 @@ impl TestArgs {
                 &test.graph,
                 &mut partials,
                 file,
+                &lc.stitcher_config,
                 &cancellation_flag.as_ref(),
                 |g, ps, p| {
                     db.add_partial_path(g, ps, p.clone());
                 },
             )?;
         }
-        let result = test.run(&mut partials, &mut db, cancellation_flag.as_ref())?;
+        let result = test.run(
+            &mut partials,
+            &mut db,
+            &lc.stitcher_config,
+            cancellation_flag.as_ref(),
+        )?;
         let success = result.failure_count() == 0;
         let outputs = if self.output_mode.test(!success) {
             let files = test.fragments.iter().map(|f| f.file).collect::<Vec<_>>();
@@ -349,6 +356,7 @@ impl TestArgs {
                 &mut db,
                 &|_: &StackGraph, h: &Handle<File>| files.contains(h),
                 success,
+                &lc.stitcher_config,
                 cancellation_flag.as_ref(),
             )?
         } else {
@@ -397,6 +405,7 @@ impl TestArgs {
         db: &mut Database,
         filter: &dyn Filter,
         success: bool,
+        stitcher_config: &StitcherConfig,
         cancellation_flag: &dyn CancellationFlag,
     ) -> anyhow::Result<Vec<String>> {
         let mut outputs = Vec::with_capacity(3);
@@ -425,7 +434,14 @@ impl TestArgs {
         }
 
         let mut db = if save_paths.is_some() || save_visualization.is_some() {
-            self.compute_paths(graph, partials, db, filter, cancellation_flag)?
+            self.compute_paths(
+                graph,
+                partials,
+                db,
+                filter,
+                stitcher_config,
+                cancellation_flag,
+            )?
         } else {
             Database::new()
         };
@@ -474,6 +490,7 @@ impl TestArgs {
         partials: &mut PartialPaths,
         db: &mut Database,
         filter: &dyn Filter,
+        stitcher_config: &StitcherConfig,
         cancellation_flag: &dyn CancellationFlag,
     ) -> anyhow::Result<Database> {
         let references = graph
@@ -484,6 +501,7 @@ impl TestArgs {
         ForwardPartialPathStitcher::find_all_complete_partial_paths(
             &mut DatabaseCandidates::new(graph, partials, db),
             references.clone(),
+            stitcher_config,
             &cancellation_flag,
             |_, _, p| {
                 paths.push(p.clone());

--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -332,7 +332,7 @@ impl TestArgs {
                 &test.graph,
                 &mut partials,
                 file,
-                &lc.stitcher_config,
+                StitcherConfig::default(),
                 &cancellation_flag.as_ref(),
                 |g, ps, p| {
                     db.add_partial_path(g, ps, p.clone());
@@ -342,7 +342,7 @@ impl TestArgs {
         let result = test.run(
             &mut partials,
             &mut db,
-            &lc.stitcher_config,
+            StitcherConfig::default(),
             cancellation_flag.as_ref(),
         )?;
         let success = result.failure_count() == 0;
@@ -356,7 +356,7 @@ impl TestArgs {
                 &mut db,
                 &|_: &StackGraph, h: &Handle<File>| files.contains(h),
                 success,
-                &lc.stitcher_config,
+                StitcherConfig::default(),
                 cancellation_flag.as_ref(),
             )?
         } else {
@@ -405,7 +405,7 @@ impl TestArgs {
         db: &mut Database,
         filter: &dyn Filter,
         success: bool,
-        stitcher_config: &StitcherConfig,
+        stitcher_config: StitcherConfig,
         cancellation_flag: &dyn CancellationFlag,
     ) -> anyhow::Result<Vec<String>> {
         let mut outputs = Vec::with_capacity(3);
@@ -490,7 +490,7 @@ impl TestArgs {
         partials: &mut PartialPaths,
         db: &mut Database,
         filter: &dyn Filter,
-        stitcher_config: &StitcherConfig,
+        stitcher_config: StitcherConfig,
         cancellation_flag: &dyn CancellationFlag,
     ) -> anyhow::Result<Database> {
         let references = graph

--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -325,6 +325,8 @@ impl TestArgs {
                 Ok(_) => {}
             }
         }
+        let stitcher_config =
+            StitcherConfig::default().with_detect_similar_paths(lc.has_similar_paths);
         let mut partials = PartialPaths::new();
         let mut db = Database::new();
         for file in test.graph.iter_files() {
@@ -332,7 +334,7 @@ impl TestArgs {
                 &test.graph,
                 &mut partials,
                 file,
-                StitcherConfig::default(),
+                stitcher_config,
                 &cancellation_flag.as_ref(),
                 |g, ps, p| {
                     db.add_partial_path(g, ps, p.clone());
@@ -342,7 +344,7 @@ impl TestArgs {
         let result = test.run(
             &mut partials,
             &mut db,
-            StitcherConfig::default(),
+            stitcher_config,
             cancellation_flag.as_ref(),
         )?;
         let success = result.failure_count() == 0;
@@ -356,7 +358,7 @@ impl TestArgs {
                 &mut db,
                 &|_: &StackGraph, h: &Handle<File>| files.contains(h),
                 success,
-                StitcherConfig::default(),
+                stitcher_config,
                 cancellation_flag.as_ref(),
             )?
         } else {

--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -326,7 +326,7 @@ impl TestArgs {
             }
         }
         let stitcher_config =
-            StitcherConfig::default().with_detect_similar_paths(lc.has_similar_paths);
+            StitcherConfig::default().with_detect_similar_paths(!lc.no_similar_paths_in_file);
         let mut partials = PartialPaths::new();
         let mut db = Database::new();
         for file in test.graph.iter_files() {

--- a/tree-sitter-stack-graphs/src/cli/visualize.rs
+++ b/tree-sitter-stack-graphs/src/cli/visualize.rs
@@ -55,10 +55,13 @@ impl VisualizeArgs {
             .filter(|n| graph[*n].is_reference())
             .collect::<Vec<_>>();
         let mut complete_paths_db = Database::new();
+        let stitcher_config = StitcherConfig::default()
+            // always detect similar paths, we don't know the language configurations for the data in the database
+            .with_detect_similar_paths(true);
         ForwardPartialPathStitcher::find_all_complete_partial_paths(
             &mut db,
             starting_nodes,
-            StitcherConfig::default(),
+            stitcher_config,
             cancellation_flag,
             |g, ps, p| {
                 complete_paths_db.add_partial_path(g, ps, p.clone());

--- a/tree-sitter-stack-graphs/src/cli/visualize.rs
+++ b/tree-sitter-stack-graphs/src/cli/visualize.rs
@@ -10,6 +10,7 @@ use clap::ValueHint;
 use stack_graphs::serde::NoFilter;
 use stack_graphs::stitching::Database;
 use stack_graphs::stitching::ForwardPartialPathStitcher;
+use stack_graphs::stitching::StitcherConfig;
 use stack_graphs::storage::SQLiteReader;
 use stack_graphs::NoCancellation;
 use std::path::Path;
@@ -54,9 +55,16 @@ impl VisualizeArgs {
             .filter(|n| graph[*n].is_reference())
             .collect::<Vec<_>>();
         let mut complete_paths_db = Database::new();
+        // FIXME We use the default stitcher config here, because we currently do not retrieve language
+        //       configurations during querying. A first step to fixing this would be to lookup the language
+        //       corresponding to the file that is queried. However, to solve this properly we would need to
+        //       isolate graphs and paths per language so we don't accidently mix different languages that
+        //       require different stitcher settings.
+        let config = StitcherConfig::default();
         ForwardPartialPathStitcher::find_all_complete_partial_paths(
             &mut db,
             starting_nodes,
+            &config,
             cancellation_flag,
             |g, ps, p| {
                 complete_paths_db.add_partial_path(g, ps, p.clone());

--- a/tree-sitter-stack-graphs/src/cli/visualize.rs
+++ b/tree-sitter-stack-graphs/src/cli/visualize.rs
@@ -55,16 +55,10 @@ impl VisualizeArgs {
             .filter(|n| graph[*n].is_reference())
             .collect::<Vec<_>>();
         let mut complete_paths_db = Database::new();
-        // FIXME We use the default stitcher config here, because we currently do not retrieve language
-        //       configurations during querying. A first step to fixing this would be to lookup the language
-        //       corresponding to the file that is queried. However, to solve this properly we would need to
-        //       isolate graphs and paths per language so we don't accidently mix different languages that
-        //       require different stitcher settings.
-        let config = StitcherConfig::default();
         ForwardPartialPathStitcher::find_all_complete_partial_paths(
             &mut db,
             starting_nodes,
-            &config,
+            StitcherConfig::default(),
             cancellation_flag,
             |g, ps, p| {
                 complete_paths_db.add_partial_path(g, ps, p.clone());

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -26,8 +26,6 @@ use tree_sitter_loader::Config as TsConfig;
 use tree_sitter_loader::LanguageConfiguration as TSLanguageConfiguration;
 use tree_sitter_loader::Loader as TsLoader;
 
-pub use stack_graphs::stitching::StitcherConfig;
-
 use crate::CancellationFlag;
 use crate::FileAnalyzer;
 use crate::StackGraphLanguage;
@@ -46,7 +44,6 @@ pub struct LanguageConfiguration {
     pub sgl: StackGraphLanguage,
     pub builtins: StackGraph,
     pub special_files: FileAnalyzers,
-    pub stitcher_config: StitcherConfig,
 }
 
 impl LanguageConfiguration {
@@ -62,7 +59,6 @@ impl LanguageConfiguration {
         builtins_source: Option<(PathBuf, &'a str)>,
         builtins_config: Option<&str>,
         special_files: FileAnalyzers,
-        stitcher_config: StitcherConfig,
         cancellation_flag: &dyn CancellationFlag,
     ) -> Result<Self, LoadError<'a>> {
         let sgl = StackGraphLanguage::from_source(language, tsg_path.clone(), tsg_source).map_err(
@@ -102,7 +98,6 @@ impl LanguageConfiguration {
             sgl,
             builtins,
             special_files,
-            stitcher_config,
         })
     }
 
@@ -573,7 +568,6 @@ impl PathLoader {
                     sgl,
                     builtins,
                     special_files: FileAnalyzers::new(),
-                    stitcher_config: StitcherConfig::default(), // FIXME we do not have a place for this configuration
                 };
                 self.cache.push((language.language, lc));
 

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -26,6 +26,8 @@ use tree_sitter_loader::Config as TsConfig;
 use tree_sitter_loader::LanguageConfiguration as TSLanguageConfiguration;
 use tree_sitter_loader::Loader as TsLoader;
 
+pub use stack_graphs::stitching::StitcherConfig;
+
 use crate::CancellationFlag;
 use crate::FileAnalyzer;
 use crate::StackGraphLanguage;
@@ -44,6 +46,7 @@ pub struct LanguageConfiguration {
     pub sgl: StackGraphLanguage,
     pub builtins: StackGraph,
     pub special_files: FileAnalyzers,
+    pub stitcher_config: StitcherConfig,
 }
 
 impl LanguageConfiguration {
@@ -59,6 +62,7 @@ impl LanguageConfiguration {
         builtins_source: Option<(PathBuf, &'a str)>,
         builtins_config: Option<&str>,
         special_files: FileAnalyzers,
+        stitcher_config: StitcherConfig,
         cancellation_flag: &dyn CancellationFlag,
     ) -> Result<Self, LoadError<'a>> {
         let sgl = StackGraphLanguage::from_source(language, tsg_path.clone(), tsg_source).map_err(
@@ -98,6 +102,7 @@ impl LanguageConfiguration {
             sgl,
             builtins,
             special_files,
+            stitcher_config,
         })
     }
 
@@ -568,6 +573,7 @@ impl PathLoader {
                     sgl,
                     builtins,
                     special_files: FileAnalyzers::new(),
+                    stitcher_config: StitcherConfig::default(), // FIXME we do not have a place for this configuration
                 };
                 self.cache.push((language.language, lc));
 

--- a/tree-sitter-stack-graphs/src/test.rs
+++ b/tree-sitter-stack-graphs/src/test.rs
@@ -74,6 +74,7 @@ use stack_graphs::graph::SourceInfo;
 use stack_graphs::graph::StackGraph;
 use stack_graphs::partial::PartialPaths;
 use stack_graphs::stitching::Database;
+use stack_graphs::stitching::StitcherConfig;
 use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
@@ -623,13 +624,20 @@ impl Test {
         &mut self,
         partials: &mut PartialPaths,
         db: &mut Database,
+        stitcher_config: &StitcherConfig,
         cancellation_flag: &dyn CancellationFlag,
     ) -> Result<TestResult, stack_graphs::CancellationError> {
         let mut result = TestResult::new();
         for fragment in &self.fragments {
             for assertion in &fragment.assertions {
                 match assertion
-                    .run(&self.graph, partials, db, &cancellation_flag)
+                    .run(
+                        &self.graph,
+                        partials,
+                        db,
+                        stitcher_config,
+                        &cancellation_flag,
+                    )
                     .map_or_else(|e| self.from_error(e), |v| Ok(v))
                 {
                     Ok(_) => result.add_success(),

--- a/tree-sitter-stack-graphs/src/test.rs
+++ b/tree-sitter-stack-graphs/src/test.rs
@@ -624,7 +624,7 @@ impl Test {
         &mut self,
         partials: &mut PartialPaths,
         db: &mut Database,
-        stitcher_config: &StitcherConfig,
+        stitcher_config: StitcherConfig,
         cancellation_flag: &dyn CancellationFlag,
     ) -> Result<TestResult, stack_graphs::CancellationError> {
         let mut result = TestResult::new();

--- a/tree-sitter-stack-graphs/tests/it/loader.rs
+++ b/tree-sitter-stack-graphs/tests/it/loader.rs
@@ -8,7 +8,6 @@
 use once_cell::sync::Lazy;
 use pretty_assertions::assert_eq;
 use stack_graphs::graph::StackGraph;
-use stack_graphs::stitching::StitcherConfig;
 use std::path::PathBuf;
 use tree_sitter_stack_graphs::loader::FileAnalyzers;
 use tree_sitter_stack_graphs::loader::LanguageConfiguration;
@@ -36,7 +35,6 @@ fn can_load_from_provided_language_configuration() {
         sgl,
         builtins: StackGraph::new(),
         special_files: FileAnalyzers::new(),
-        stitcher_config: StitcherConfig::default(),
     };
     let mut loader =
         Loader::from_language_configurations(vec![lc], None).expect("Expected loader to succeed");

--- a/tree-sitter-stack-graphs/tests/it/loader.rs
+++ b/tree-sitter-stack-graphs/tests/it/loader.rs
@@ -8,6 +8,7 @@
 use once_cell::sync::Lazy;
 use pretty_assertions::assert_eq;
 use stack_graphs::graph::StackGraph;
+use stack_graphs::stitching::StitcherConfig;
 use std::path::PathBuf;
 use tree_sitter_stack_graphs::loader::FileAnalyzers;
 use tree_sitter_stack_graphs::loader::LanguageConfiguration;
@@ -35,6 +36,7 @@ fn can_load_from_provided_language_configuration() {
         sgl,
         builtins: StackGraph::new(),
         special_files: FileAnalyzers::new(),
+        stitcher_config: StitcherConfig::default(),
     };
     let mut loader =
         Loader::from_language_configurations(vec![lc], None).expect("Expected loader to succeed");

--- a/tree-sitter-stack-graphs/tests/it/loader.rs
+++ b/tree-sitter-stack-graphs/tests/it/loader.rs
@@ -35,7 +35,7 @@ fn can_load_from_provided_language_configuration() {
         sgl,
         builtins: StackGraph::new(),
         special_files: FileAnalyzers::new(),
-        has_similar_paths: true,
+        no_similar_paths_in_file: false,
     };
     let mut loader =
         Loader::from_language_configurations(vec![lc], None).expect("Expected loader to succeed");

--- a/tree-sitter-stack-graphs/tests/it/loader.rs
+++ b/tree-sitter-stack-graphs/tests/it/loader.rs
@@ -35,6 +35,7 @@ fn can_load_from_provided_language_configuration() {
         sgl,
         builtins: StackGraph::new(),
         special_files: FileAnalyzers::new(),
+        has_similar_paths: true,
     };
     let mut loader =
         Loader::from_language_configurations(vec![lc], None).expect("Expected loader to succeed");

--- a/tree-sitter-stack-graphs/tests/it/test.rs
+++ b/tree-sitter-stack-graphs/tests/it/test.rs
@@ -114,7 +114,7 @@ fn check_test(
             &test.graph,
             &mut partials,
             fragment.file,
-            &StitcherConfig::default(),
+            StitcherConfig::default(),
             &stack_graphs::NoCancellation,
             |graph, partials, path| {
                 db.add_partial_path(graph, partials, path.clone());
@@ -127,7 +127,7 @@ fn check_test(
         .run(
             &mut partials,
             &mut db,
-            &StitcherConfig::default(),
+            StitcherConfig::default(),
             &NoCancellation,
         )
         .expect("should never be cancelled");

--- a/tree-sitter-stack-graphs/tests/it/test.rs
+++ b/tree-sitter-stack-graphs/tests/it/test.rs
@@ -13,6 +13,7 @@ use stack_graphs::graph::StackGraph;
 use stack_graphs::partial::PartialPaths;
 use stack_graphs::stitching::Database;
 use stack_graphs::stitching::ForwardPartialPathStitcher;
+use stack_graphs::stitching::StitcherConfig;
 use std::path::Path;
 use std::path::PathBuf;
 use tree_sitter_graph::Variables;
@@ -113,6 +114,7 @@ fn check_test(
             &test.graph,
             &mut partials,
             fragment.file,
+            &StitcherConfig::default(),
             &stack_graphs::NoCancellation,
             |graph, partials, path| {
                 db.add_partial_path(graph, partials, path.clone());
@@ -122,7 +124,12 @@ fn check_test(
     }
 
     let results = test
-        .run(&mut partials, &mut db, &NoCancellation)
+        .run(
+            &mut partials,
+            &mut db,
+            &StitcherConfig::default(),
+            &NoCancellation,
+        )
         .expect("should never be cancelled");
     assert_eq!(
         expected_successes,


### PR DESCRIPTION
« #346 | #326 »

The static methods on `ForwardPartialPathStitcher` do not allow configuration of stitcher properties. This PR adds a `StitcherConfig` type to remedy that.