### PR TITLE
Fix root paths candidates

### DIFF
--- a/stack-graphs/tests/it/can_find_root_partial_paths_in_database.rs
+++ b/stack-graphs/tests/it/can_find_root_partial_paths_in_database.rs
@@ -17,7 +17,6 @@ use stack_graphs::partial::PartialScopedSymbol;
 use stack_graphs::partial::PartialSymbolStack;
 use stack_graphs::stitching::Database;
 use stack_graphs::stitching::ForwardPartialPathStitcher;
-use stack_graphs::stitching::SymbolStackKey;
 use stack_graphs::NoCancellation;
 
 use crate::test_graphs;
@@ -53,8 +52,12 @@ fn check_root_partial_paths(
     }
 
     let mut results = Vec::<Handle<PartialPath>>::new();
-    let key = SymbolStackKey::from_partial_symbol_stack(&mut partials, &mut db, symbol_stack);
-    db.find_candidate_partial_paths_from_root(graph, &mut partials, Some(key), &mut results);
+    db.find_candidate_partial_paths_from_root(
+        graph,
+        &mut partials,
+        Some(symbol_stack),
+        &mut results,
+    );
 
     let actual_partial_paths = results
         .into_iter()

--- a/stack-graphs/tests/it/main.rs
+++ b/stack-graphs/tests/it/main.rs
@@ -25,4 +25,6 @@ mod partial;
 #[cfg(feature = "serde")]
 mod serde;
 mod stitching;
+#[cfg(feature = "storage")]
+mod storage;
 mod util;

--- a/stack-graphs/tests/it/main.rs
+++ b/stack-graphs/tests/it/main.rs
@@ -24,4 +24,5 @@ mod graph;
 mod partial;
 #[cfg(feature = "serde")]
 mod serde;
+mod stitching;
 mod util;

--- a/stack-graphs/tests/it/stitching.rs
+++ b/stack-graphs/tests/it/stitching.rs
@@ -1,0 +1,104 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2023, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use itertools::Itertools;
+use stack_graphs::graph::StackGraph;
+use stack_graphs::partial::PartialPaths;
+use stack_graphs::stitching::Database;
+
+use crate::util::create_partial_path_and_edges;
+use crate::util::create_pop_symbol_node;
+use crate::util::create_push_symbol_node;
+
+fn test_foo_bar_root_candidate_paths(symbols: &[&str], variable: bool) -> usize {
+    let mut graph = StackGraph::new();
+    let file = graph.add_file("test").unwrap();
+    let mut partials = PartialPaths::new();
+
+    let r = StackGraph::root_node();
+    let foo = create_pop_symbol_node(&mut graph, file, "foo", true);
+    let bar = create_pop_symbol_node(&mut graph, file, "bar", true);
+
+    let path_with_variable =
+        create_partial_path_and_edges(&mut graph, &mut partials, &[r, foo, bar]).unwrap();
+
+    let mut path_without_variable = path_with_variable.clone();
+    path_without_variable.eliminate_precondition_stack_variables(&mut partials);
+
+    let mut db = Database::new();
+    db.add_partial_path(&graph, &mut partials, path_with_variable);
+    db.add_partial_path(&graph, &mut partials, path_without_variable);
+
+    let r = StackGraph::root_node();
+    let refs = symbols
+        .into_iter()
+        .map(|r| create_push_symbol_node(&mut graph, file, *r, true))
+        .chain(std::iter::once(r))
+        .collect_vec();
+    let mut path = create_partial_path_and_edges(&mut graph, &mut partials, &refs).unwrap();
+    if !variable {
+        path.eliminate_precondition_stack_variables(&mut partials);
+    }
+
+    let mut results = Vec::new();
+    db.find_candidate_partial_paths_from_root(
+        &mut graph,
+        &mut partials,
+        Some(path.symbol_stack_postcondition),
+        &mut results,
+    );
+
+    results.len()
+}
+
+#[test]
+fn find_candidates_for_exact_symbol_stack_with_variable() {
+    // <"foo","bar",%2> ~ <"foo","bar",%1> | yes, %2 = %1
+    // <"foo","bar",%2> ~ <"foo","bar">    | yes, %2 = <>
+    let results = test_foo_bar_root_candidate_paths(&["bar", "foo"], true);
+    assert_eq!(2, results);
+}
+
+#[test]
+fn find_candidates_for_exact_symbol_stack_without_variable() {
+    // <"foo","bar"> ~ <"foo","bar",%1> | yes, %1 = <>
+    // <"foo","bar"> ~ <"foo","bar">    | yes
+    let results = test_foo_bar_root_candidate_paths(&["bar", "foo"], false);
+    assert_eq!(2, results);
+}
+
+#[test]
+fn find_candidates_for_longer_symbol_stack_with_variable() {
+    // <"foo","bar","quz",%2> ~ <"foo","bar",%1> | yes, %1 = <"quz",%2>
+    // <"foo","bar","quz",%2> ~ <"foo","bar">    | no
+    let results = test_foo_bar_root_candidate_paths(&["quz", "bar", "foo"], true);
+    assert_eq!(1, results);
+}
+
+#[test]
+fn find_candidates_for_longer_symbol_stack_without_variable() {
+    // <"foo","bar","quz"> ~ <"foo","bar",%1> | yes, %1 = <"quz">
+    // <"foo","bar","quz"> ~ <"foo","bar">    | no
+    let results = test_foo_bar_root_candidate_paths(&["quz", "bar", "foo"], false);
+    assert_eq!(1, results);
+}
+
+#[test]
+fn find_candidates_for_shorter_symbol_stack_with_variable() {
+    // <"foo",%2> ~ <"foo","bar",%1> | yes, %2 = <"bar",%1>
+    // <"foo",%2> ~ <"foo","bar">    | yes, %2 = <"bar">
+    let results = test_foo_bar_root_candidate_paths(&["foo"], true);
+    assert_eq!(2, results);
+}
+
+#[test]
+fn find_candidates_for_shorter_symbol_stack_without_variable() {
+    // <"foo"> ~ <"foo","bar",%1> | no
+    // <"foo"> ~ <"foo","bar">    | no
+    let results = test_foo_bar_root_candidate_paths(&["foo"], false);
+    assert_eq!(0, results);
+}

--- a/stack-graphs/tests/it/storage.rs
+++ b/stack-graphs/tests/it/storage.rs
@@ -1,0 +1,127 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2023, stack-graphs authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use itertools::Itertools;
+use stack_graphs::graph::StackGraph;
+use stack_graphs::partial::PartialPaths;
+use stack_graphs::storage::SQLiteWriter;
+use stack_graphs::NoCancellation;
+
+use crate::util::create_partial_path_and_edges;
+use crate::util::create_pop_symbol_node;
+use crate::util::create_push_symbol_node;
+
+fn test_foo_bar_root_candidate_paths(symbols: &[&str], variable: bool) -> usize {
+    let mut reader = {
+        let mut writer = SQLiteWriter::open_in_memory().unwrap();
+
+        let mut graph = StackGraph::new();
+        let file = graph.add_file("test1").unwrap();
+        let mut partials = PartialPaths::new();
+
+        let r = StackGraph::root_node();
+        let foo = create_pop_symbol_node(&mut graph, file, "foo", true);
+        let bar = create_pop_symbol_node(&mut graph, file, "bar", true);
+
+        let path_with_variable =
+            create_partial_path_and_edges(&mut graph, &mut partials, &[r, foo, bar]).unwrap();
+
+        let mut path_without_variable = path_with_variable.clone();
+        path_without_variable.eliminate_precondition_stack_variables(&mut partials);
+
+        writer
+            .store_result_for_file(
+                &graph,
+                file,
+                "",
+                &mut partials,
+                vec![&path_with_variable, &path_without_variable],
+            )
+            .unwrap();
+
+        writer.into_reader()
+    };
+
+    {
+        let (graph, partials, _) = reader.get();
+        let file = graph.add_file("test2").unwrap();
+
+        let r = StackGraph::root_node();
+        let refs = symbols
+            .into_iter()
+            .map(|r| create_push_symbol_node(graph, file, *r, true))
+            .chain(std::iter::once(r))
+            .collect_vec();
+        let mut path = create_partial_path_and_edges(graph, partials, &refs).unwrap();
+        if !variable {
+            path.eliminate_precondition_stack_variables(partials);
+        }
+
+        reader
+            .load_partial_path_extensions(&path, &NoCancellation)
+            .unwrap();
+
+        let (graph, partials, db) = reader.get();
+        let mut results = Vec::new();
+        db.find_candidate_partial_paths_from_root(
+            graph,
+            partials,
+            Some(path.symbol_stack_postcondition),
+            &mut results,
+        );
+
+        results.len()
+    }
+}
+
+#[test]
+fn find_candidates_for_exact_symbol_stack_with_variable() {
+    // <"foo","bar",%2> ~ <"foo","bar",%1> | yes, %2 = %1
+    // <"foo","bar",%2> ~ <"foo","bar">    | yes, %2 = <>
+    let results = test_foo_bar_root_candidate_paths(&["bar", "foo"], true);
+    assert_eq!(2, results);
+}
+
+#[test]
+fn find_candidates_for_exact_symbol_stack_without_variable() {
+    // <"foo","bar"> ~ <"foo","bar",%1> | yes, %1 = <>
+    // <"foo","bar"> ~ <"foo","bar">    | yes
+    let results = test_foo_bar_root_candidate_paths(&["bar", "foo"], false);
+    assert_eq!(2, results);
+}
+
+#[test]
+fn find_candidates_for_longer_symbol_stack_with_variable() {
+    // <"foo","bar","quz",%2> ~ <"foo","bar",%1> | yes, %1 = <"quz",%2>
+    // <"foo","bar","quz",%2> ~ <"foo","bar">    | no
+    let results = test_foo_bar_root_candidate_paths(&["quz", "bar", "foo"], true);
+    assert_eq!(1, results);
+}
+
+#[test]
+fn find_candidates_for_longer_symbol_stack_without_variable() {
+    // <"foo","bar","quz"> ~ <"foo","bar",%1> | yes, %1 = <"quz">
+    // <"foo","bar","quz"> ~ <"foo","bar">    | no
+    let results = test_foo_bar_root_candidate_paths(&["quz", "bar", "foo"], false);
+    assert_eq!(1, results);
+}
+
+#[test]
+fn find_candidates_for_shorter_symbol_stack_with_variable() {
+    // <"foo",%2> ~ <"foo","bar",%1> | yes, %2 = <"bar",%1>
+    // <"foo",%2> ~ <"foo","bar">    | yes, %2 = <"bar">
+    let results = test_foo_bar_root_candidate_paths(&["foo"], true);
+    assert_eq!(2, results);
+}
+
+#[test]
+fn find_candidates_for_shorter_symbol_stack_without_variable() {
+    // <"foo"> ~ <"foo","bar",%1> | no
+    // <"foo"> ~ <"foo","bar">    | no
+    let results = test_foo_bar_root_candidate_paths(&["foo"], false);
+    assert_eq!(0, results);
+}


### PR DESCRIPTION
« #349

This PR makes changes to the loading of candidate paths from the root node:

- It ensure valid candidate paths that were previously missing are included.
- It makes the lookups more precise by considering the absence or presence of variables in the symbol stacks.

## Current

When finding candidate paths from root for a given symbol stack postcondition, any root path with a symbol stack precondition matching (a prefix) of the symbols in the postcondition was selected.

This has two issues:

- _**Incorrect:**_ It would not consider paths with a precondition that _extends_ the postcondition. However, if the postcondition has a variable, it can unify with extensions of the postcondition symbols as well. _This has probably not been a huge problem in practice, because we have used stitching mostly for constructing complete paths. For these paths, the overall precondition does not have a variable, and this case cannot arise._

- _**Imprecise:**_ If a root path has a precondition without variable and which is a strict prefix of the postcondition, it is not actually viable for that postcondition.

## Changes

The `Database` was changed as follows:

- A new `root_paths_by_precondition_prefix` is introduced to record the precondition prefixes of paths in the database, to find the previously missing paths.

- `root_paths_by_precondition_with_variable` and `root_paths_by_precondition_without_variable`.

- The `root_paths_by_precondition` is replaced by `root_paths_by_precondition_with_variable` and `root_paths_by_precondition_without_variable`, to make the lookup more precise.
