### PR TITLE
Fix arena clear methods

### DIFF
--- a/stack-graphs/src/arena.rs
+++ b/stack-graphs/src/arena.rs
@@ -185,8 +185,7 @@ impl<T> Arena<T> {
     /// the arena are invalid.
     #[inline(always)]
     pub fn clear(&mut self) {
-        self.items.clear();
-        self.items.push(MaybeUninit::uninit());
+        self.items.truncate(1);
     }
 
     /// Adds a new instance to this arena, returning a stable handle to it.
@@ -292,8 +291,7 @@ impl<H, T> SupplementalArena<H, T> {
     /// all previous handles into the arena are invalid.
     #[inline(always)]
     pub fn clear(&mut self) {
-        self.items.clear();
-        self.items.push(MaybeUninit::uninit());
+        self.items.truncate(1);
     }
 
     /// Creates a new, empty supplemental arena, preallocating enough space to store supplemental

--- a/stack-graphs/src/arena.rs
+++ b/stack-graphs/src/arena.rs
@@ -183,10 +183,10 @@ impl<T> Arena<T> {
 
     /// Clear the arena, keeping underlying allocated capacity.  After this, all previous handles into
     /// the arena are invalid.
-    #[cfg_attr(not(feature = "storage"), allow(dead_code))]
     #[inline(always)]
-    pub(crate) fn clear(&mut self) {
+    pub fn clear(&mut self) {
         self.items.clear();
+        self.items.push(MaybeUninit::uninit());
     }
 
     /// Adds a new instance to this arena, returning a stable handle to it.
@@ -290,10 +290,10 @@ impl<H, T> SupplementalArena<H, T> {
 
     /// Clear the supplemantal arena, keeping underlying allocated capacity.  After this,
     /// all previous handles into the arena are invalid.
-    #[cfg_attr(not(feature = "storage"), allow(dead_code))]
     #[inline(always)]
-    pub(crate) fn clear(&mut self) {
+    pub fn clear(&mut self) {
         self.items.clear();
+        self.items.push(MaybeUninit::uninit());
     }
 
     /// Creates a new, empty supplemental arena, preallocating enough space to store supplemental

--- a/stack-graphs/tests/it/arena.rs
+++ b/stack-graphs/tests/it/arena.rs
@@ -229,3 +229,28 @@ fn can_compare_deques() {
     deque10.ensure_backwards(&mut arena);
     assert_eq!(deque1.cmp(&mut arena, deque10), Ordering::Less);
 }
+
+#[test]
+fn can_use_arena_after_clear() {
+    let mut a = Arena::new();
+    let h = a.add(12 as u8);
+    assert_eq!(12, *a.get(h));
+
+    a.clear();
+    let h = a.add(7);
+    assert_eq!(7, *a.get(h));
+}
+
+#[test]
+fn can_use_supplemental_arena_after_clear() {
+    let mut a = Arena::new();
+    let h = a.add(());
+
+    let mut x = SupplementalArena::new();
+    x[h] = 12;
+    assert_eq!(Some(12), x.get(h).cloned());
+
+    x.clear();
+    x[h] = 7;
+    assert_eq!(Some(7), x.get(h).cloned());
+}


### PR DESCRIPTION
The `.clear()` methods would lose the element at position 0, which could lead to panics. This PR fixes that.
