### PR TITLE
Support main module configuration in `package.json`

### DIFF
--- a/languages/tree-sitter-stack-graphs-typescript/rust/tsconfig.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/tsconfig.rs
@@ -498,15 +498,15 @@ fn longest_common_prefix(left: &Path, right: &Path) -> Option<PathBuf> {
     Some(prefix)
 }
 
-struct NormalizedRelativePath(PathBuf);
+pub(crate) struct NormalizedRelativePath(PathBuf);
 
 impl NormalizedRelativePath {
-    pub(self) fn from_str(path: &str) -> Option<Self> {
+    pub(crate) fn from_str(path: &str) -> Option<Self> {
         Self::from_path(Path::new(path))
     }
 
     /// Creates a new normalized, relative path from a path.
-    pub(self) fn from_path(path: &Path) -> Option<Self> {
+    pub(crate) fn from_path(path: &Path) -> Option<Self> {
         let mut np = PathBuf::new();
         let mut normal_components = 0usize;
         for c in path.components() {
@@ -538,18 +538,18 @@ impl NormalizedRelativePath {
     }
 
     /// Returns if the relative path escapes to the parent.
-    pub(self) fn escapes(&self) -> bool {
+    pub(crate) fn escapes(&self) -> bool {
         self.0
             .components()
             .next()
             .map_or(false, |c| c == Component::ParentDir)
     }
 
-    pub(self) fn as_path(&self) -> &Path {
+    pub(crate) fn as_path(&self) -> &Path {
         &self.0
     }
 
-    pub(self) fn into_path_buf(self) -> PathBuf {
+    pub(crate) fn into_path_buf(self) -> PathBuf {
         self.0
     }
 }

--- a/languages/tree-sitter-stack-graphs-typescript/test/packages/can-access-package-non-main-explicilty.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/packages/can-access-package-non-main-explicilty.ts
@@ -1,0 +1,51 @@
+/* --- path: acme_foo/tsconfig.json --- */
+/* --- global: FILE_PATH=tsconfig.json --- */
+/* --- global: PROJECT_NAME=acme_foo --- */
+
+{}
+
+/* --- path: acme_foo/package.json --- */
+/* --- global: FILE_PATH=package.json --- */
+/* --- global: PROJECT_NAME=acme_foo --- */
+
+{
+    "name": "@acme/foo",
+    "version": "1.0",
+    "main": "./api"
+}
+
+/* --- path: acme_foo/api.ts --- */
+/* --- global: FILE_PATH=api.ts --- */
+/* --- global: PROJECT_NAME=acme_foo --- */
+
+export let x;
+
+/* --- path: acme_foo/core.ts --- */
+/* --- global: FILE_PATH=core.ts --- */
+/* --- global: PROJECT_NAME=acme_foo --- */
+
+export let x;
+
+/* --- path: bar/tsconfig.json --- */
+/* --- global: FILE_PATH=tsconfig.json --- */
+/* --- global: PROJECT_NAME=bar --- */
+
+{}
+
+/* --- path: bar/package.json --- */
+/* --- global: FILE_PATH=package.json --- */
+/* --- global: PROJECT_NAME=bar --- */
+
+{
+    "name": "bar",
+    "dependencies": {
+        "@acme/foo": "1"
+    }
+}
+
+/* --- path: bar/app.ts --- */
+/* --- global: FILE_PATH=app.ts --- */
+/* --- global: PROJECT_NAME=bar --- */
+
+import { x } from "@acme/foo/core"
+//       ^ defined: 27

--- a/languages/tree-sitter-stack-graphs-typescript/test/packages/package-does-not-export-non-main.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/packages/package-does-not-export-non-main.ts
@@ -1,0 +1,44 @@
+/* --- path: foo/tsconfig.json --- */
+/* --- global: FILE_PATH=tsconfig.json --- */
+/* --- global: PROJECT_NAME=foo --- */
+
+{}
+
+/* --- path: foo/package.json --- */
+/* --- global: FILE_PATH=package.json --- */
+/* --- global: PROJECT_NAME=foo --- */
+
+{
+    "name": "foo",
+    "version": "1.0"
+}
+
+/* --- path: foo/impl.ts --- */
+/* --- global: FILE_PATH=impl.ts --- */
+/* --- global: PROJECT_NAME=foo --- */
+
+export let x;
+
+/* --- path: bar/tsconfig.json --- */
+/* --- global: FILE_PATH=tsconfig.json --- */
+/* --- global: PROJECT_NAME=bar --- */
+
+{}
+
+/* --- path: bar/package.json --- */
+/* --- global: FILE_PATH=package.json --- */
+/* --- global: PROJECT_NAME=bar --- */
+
+{
+    "name": "bar",
+    "dependencies": {
+        "foo": "1"
+    }
+}
+
+/* --- path: bar/app.ts --- */
+/* --- global: FILE_PATH=app.ts --- */
+/* --- global: PROJECT_NAME=bar --- */
+
+import { x } from "foo"
+//       ^ defined:

--- a/languages/tree-sitter-stack-graphs-typescript/test/packages/package-exports-explicit-main.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/packages/package-exports-explicit-main.ts
@@ -1,0 +1,51 @@
+/* --- path: acme_foo/tsconfig.json --- */
+/* --- global: FILE_PATH=tsconfig.json --- */
+/* --- global: PROJECT_NAME=acme_foo --- */
+
+{}
+
+/* --- path: acme_foo/package.json --- */
+/* --- global: FILE_PATH=package.json --- */
+/* --- global: PROJECT_NAME=acme_foo --- */
+
+{
+    "name": "@acme/foo",
+    "version": "1.0",
+    "main": "./api"
+}
+
+/* --- path: acme_foo/api.ts --- */
+/* --- global: FILE_PATH=api.ts --- */
+/* --- global: PROJECT_NAME=acme_foo --- */
+
+export let x;
+
+/* --- path: acme_foo/core.ts --- */
+/* --- global: FILE_PATH=core.ts --- */
+/* --- global: PROJECT_NAME=acme_foo --- */
+
+export let x;
+
+/* --- path: bar/tsconfig.json --- */
+/* --- global: FILE_PATH=tsconfig.json --- */
+/* --- global: PROJECT_NAME=bar --- */
+
+{}
+
+/* --- path: bar/package.json --- */
+/* --- global: FILE_PATH=package.json --- */
+/* --- global: PROJECT_NAME=bar --- */
+
+{
+    "name": "bar",
+    "dependencies": {
+        "@acme/foo": "1"
+    }
+}
+
+/* --- path: bar/app.ts --- */
+/* --- global: FILE_PATH=app.ts --- */
+/* --- global: PROJECT_NAME=bar --- */
+
+import { x } from "@acme/foo"
+//       ^ defined: 21

--- a/languages/tree-sitter-stack-graphs-typescript/test/packages/package-invisible-without-dependency.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/packages/package-invisible-without-dependency.ts
@@ -1,6 +1,7 @@
 /* --- path: ./my_lib/package.json --- */
 /* --- global: FILE_PATH=package.json --- */
 /* --- global: PROJECT_NAME=my_lib --- */
+
 {
     "name": "@my/lib"
 }
@@ -8,17 +9,19 @@
 /* --- path: ./my_lib/tsconfig.json --- */
 /* --- global: FILE_PATH=tsconfig.json --- */
 /* --- global: PROJECT_NAME=my_lib --- */
-{
-}
+
+{}
 
 /* --- path: ./my_lib/src/foo.ts --- */
 /* --- global: FILE_PATH=src/foo.ts --- */
 /* --- global: PROJECT_NAME=my_lib --- */
+
 export const bar = 42;
 
 /* --- path: ./my_app/package.json --- */
 /* --- global: FILE_PATH=package.json --- */
 /* --- global: PROJECT_NAME=my_app --- */
+
 {
     "name": "@my/app"
 }
@@ -26,11 +29,12 @@ export const bar = 42;
 /* --- path: ./my_app/tsconfig.json --- */
 /* --- global: FILE_PATH=tsconfig.json --- */
 /* --- global: PROJECT_NAME=my_app --- */
-{
-}
+
+{}
 
 /* --- path: ./my_app/src/index.ts --- */
 /* --- global: FILE_PATH=src/index.ts --- */
 /* --- global: PROJECT_NAME=my_app --- */
+
 import { bar } from "@my/lib/foo";
 //       ^ defined:

--- a/languages/tree-sitter-stack-graphs-typescript/test/packages/package-main-defaults-to-index.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/packages/package-main-defaults-to-index.ts
@@ -1,0 +1,50 @@
+/* --- path: foo/tsconfig.json --- */
+/* --- global: FILE_PATH=tsconfig.json --- */
+/* --- global: PROJECT_NAME=foo --- */
+
+{}
+
+/* --- path: foo/package.json --- */
+/* --- global: FILE_PATH=package.json --- */
+/* --- global: PROJECT_NAME=foo --- */
+
+{
+    "name": "foo",
+    "version": "1.0"
+}
+
+/* --- path: foo/index.ts --- */
+/* --- global: FILE_PATH=index.ts --- */
+/* --- global: PROJECT_NAME=foo --- */
+
+export let x;
+
+/* --- path: foo/impl.ts --- */
+/* --- global: FILE_PATH=impl.ts --- */
+/* --- global: PROJECT_NAME=foo --- */
+
+export let x;
+
+/* --- path: bar/tsconfig.json --- */
+/* --- global: FILE_PATH=tsconfig.json --- */
+/* --- global: PROJECT_NAME=bar --- */
+
+{}
+
+/* --- path: bar/package.json --- */
+/* --- global: FILE_PATH=package.json --- */
+/* --- global: PROJECT_NAME=bar --- */
+
+{
+    "name": "bar",
+    "dependencies": {
+        "foo": "1"
+    }
+}
+
+/* --- path: bar/app.ts --- */
+/* --- global: FILE_PATH=app.ts --- */
+/* --- global: PROJECT_NAME=bar --- */
+
+import { x } from "foo"
+//       ^ defined: 20


### PR DESCRIPTION
Similar to `tree-sitter-stack-graphs-javascript`, this PR add support for the `main` attribute in `package.json` files.

If a `main` module is specified, the exports of that module are accessible directly from the package name. If it is unspecified, we default to `index` as Node does.
