### PR TITLE
Collect stitching and database stats

### DIFF
--- a/stack-graphs/src/cycles.rs
+++ b/stack-graphs/src/cycles.rs
@@ -107,7 +107,7 @@ where
         }
     }
 
-    /// Add a apth, and determine whether we should process this path during the path-finding algorithm.
+    /// Add a path, and determine whether we should process this path during the path-finding algorithm.
     /// If we have seen a path with the same start and end node, and the same pre- and postcondition, then
     /// we return false. Otherwise, we return true.
     pub fn add_path<Cmp>(

--- a/stack-graphs/src/graph.rs
+++ b/stack-graphs/src/graph.rs
@@ -425,7 +425,7 @@ impl Handle<File> {
 /// Each node (except for the _root node_ and _jump to scope_ node) lives in a file, and has a
 /// _local ID_ that must be unique within its file.
 #[repr(C)]
-#[derive(Clone, Copy, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct NodeID {
     file: ControlledOption<Handle<File>>,
     local_id: u32,

--- a/stack-graphs/src/lib.rs
+++ b/stack-graphs/src/lib.rs
@@ -69,6 +69,7 @@ pub mod graph;
 pub mod partial;
 pub mod paths;
 pub mod serde;
+pub mod stats;
 pub mod stitching;
 #[cfg(feature = "storage")]
 pub mod storage;

--- a/stack-graphs/src/stats.rs
+++ b/stack-graphs/src/stats.rs
@@ -1,0 +1,90 @@
+use std::collections::HashMap;
+use std::hash::Hash;
+
+use itertools::Itertools;
+
+/// Frequency distribution maintains the frequency of T values.
+#[derive(Clone, Debug, Default)]
+pub struct FrequencyDistribution<T>
+where
+    T: Eq + Hash,
+{
+    values: HashMap<T, usize>,
+    total: usize,
+}
+
+impl<T: Eq + Hash> FrequencyDistribution<T> {
+    pub fn total(&self) -> usize {
+        return self.total;
+    }
+
+    pub fn unique(&self) -> usize {
+        return self.values.len();
+    }
+
+    pub fn frequencies(&self) -> FrequencyDistribution<usize> {
+        let mut fs = FrequencyDistribution::default();
+        for count in self.values.values() {
+            fs += *count
+        }
+        fs
+    }
+}
+
+impl<T: Eq + Hash + Ord> FrequencyDistribution<T> {
+    pub fn quantiles(&self, q: usize) -> Vec<&T> {
+        if q == 0 || self.total == 0 {
+            return vec![];
+        }
+
+        let mut it = self.values.iter().sorted_by_key(|e| e.0);
+        let mut total_count = 0;
+        let mut last_value;
+        let mut result = Vec::new();
+
+        if let Some((value, count)) = it.next() {
+            total_count += count;
+            last_value = value;
+        } else {
+            return vec![];
+        }
+        result.push(last_value);
+
+        for k in 1..=q {
+            let limit = ((self.total as f64 * k as f64) / q as f64).round() as usize;
+            while total_count < limit {
+                if let Some((value, count)) = it.next() {
+                    total_count += count;
+                    last_value = value;
+                } else {
+                    break;
+                }
+            }
+            result.push(last_value);
+        }
+
+        result
+    }
+}
+
+impl<T> std::ops::AddAssign<T> for FrequencyDistribution<T>
+where
+    T: Eq + Hash,
+{
+    fn add_assign(&mut self, rhs: T) {
+        *self.values.entry(rhs).or_default() += 1;
+        self.total += 1;
+    }
+}
+
+impl<T> std::ops::AddAssign<&Self> for FrequencyDistribution<T>
+where
+    T: Eq + Hash + Clone,
+{
+    fn add_assign(&mut self, rhs: &Self) {
+        for (value, count) in &rhs.values {
+            *self.values.entry(value.clone()).or_default() += count;
+        }
+        self.total += rhs.total;
+    }
+}

--- a/stack-graphs/src/stats.rs
+++ b/stack-graphs/src/stats.rs
@@ -1,3 +1,10 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2023, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
 use std::collections::HashMap;
 use std::hash::Hash;
 
@@ -14,6 +21,11 @@ where
 }
 
 impl<T: Eq + Hash> FrequencyDistribution<T> {
+    pub fn record(&mut self, value: T) {
+        *self.values.entry(value).or_default() += 1;
+        self.total += 1;
+    }
+
     pub fn total(&self) -> usize {
         return self.total;
     }
@@ -25,7 +37,7 @@ impl<T: Eq + Hash> FrequencyDistribution<T> {
     pub fn frequencies(&self) -> FrequencyDistribution<usize> {
         let mut fs = FrequencyDistribution::default();
         for count in self.values.values() {
-            fs += *count
+            fs.record(*count);
         }
         fs
     }
@@ -67,13 +79,15 @@ impl<T: Eq + Hash + Ord> FrequencyDistribution<T> {
     }
 }
 
-impl<T> std::ops::AddAssign<T> for FrequencyDistribution<T>
+impl<T> std::ops::AddAssign<Self> for FrequencyDistribution<T>
 where
     T: Eq + Hash,
 {
-    fn add_assign(&mut self, rhs: T) {
-        *self.values.entry(rhs).or_default() += 1;
-        self.total += 1;
+    fn add_assign(&mut self, rhs: Self) {
+        for (value, count) in rhs.values {
+            *self.values.entry(value).or_default() += count;
+        }
+        self.total += rhs.total;
     }
 }
 

--- a/stack-graphs/src/stats.rs
+++ b/stack-graphs/src/stats.rs
@@ -26,10 +26,12 @@ impl<T: Eq + Hash> FrequencyDistribution<T> {
         self.total += 1;
     }
 
-    pub fn total(&self) -> usize {
+    // The number of recorded values.
+    pub fn count(&self) -> usize {
         return self.total;
     }
 
+    // The number of unique recorded values.
     pub fn unique(&self) -> usize {
         return self.values.len();
     }

--- a/stack-graphs/src/stitching.rs
+++ b/stack-graphs/src/stitching.rs
@@ -1083,7 +1083,7 @@ impl<H: Clone> ForwardPartialPathStitcher<H> {
 
         if extension_count == 0 {
             self.stats
-                .nonextensible_path_lengh
+                .terminal_path_lengh
                 .record(partial_path.edges.len());
         }
         candidate_count
@@ -1299,7 +1299,7 @@ pub struct Stats {
     /// The distribution of the length of accepted paths
     pub accepted_path_length: FrequencyDistribution<usize>,
     /// The distribution of the maximal length of paths (when they cannot be extended more)
-    pub nonextensible_path_lengh: FrequencyDistribution<usize>,
+    pub terminal_path_lengh: FrequencyDistribution<usize>,
     /// The distribution of the number of candidates for paths ending in a regular node
     pub candidates_per_node_path: FrequencyDistribution<usize>,
     /// The distribution of the number of candidates for paths ending in the root node
@@ -1322,7 +1322,7 @@ impl std::ops::AddAssign<Self> for Stats {
         self.queued_paths_per_phase += rhs.queued_paths_per_phase;
         self.processed_paths_per_phase += rhs.processed_paths_per_phase;
         self.accepted_path_length += rhs.accepted_path_length;
-        self.nonextensible_path_lengh += rhs.nonextensible_path_lengh;
+        self.terminal_path_lengh += rhs.terminal_path_lengh;
         self.candidates_per_node_path += rhs.candidates_per_node_path;
         self.candidates_per_root_path += rhs.candidates_per_root_path;
         self.extensions_per_node_path += rhs.extensions_per_node_path;
@@ -1338,7 +1338,7 @@ impl std::ops::AddAssign<&Self> for Stats {
         self.initial_paths += &rhs.initial_paths;
         self.processed_paths_per_phase += &rhs.processed_paths_per_phase;
         self.accepted_path_length += &rhs.accepted_path_length;
-        self.nonextensible_path_lengh += &rhs.nonextensible_path_lengh;
+        self.terminal_path_lengh += &rhs.terminal_path_lengh;
         self.candidates_per_node_path += &rhs.candidates_per_node_path;
         self.candidates_per_root_path += &rhs.candidates_per_root_path;
         self.extensions_per_node_path += &rhs.extensions_per_node_path;

--- a/stack-graphs/src/stitching.rs
+++ b/stack-graphs/src/stitching.rs
@@ -896,7 +896,9 @@ impl<H> ForwardPartialPathStitcher<H> {
         if !detect_similar_paths {
             self.similar_path_detector = None;
         } else if self.similar_path_detector.is_none() {
-            self.similar_path_detector = Some(SimilarPathDetector::new());
+            let mut similar_path_detector = SimilarPathDetector::new();
+            similar_path_detector.set_collect_stats(self.stats.is_some());
+            self.similar_path_detector = Some(similar_path_detector);
         }
     }
 
@@ -925,6 +927,9 @@ impl<H> ForwardPartialPathStitcher<H> {
             let mut stats = Stats::default();
             stats.initial_paths.record(self.initial_paths);
             self.stats = Some(stats);
+        }
+        if let Some(similar_path_detector) = &mut self.similar_path_detector {
+            similar_path_detector.set_collect_stats(collect_stats);
         }
     }
 
@@ -1050,7 +1055,7 @@ impl<H: Clone> ForwardPartialPathStitcher<H> {
             let (graph, partials, _) = candidates.get_graph_partials_and_db();
             if check_similar_path {
                 if let Some(similar_path_detector) = &mut self.similar_path_detector {
-                    if similar_path_detector.has_similar_path(
+                    if similar_path_detector.add_path(
                         graph,
                         partials,
                         &new_partial_path,

--- a/stack-graphs/tests/it/main.rs
+++ b/stack-graphs/tests/it/main.rs
@@ -24,6 +24,7 @@ mod graph;
 mod partial;
 #[cfg(feature = "serde")]
 mod serde;
+mod stats;
 mod stitching;
 #[cfg(feature = "storage")]
 mod storage;

--- a/stack-graphs/tests/it/stats.rs
+++ b/stack-graphs/tests/it/stats.rs
@@ -15,7 +15,7 @@ fn empty_distribution() {
     let hist: FrequencyDistribution<i32> = FrequencyDistribution::default();
 
     assert_eq!(0, hist.unique());
-    assert_eq!(0, hist.total());
+    assert_eq!(0, hist.count());
 
     let result = hist.quantiles(0).into_iter().cloned().collect_vec();
     let expected: Vec<i32> = vec![];
@@ -28,7 +28,7 @@ fn singleton_distribution() {
     hist.record(42);
 
     assert_eq!(1, hist.unique());
-    assert_eq!(1, hist.total());
+    assert_eq!(1, hist.count());
 
     let result = hist.quantiles(4).into_iter().cloned().collect_vec();
     let expected: Vec<i32> = vec![42, 42, 42, 42, 42];
@@ -44,7 +44,7 @@ fn four_value_distribution() {
     hist.record(2);
 
     assert_eq!(4, hist.unique());
-    assert_eq!(4, hist.total());
+    assert_eq!(4, hist.count());
 
     let result = hist.quantiles(4).into_iter().cloned().collect_vec();
     let expected: Vec<i32> = vec![1, 1, 2, 3, 4];

--- a/stack-graphs/tests/it/stats.rs
+++ b/stack-graphs/tests/it/stats.rs
@@ -1,0 +1,45 @@
+use itertools::Itertools;
+use pretty_assertions::assert_eq;
+
+use stack_graphs::stats::*;
+
+#[test]
+fn empty_distribution() {
+    let hist: FrequencyDistribution<i32> = FrequencyDistribution::default();
+
+    assert_eq!(0, hist.unique());
+    assert_eq!(0, hist.total());
+
+    let result = hist.quantiles(0).into_iter().cloned().collect_vec();
+    let expected: Vec<i32> = vec![];
+    assert_eq!(expected, result);
+}
+
+#[test]
+fn singleton_distribution() {
+    let mut hist = FrequencyDistribution::default();
+    hist += 42;
+
+    assert_eq!(1, hist.unique());
+    assert_eq!(1, hist.total());
+
+    let result = hist.quantiles(4).into_iter().cloned().collect_vec();
+    let expected: Vec<i32> = vec![42, 42, 42, 42, 42];
+    assert_eq!(expected, result);
+}
+
+#[test]
+fn four_value_distribution() {
+    let mut hist = FrequencyDistribution::default();
+    hist += 3;
+    hist += 4;
+    hist += 1;
+    hist += 2;
+
+    assert_eq!(4, hist.unique());
+    assert_eq!(4, hist.total());
+
+    let result = hist.quantiles(4).into_iter().cloned().collect_vec();
+    let expected: Vec<i32> = vec![1, 1, 2, 3, 4];
+    assert_eq!(expected, result);
+}

--- a/stack-graphs/tests/it/stats.rs
+++ b/stack-graphs/tests/it/stats.rs
@@ -1,3 +1,10 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2023, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
 use itertools::Itertools;
 use pretty_assertions::assert_eq;
 
@@ -18,7 +25,7 @@ fn empty_distribution() {
 #[test]
 fn singleton_distribution() {
     let mut hist = FrequencyDistribution::default();
-    hist += 42;
+    hist.record(42);
 
     assert_eq!(1, hist.unique());
     assert_eq!(1, hist.total());
@@ -31,10 +38,10 @@ fn singleton_distribution() {
 #[test]
 fn four_value_distribution() {
     let mut hist = FrequencyDistribution::default();
-    hist += 3;
-    hist += 4;
-    hist += 1;
-    hist += 2;
+    hist.record(3);
+    hist.record(4);
+    hist.record(1);
+    hist.record(2);
 
     assert_eq!(4, hist.unique());
     assert_eq!(4, hist.total());

--- a/tree-sitter-stack-graphs/src/cli/index.rs
+++ b/tree-sitter-stack-graphs/src/cli/index.rs
@@ -370,13 +370,14 @@ impl<'a> Indexer<'a> {
                 .total_graph_nodes
                 .record(graph.iter_nodes().count());
             let mut total_edges = 0;
-            for node_edges in graph
-                .iter_nodes()
-                .filter(|n| !graph[*n].is_root())
-                .map(|n| graph.outgoing_edges(n).count())
-            {
-                self.stats.node_out_degrees.record(node_edges);
-                total_edges += node_edges;
+            for n in graph.iter_nodes() {
+                let edge_count = graph.outgoing_edges(n).count();
+                if graph[n].is_root() {
+                    self.stats.root_out_degree = edge_count;
+                } else {
+                    self.stats.node_out_degrees.record(edge_count);
+                    total_edges += edge_count;
+                }
             }
             self.stats.total_graph_edges.record(total_edges);
         }
@@ -513,6 +514,8 @@ pub struct IndexingStats {
     pub total_graph_edges: FrequencyDistribution<usize>,
     // The distribution of the out-degrees of non-root nodes.
     pub node_out_degrees: FrequencyDistribution<usize>,
+    // The root node's out-degree.
+    pub root_out_degree: usize,
     // The stitching statistics.
     pub stitching_stats: StitchingStats,
 }

--- a/tree-sitter-stack-graphs/src/cli/index.rs
+++ b/tree-sitter-stack-graphs/src/cli/index.rs
@@ -12,6 +12,7 @@ use stack_graphs::graph::File;
 use stack_graphs::graph::StackGraph;
 use stack_graphs::partial::PartialPaths;
 use stack_graphs::stitching::ForwardPartialPathStitcher;
+use stack_graphs::stitching::Stats as StitchingStats;
 use stack_graphs::stitching::StitcherConfig;
 use stack_graphs::storage::FileStatus;
 use stack_graphs::storage::SQLiteWriter;
@@ -24,6 +25,7 @@ use tree_sitter_graph::Variables;
 
 use crate::cli::util::duration_from_seconds_str;
 use crate::cli::util::iter_files_and_directories;
+use crate::cli::util::print_stitcher_stats;
 use crate::cli::util::reporter::ConsoleReporter;
 use crate::cli::util::reporter::Level;
 use crate::cli::util::reporter::Reporter;
@@ -79,6 +81,9 @@ pub struct IndexArgs {
     )]
     pub max_file_time: Option<Duration>,
 
+    #[clap(long)]
+    pub stats: bool,
+
     /// Wait for user input before starting analysis. Useful for profiling.
     #[clap(long)]
     pub wait_at_start: bool,
@@ -94,6 +99,7 @@ impl IndexArgs {
             hide_error_details: false,
             max_file_time: None,
             wait_at_start: false,
+            stats: false,
         }
     }
 
@@ -113,6 +119,10 @@ impl IndexArgs {
             .map(|p| p.canonicalize())
             .collect::<std::result::Result<Vec<_>, _>>()?;
         indexer.index_all(source_paths, self.continue_from, &NoCancellation)?;
+
+        if self.stats {
+            print_stitcher_stats(indexer.into_stats());
+        }
         Ok(())
     }
 
@@ -146,6 +156,7 @@ pub struct Indexer<'a> {
     db: &'a mut SQLiteWriter,
     loader: &'a mut Loader,
     reporter: &'a dyn Reporter,
+    stats: StitchingStats,
     /// Index files, even if they already exist in the database.
     pub force: bool,
     /// Maximum time per file.
@@ -164,6 +175,7 @@ impl<'a> Indexer<'a> {
             reporter,
             force: false,
             max_file_time: None,
+            stats: StitchingStats::default(),
         }
     }
 
@@ -364,7 +376,9 @@ impl<'a> Indexer<'a> {
                 paths.push(p.clone());
             },
         ) {
-            Ok(_) => {}
+            Ok(stats) => {
+                self.stats += &stats;
+            }
             Err(_) => {
                 file_status.warning("path computation timed out", None);
                 self.db.store_error_for_file(
@@ -441,6 +455,14 @@ impl<'a> Indexer<'a> {
         };
         *continue_from = None;
         false
+    }
+
+    pub fn stats(&self) -> &StitchingStats {
+        &self.stats
+    }
+
+    pub fn into_stats(self) -> StitchingStats {
+        self.stats
     }
 }
 

--- a/tree-sitter-stack-graphs/src/cli/index.rs
+++ b/tree-sitter-stack-graphs/src/cli/index.rs
@@ -25,7 +25,7 @@ use tree_sitter_graph::Variables;
 
 use crate::cli::util::duration_from_seconds_str;
 use crate::cli::util::iter_files_and_directories;
-use crate::cli::util::print_stitcher_stats;
+use crate::cli::util::print_stitching_stats;
 use crate::cli::util::reporter::ConsoleReporter;
 use crate::cli::util::reporter::Level;
 use crate::cli::util::reporter::Reporter;
@@ -122,7 +122,7 @@ impl IndexArgs {
 
         if self.stats {
             println!();
-            print_stitcher_stats(indexer.into_stats());
+            print_stitching_stats(indexer.into_stats());
         }
         Ok(())
     }

--- a/tree-sitter-stack-graphs/src/cli/index.rs
+++ b/tree-sitter-stack-graphs/src/cli/index.rs
@@ -378,7 +378,7 @@ impl<'a> Indexer<'a> {
             },
         ) {
             Ok(stats) => {
-                self.stats += &stats;
+                self.stats += stats;
             }
             Err(_) => {
                 file_status.warning("path computation timed out", None);

--- a/tree-sitter-stack-graphs/src/cli/index.rs
+++ b/tree-sitter-stack-graphs/src/cli/index.rs
@@ -121,6 +121,7 @@ impl IndexArgs {
         indexer.index_all(source_paths, self.continue_from, &NoCancellation)?;
 
         if self.stats {
+            println!();
             print_stitcher_stats(indexer.into_stats());
         }
         Ok(())

--- a/tree-sitter-stack-graphs/src/cli/query.rs
+++ b/tree-sitter-stack-graphs/src/cli/query.rs
@@ -53,6 +53,7 @@ impl QueryArgs {
         let mut db = SQLiteReader::open(&db_path)?;
         let stitcher_stats = self.target.run(&mut db)?;
         if self.stats {
+            println!();
             print_stitcher_stats(stitcher_stats);
             println!();
             print_database_stats(db.stats());
@@ -132,7 +133,7 @@ impl Definition {
                     n => println!("{}has {} definitions", " ".repeat(indent), n),
                 }
                 for definition in definitions.into_iter() {
-                    println!(
+                    print!(
                         "{}",
                         Excerpt::from_source(
                             &definition.path,

--- a/tree-sitter-stack-graphs/src/cli/query.rs
+++ b/tree-sitter-stack-graphs/src/cli/query.rs
@@ -21,7 +21,7 @@ use thiserror::Error;
 use tree_sitter_graph::parse_error::Excerpt;
 
 use crate::cli::util::print_database_stats;
-use crate::cli::util::print_stitcher_stats;
+use crate::cli::util::print_stitching_stats;
 use crate::cli::util::reporter::ConsoleReporter;
 use crate::cli::util::reporter::Reporter;
 use crate::cli::util::sha1;
@@ -51,10 +51,10 @@ impl QueryArgs {
             wait_for_input()?;
         }
         let mut db = SQLiteReader::open(&db_path)?;
-        let stitcher_stats = self.target.run(&mut db)?;
+        let stitching_stats = self.target.run(&mut db)?;
         if self.stats {
             println!();
-            print_stitcher_stats(stitcher_stats);
+            print_stitching_stats(stitching_stats);
             println!();
             print_database_stats(db.stats());
         }

--- a/tree-sitter-stack-graphs/src/cli/query.rs
+++ b/tree-sitter-stack-graphs/src/cli/query.rs
@@ -72,8 +72,9 @@ impl Target {
         let reporter = ConsoleReporter::details();
         let mut querier = Querier::new(db, &reporter);
         match self {
-            Self::Definition(cmd) => cmd.run(&mut querier),
+            Self::Definition(cmd) => cmd.run(&mut querier)?,
         }
+        Ok(querier.into_stats())
     }
 }
 
@@ -90,15 +91,13 @@ pub struct Definition {
 }
 
 impl Definition {
-    pub fn run(self, querier: &mut Querier) -> anyhow::Result<StitchingStats> {
+    pub fn run(self, querier: &mut Querier) -> anyhow::Result<()> {
         let cancellation_flag = NoCancellation;
-        let mut stats = StitchingStats::default();
         let mut file_reader = FileReader::new();
         for mut reference in self.references {
             reference.canonicalize()?;
 
             let results = querier.definitions(reference.clone(), &cancellation_flag)?;
-            stats += querier.stats();
             let numbered = results.len() > 1;
             let indent = if numbered { 6 } else { 0 };
             if numbered {
@@ -146,7 +145,7 @@ impl Definition {
                 }
             }
         }
-        Ok(stats)
+        Ok(())
     }
 }
 
@@ -220,7 +219,7 @@ impl<'a> Querier<'a> {
                 },
             );
             match ref_result {
-                Ok(ref_stats) => self.stats += &ref_stats,
+                Ok(ref_stats) => self.stats += ref_stats,
                 Err(err) => {
                     self.reporter.failed(&log_path, "query timed out", None);
                     return Err(err.into());

--- a/tree-sitter-stack-graphs/src/cli/util.rs
+++ b/tree-sitter-stack-graphs/src/cli/util.rs
@@ -518,7 +518,7 @@ pub(super) fn print_stitching_stats(stats: StitchingStats) {
     print_quartiles_row("queued paths per phase", stats.queued_paths_per_phase);
     print_quartiles_row("processed paths per phase", stats.processed_paths_per_phase);
     print_quartiles_row("accepted path length", stats.accepted_path_length);
-    print_quartiles_row("non-extensible path length", stats.nonextensible_path_lengh);
+    print_quartiles_row("terminal path length", stats.terminal_path_lengh);
     print_quartiles_row("node path candidates", stats.candidates_per_node_path);
     print_quartiles_row("node path extensions", stats.extensions_per_node_path);
     print_quartiles_row("root path candidates", stats.candidates_per_root_path);

--- a/tree-sitter-stack-graphs/src/cli/util.rs
+++ b/tree-sitter-stack-graphs/src/cli/util.rs
@@ -507,21 +507,24 @@ pub(super) fn print_indexing_stats(stats: IndexingStats) {
     print_quartiles_row("total graph nodes", stats.total_graph_nodes);
     print_quartiles_row("total graph edges", stats.total_graph_edges);
     print_quartiles_row("node out degrees", stats.node_out_degrees);
+    print_value_row("root out degree", stats.root_out_degree);
     println!();
     print_stitching_stats(stats.stitching_stats);
 }
 
 pub(super) fn print_stitching_stats(stats: StitchingStats) {
     print_quartiles_header("stitching stats");
+    print_quartiles_row("initial paths", stats.initial_paths);
     print_quartiles_row("queued paths per phase", stats.queued_paths_per_phase);
     print_quartiles_row("processed paths per phase", stats.processed_paths_per_phase);
     print_quartiles_row("accepted path length", stats.accepted_path_length);
-    print_quartiles_row("maximal path length", stats.maximal_path_lengh);
+    print_quartiles_row("non-extensible path length", stats.nonextensible_path_lengh);
     print_quartiles_row("node path candidates", stats.candidates_per_node_path);
     print_quartiles_row("node path extensions", stats.extensions_per_node_path);
     print_quartiles_row("root path candidates", stats.candidates_per_root_path);
     print_quartiles_row("root path extensions", stats.extensions_per_root_path);
     print_quartiles_row("node visits", stats.node_visits.frequencies());
+    print_value_row("root visits", stats.root_visits);
     print_quartiles_row(
         "similar path counts",
         stats.similar_paths_stats.similar_path_count,
@@ -530,33 +533,35 @@ pub(super) fn print_stitching_stats(stats: StitchingStats) {
         "similar path bucket sizes",
         stats.similar_paths_stats.similar_path_bucket_size,
     );
-    print_value_row("root visits", stats.root_visits);
 }
 
 pub(super) fn print_database_stats(stats: StorageStats) {
-    println!("      database stats       |  loads  | cached  ");
-    println!("---------------------------+---------+---------");
     println!(
-        " files                     | {:>9} | {:>9} ",
-        stats.file_loads, stats.file_cached
+        "| {:^29} | {:^9} | {:^9} |",
+        "database stats", "loads", "cached",
+    );
+    println!("|-------------------------------|-----------|-----------|");
+    println!(
+        "| {:>29} | {:>9} | {:>9} |",
+        "files", stats.file_loads, stats.file_cached
     );
     println!(
-        " node paths                | {:>9} | {:>9} ",
-        stats.node_path_loads, stats.node_path_cached
+        "| {:>29} | {:>9} | {:>9} |",
+        "node paths", stats.node_path_loads, stats.node_path_cached
     );
     println!(
-        " root paths                | {:>9} | {:>9} ",
-        stats.root_path_loads, stats.root_path_cached
+        "| {:>29} | {:>9} | {:>9} |",
+        "rootpaths", stats.root_path_loads, stats.root_path_cached
     );
 }
 
 fn print_quartiles_header(title: &str) {
     println!(
-        "| {:^25} |    min    |    p25    |    p50    |    p75    |    max    |   total   |",
-        title
+        "| {:^29} | {:^9} | {:^9} | {:^9} | {:^9} | {:^9} | {:^9} |",
+        title, "min", "p25", "p50", "p75", "max", "count",
     );
     println!(
-        "|---------------------------|-----------|-----------|-----------|-----------|-----------|-----------|"
+        "|-------------------------------|-----------|-----------|-----------|-----------|-----------|-----------|"
     );
 }
 
@@ -564,26 +569,26 @@ fn print_quartiles_row<X: Display + Eq + Hash + Ord>(title: &str, hist: Frequenc
     let qs = hist.quantiles(4);
     if qs.is_empty() {
         println!(
-            "| {:>25} | {:>9} | {:>9} | {:>9} | {:>9} | {:>9} | {:>9} |",
+            "| {:>29} | {:>9} | {:>9} | {:>9} | {:>9} | {:>9} | {:>9} |",
             title, "-", "-", "-", "-", "-", 0
         );
     } else {
         println!(
-            "| {:>25} | {:>9} | {:>9} | {:>9} | {:>9} | {:>9} | {:>9} |",
+            "| {:>29} | {:>9} | {:>9} | {:>9} | {:>9} | {:>9} | {:>9} |",
             title,
             qs[0],
             qs[1],
             qs[2],
             qs[3],
             qs[4],
-            hist.total(),
+            hist.count(),
         );
     }
 }
 
 fn print_value_row<X: Display>(title: &str, value: X) {
     println!(
-        "| {:>25} | {:>9} | {:>9} | {:>9} | {:>9} | {:>9} | {:>9} |",
+        "| {:>29} | {:>9} | {:>9} | {:>9} | {:>9} | {:>9} | {:>9} |",
         title, "-", "-", "-", "-", "-", value
     );
 }

--- a/tree-sitter-stack-graphs/src/cli/util.rs
+++ b/tree-sitter-stack-graphs/src/cli/util.rs
@@ -501,7 +501,7 @@ impl std::fmt::Display for DisplayBuildErrorPretty<'_> {
     }
 }
 
-pub(super) fn print_stitcher_stats(stats: StitchingStats) {
+pub(super) fn print_stitching_stats(stats: StitchingStats) {
     fn quartiles<X: Display + Eq + Hash + Ord>(hist: FrequencyDistribution<X>) -> String {
         let qs = hist.quantiles(4);
         if qs.is_empty() {

--- a/tree-sitter-stack-graphs/src/cli/util.rs
+++ b/tree-sitter-stack-graphs/src/cli/util.rs
@@ -522,6 +522,14 @@ pub(super) fn print_stitching_stats(stats: StitchingStats) {
     print_quartiles_row("root path candidates", stats.candidates_per_root_path);
     print_quartiles_row("root path extensions", stats.extensions_per_root_path);
     print_quartiles_row("node visits", stats.node_visits.frequencies());
+    print_quartiles_row(
+        "similar path counts",
+        stats.similar_paths_stats.similar_path_count,
+    );
+    print_quartiles_row(
+        "similar path bucket sizes",
+        stats.similar_paths_stats.similar_path_bucket_size,
+    );
     print_value_row("root visits", stats.root_visits);
 }
 

--- a/tree-sitter-stack-graphs/src/cli/util.rs
+++ b/tree-sitter-stack-graphs/src/cli/util.rs
@@ -506,12 +506,12 @@ pub(super) fn print_stitching_stats(stats: StitchingStats) {
         let qs = hist.quantiles(4);
         if qs.is_empty() {
             format!(
-                "{:>7} | {:>7} | {:>7} | {:>7} | {:>7} | {:>7}",
+                "{:>9} | {:>9} | {:>9} | {:>9} | {:>9} | {:>9}",
                 "-", "-", "-", "-", "-", 0
             )
         } else {
             format!(
-                "{:>7} | {:>7} | {:>7} | {:>7} | {:>7} | {:>7}",
+                "{:>9} | {:>9} | {:>9} | {:>9} | {:>9} | {:>9}",
                 qs[0],
                 qs[1],
                 qs[2],
@@ -522,10 +522,10 @@ pub(super) fn print_stitching_stats(stats: StitchingStats) {
         }
     }
     println!(
-        "      stitching stats      |   min   |   p25   |   p50   |   p75   |   max   |  total  "
+        "      stitching stats      |    min    |    p25    |    p50    |    p75    |    max    |   total   "
     );
     println!(
-        "---------------------------+---------+---------+---------+---------+---------+---------"
+        "---------------------------+-----------+-----------+-----------+-----------+-----------+-----------"
     );
     println!(
         " queued paths per phase    | {} ",
@@ -563,22 +563,22 @@ pub(super) fn print_stitching_stats(stats: StitchingStats) {
         " node visits               | {} ",
         quartiles(stats.node_visits.frequencies())
     );
-    println!(" root visits               | {:>7} ", stats.root_visits);
+    println!(" root visits               | {:>9} ", stats.root_visits);
 }
 
 pub(super) fn print_database_stats(stats: StorageStats) {
     println!("      database stats       |  loads  | cached  ");
     println!("---------------------------+---------+---------");
     println!(
-        " files                     | {:>7} | {:>7} ",
+        " files                     | {:>9} | {:>9} ",
         stats.file_loads, stats.file_cached
     );
     println!(
-        " node paths                | {:>7} | {:>7} ",
+        " node paths                | {:>9} | {:>9} ",
         stats.node_path_loads, stats.node_path_cached
     );
     println!(
-        " root paths                | {:>7} | {:>7} ",
+        " root paths                | {:>9} | {:>9} ",
         stats.root_path_loads, stats.root_path_cached
     );
 }


### PR DESCRIPTION
« #321

Adds stats collection during stitching and in the storage reader. This is a first step to making the behavior of the algorithms more visible. This could be useful to understand performance, and e.g. compare the effect of using different path sets for resolution.

The stats can be printed from the CLI's `index` and `query` commands by passing `--stats`. They look as follows:

```
      stitching stats      |   min   |   p25   |   p50   |   p75   |   max   |  total  
---------------------------+---------+---------+---------+---------+---------+---------
 queued paths per phase    |       1 |       1 |       3 |       4 |      11 |      22 
 processed paths per phase |       1 |       3 |       5 |      80 |    1343 |      22 
 accepted path length      |      93 |      93 |      93 |     157 |     157 |       2 
 maximal path length       |      24 |      44 |      79 |      91 |     157 |      31 
 node path candidates      |       1 |       1 |       3 |      51 |     223 |      45 
 node path extensions      |       0 |       0 |       1 |       1 |       5 |      45 
 root path candidates      |       0 |       0 |       0 |       1 |       2 |      27 
 root path extensions      |       0 |       0 |       0 |       1 |       2 |      27 
 node visits               |       1 |       1 |       1 |       1 |       9 |      37 
 root visits               |      27 

      database stats       |  loads  | cached  
---------------------------+---------+---------
 files                     |       6 |     594 
 node paths                |      37 |       8 
 root paths                |     236 |     134 
```

## Changes

The main changes are:

- A new `stats` module contains a `FrequencyDistribution` for collecting stats and computing quantiles for them.
- Add stats to the `ForwardPartialPathStitcher` which are threaded all the way to the `Indexer` and `Querier` used in the CLI.
- Add stats to the `SQLReader`.
- Add stats to the `SimialrPathDetector`
- Add stats printing to the `query` and `index` CLI commands.

The code is written such that stats collection must be explicitly enabled. It stats collection is not disabled, memory usage should not differ much from current code.