### PR TITLE
Enable similar path detection by default

### DIFF
--- a/stack-graphs/src/stitching.rs
+++ b/stack-graphs/src/stitching.rs
@@ -775,7 +775,7 @@ impl<H> ForwardPartialPathStitcher<H> {
             initial_paths: next_iteration.0.len(),
             next_iteration,
             appended_paths,
-            similar_path_detector: None,
+            similar_path_detector: Some(SimilarPathDetector::new()),
             // By default, there's no artificial bound on the amount of work done per phase
             max_work_per_phase: usize::MAX,
             #[cfg(feature = "copious-debugging")]
@@ -807,13 +807,13 @@ impl<H: Clone> ForwardPartialPathStitcher<H> {
 
     /// Sets whether similar path detection should be enabled during path stitching. Paths are similar
     /// if start and end node, and pre- and postconditions are the same. The presence of similar paths
-    /// can lead to exponential blow up during path stitching. Similar path detection is disabled by
-    /// default because of the associated preformance cost.
+    /// can lead to exponential blow up during path stitching. Similar path detection is enabled by
+    /// default.
     pub fn set_similar_path_detection(&mut self, detect_similar_paths: bool) {
-        if detect_similar_paths {
-            self.similar_path_detector = Some(SimilarPathDetector::new());
-        } else {
+        if !detect_similar_paths {
             self.similar_path_detector = None;
+        } else if self.similar_path_detector.is_none() {
+            self.similar_path_detector = Some(SimilarPathDetector::new());
         }
     }
 


### PR DESCRIPTION
Similar path detection prevents exponential path blowup during path stitching. However, it incurs a preformance cost and for that reason it was disabled by default.

The problem is that users cannot pass along the right stitcher configuration in all places where stitching is used. If the rules for a language can result in exponential blowup, users have no way of preventing that at the moment.

This PR changes the partial path stitcher to use similar path detection by default. This will make the library safe and unblock other work depending on this to work. In the future, users should be able to pass along stitcher configuration everywhere it is relevant. This work is tracked in issue #322.
