### PR TITLE
Serialized instead of parallel path finding

### DIFF
--- a/stack-graphs/src/arena.rs
+++ b/stack-graphs/src/arena.rs
@@ -187,6 +187,7 @@ impl<T> Arena<T> {
     #[inline(always)]
     pub(crate) fn clear(&mut self) {
         self.items.clear();
+        self.items.push(MaybeUninit::uninit());
     }
 
     /// Adds a new instance to this arena, returning a stable handle to it.
@@ -294,6 +295,7 @@ impl<H, T> SupplementalArena<H, T> {
     #[inline(always)]
     pub(crate) fn clear(&mut self) {
         self.items.clear();
+        self.items.push(MaybeUninit::uninit());
     }
 
     /// Creates a new, empty supplemental arena, preallocating enough space to store supplemental

--- a/stack-graphs/src/cycles.rs
+++ b/stack-graphs/src/cycles.rs
@@ -52,6 +52,12 @@ pub struct SimilarPathDetector<P> {
     paths: HashMap<PathKey, SmallVec<[P; 4]>>,
 }
 
+impl<P> SimilarPathDetector<P> {
+    pub fn clear(&mut self) {
+        self.paths.clear();
+    }
+}
+
 #[doc(hidden)]
 #[derive(Clone, Eq, Hash, PartialEq)]
 pub struct PathKey {
@@ -162,6 +168,11 @@ impl<H> Appendables<H> {
             elements: ListArena::new(),
             interned: Arena::new(),
         }
+    }
+
+    pub fn clear(&mut self) {
+        self.elements.clear();
+        self.interned.clear();
     }
 }
 

--- a/stack-graphs/tests/it/serde.rs
+++ b/stack-graphs/tests/it/serde.rs
@@ -1002,55 +1002,6 @@ fn can_serialize_partial_paths() {
                         "precedence" : 0,
                         "source" : {
                             "file" : "test.py",
-                            "local_id" : 3
-                        }
-                    },
-                    {
-                        "precedence" : 0,
-                        "source" : {
-                            "file" : "test.py",
-                            "local_id" : 8
-                        }
-                    }
-                ],
-                "end_node" : {
-                    "file" : "test.py",
-                    "local_id" : 9
-                },
-                "scope_stack_postcondition" : {
-                    "scopes" : [],
-                    "variable" : 1
-                },
-                "scope_stack_precondition" : {
-                    "scopes" : [],
-                    "variable" : 1
-                },
-                "start_node" : {
-                    "file" : "test.py",
-                    "local_id" : 3
-                },
-                "symbol_stack_postcondition" : {
-                    "symbols" : [],
-                    "variable" : 1
-                },
-                "symbol_stack_precondition" : {
-                    "symbols" : [
-                        {
-                            "symbol" : "."
-                        },
-                        {
-                            "symbol" : "x"
-                        }
-                    ],
-                    "variable" : 1
-                }
-            },
-            {
-                "edges" : [
-                    {
-                        "precedence" : 0,
-                        "source" : {
-                            "file" : "test.py",
                             "local_id" : 1
                         }
                     },
@@ -1268,6 +1219,55 @@ fn can_serialize_partial_paths() {
                 },
                 "symbol_stack_precondition" : {
                     "symbols" : [],
+                    "variable" : 1
+                }
+            },
+            {
+                "edges" : [
+                    {
+                        "precedence" : 0,
+                        "source" : {
+                            "file" : "test.py",
+                            "local_id" : 3
+                        }
+                    },
+                    {
+                        "precedence" : 0,
+                        "source" : {
+                            "file" : "test.py",
+                            "local_id" : 8
+                        }
+                    }
+                ],
+                "end_node" : {
+                    "file" : "test.py",
+                    "local_id" : 9
+                },
+                "scope_stack_postcondition" : {
+                    "scopes" : [],
+                    "variable" : 1
+                },
+                "scope_stack_precondition" : {
+                    "scopes" : [],
+                    "variable" : 1
+                },
+                "start_node" : {
+                    "file" : "test.py",
+                    "local_id" : 3
+                },
+                "symbol_stack_postcondition" : {
+                    "symbols" : [],
+                    "variable" : 1
+                },
+                "symbol_stack_precondition" : {
+                    "symbols" : [
+                        {
+                            "symbol" : "."
+                        },
+                        {
+                            "symbol" : "x"
+                        }
+                    ],
                     "variable" : 1
                 }
             }


### PR DESCRIPTION
This PR implements an idea I raised in #346: instead of processing all initial paths in parallel, process them in serial.

Note that I've made that change for `find_minimal_partial_path_set_in_file` and `find_all_complete_partial_paths`, not the stitcher itself. Especialyl the former is often called with initial paths for all clickable nodes in the graph, and the effect on max memory usage should be noticable, I hope.
