### PR TITLE
Fix panic when error was already reported

### DIFF
--- a/tree-sitter-stack-graphs/src/cli/util.rs
+++ b/tree-sitter-stack-graphs/src/cli/util.rs
@@ -437,7 +437,7 @@ impl<'a> CLIFileReporter<'a> {
         status: &str,
         details: Option<&dyn std::fmt::Display>,
     ) {
-        if !self.path_logged {
+        if !self.path_logged || self.status_logged {
             return;
         }
         self.failure(status, details);


### PR DESCRIPTION
The logic that would report an error if it wasn't already reported has a bug that causes a panic when the error was already reported.

This PR fixes that by not reporting anything in that case (since it was already reported).
