### PR TITLE
Cleanup TypeScript tests and add two missing cases

### DIFF
--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-directly-exported-variable.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-directly-exported-variable.ts
@@ -1,10 +1,10 @@
-/*--- path: ./ModA.ts ---*/
+/*--- path: ModA.ts ---*/
 
 export let a = {
     v: 42
 };
 
-/*--- path: ./ModB.ts ---*/
+/*--- path: ModB.ts ---*/
 
 import { a } from "./ModA";
 //       ^ defined: 3

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-from-ambient-module-declaration.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-from-ambient-module-declaration.ts
@@ -1,8 +1,8 @@
-/* --- path: ./index.ts --- */
+/* --- path: index.ts --- */
 import { foo } from "@my/lib";
 //       ^ defined: 8
 
-/* --- path: ./mod.ts --- */
+/* --- path: mod.ts --- */
 
 declare module "@my/lib" {
     export const foo = 42;

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-from-own-direcotry-in-index.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-from-own-direcotry-in-index.ts
@@ -1,0 +1,8 @@
+/*--- path: foo/index.ts ---*/
+
+import { FOO } from "./bar";
+//       ^ defined: 8
+
+/*--- path: foo/bar.ts ---*/
+
+export const FOO = 42;

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-from-own-project-subdirectory.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-from-own-project-subdirectory.ts
@@ -1,11 +1,11 @@
-/*--- path: ./A/ModA.ts ---*/
+/*--- path: A/ModA.ts ---*/
 /*--- global: PROJECT_NAME=foo/bar ---*/
 
 export let a = {
     v: 42
 };
 
-/*--- path: ./ModB.ts ---*/
+/*--- path: ModB.ts ---*/
 /*--- global: PROJECT_NAME=foo/bar ---*/
 
 import { a } from "./A/ModA";

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-from-subdirectory.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-from-subdirectory.ts
@@ -1,10 +1,10 @@
-/*--- path: ./A/ModA.ts ---*/
+/*--- path: A/ModA.ts ---*/
 
 export let a = {
     v: 42
 };
 
-/*--- path: ./ModB.ts ---*/
+/*--- path: ModB.ts ---*/
 
 import { a } from "./A/ModA";
 //       ^ defined: 3

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-from-superdirectory.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-from-superdirectory.ts
@@ -1,10 +1,10 @@
-/*--- path: ./ModA.ts ---*/
+/*--- path: ModA.ts ---*/
 
 export let a = {
     v: 42
 };
 
-/*--- path: ./B/ModB.ts ---*/
+/*--- path: B/ModB.ts ---*/
 
 import { a } from "../ModA";
 //       ^ defined: 3

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-indirectly-exported-variable.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-indirectly-exported-variable.ts
@@ -1,4 +1,4 @@
-/*--- path: ./ModA.ts ---*/
+/*--- path: ModA.ts ---*/
 
 let a = {
     v: 42
@@ -7,7 +7,7 @@ let a = {
 export { a };
 //       ^ defined: 3
 
-/*--- path: ./ModB.ts ---*/
+/*--- path: ModB.ts ---*/
 
 import { a } from "./ModA";
 //       ^ defined: 7, 3

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-relative-to-project-root.ts.skip
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-relative-to-project-root.ts.skip
@@ -1,8 +1,8 @@
-/*--- path: ./ModA.ts ---*/
+/*--- path: ModA.ts ---*/
 
 export const a = 42;
 
-/*--- path: ./B/ModB.ts ---*/
+/*--- path: B/ModB.ts ---*/
 
 import { a } from "./ModA";
 //       ^ defined:

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-via-index.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-via-index.ts
@@ -1,10 +1,10 @@
-/*--- path: ./A/index.ts ---*/
+/*--- path: A/index.ts ---*/
 
 export let a = {
     v: 42
 };
 
-/*--- path: ./B/ModB.ts ---*/
+/*--- path: B/ModB.ts ---*/
 
 import { a } from "../A";
 //       ^ defined: 3

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-via-superdirectory.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-via-superdirectory.ts
@@ -1,10 +1,10 @@
-/*--- path: ./A/ModA.ts ---*/
+/*--- path: A/ModA.ts ---*/
 
 export let a = {
     v: 42
 };
 
-/*--- path: ./B/ModB.ts ---*/
+/*--- path: B/ModB.ts ---*/
 
 import { a } from "../A/ModA";
 //       ^ defined: 3

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-via-two-reexports.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-via-two-reexports.ts
@@ -1,0 +1,15 @@
+/* --- path: src/foo/index.ts --- */
+
+export * from "../bar";
+
+/* --- path: src/bar/index.ts --- */
+
+export * from "./quz";
+
+/* --- path: src/bar/quz.ts --- */
+
+export const QUZ = 42;
+
+/* --- path: src/test.ts --- */
+
+import { QUZ } from "./foo";

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/rename-imported-directly-exported-variable.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/rename-imported-directly-exported-variable.ts
@@ -1,10 +1,10 @@
-/*--- path: ./ModA.ts ---*/
+/*--- path: ModA.ts ---*/
 
 export let a = {
     v: 42
 };
 
-/*--- path: ./ModB.ts ---*/
+/*--- path: ModB.ts ---*/
 
 import { a as b } from "./ModA";
 //       ^ defined: 3

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/rename-imported-indirectly-exported-variable.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/rename-imported-indirectly-exported-variable.ts
@@ -1,4 +1,4 @@
-/*--- path: ./ModA.ts ---*/
+/*--- path: ModA.ts ---*/
 
 let a = {
     v: 42
@@ -7,7 +7,7 @@ let a = {
 export { a };
 //       ^ defined: 3
 
-/*--- path: ./ModB.ts ---*/
+/*--- path: ModB.ts ---*/
 
 import { a as b } from "./ModA";
 //       ^ defined: 7, 3

--- a/languages/tree-sitter-stack-graphs-typescript/test/packages/package-invisible-without-dependency.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/packages/package-invisible-without-dependency.ts
@@ -1,4 +1,4 @@
-/* --- path: ./my_lib/package.json --- */
+/* --- path: my_lib/package.json --- */
 /* --- global: FILE_PATH=package.json --- */
 /* --- global: PROJECT_NAME=my_lib --- */
 
@@ -6,19 +6,19 @@
     "name": "@my/lib"
 }
 
-/* --- path: ./my_lib/tsconfig.json --- */
+/* --- path: my_lib/tsconfig.json --- */
 /* --- global: FILE_PATH=tsconfig.json --- */
 /* --- global: PROJECT_NAME=my_lib --- */
 
 {}
 
-/* --- path: ./my_lib/src/foo.ts --- */
+/* --- path: my_lib/src/foo.ts --- */
 /* --- global: FILE_PATH=src/foo.ts --- */
 /* --- global: PROJECT_NAME=my_lib --- */
 
 export const bar = 42;
 
-/* --- path: ./my_app/package.json --- */
+/* --- path: my_app/package.json --- */
 /* --- global: FILE_PATH=package.json --- */
 /* --- global: PROJECT_NAME=my_app --- */
 
@@ -26,13 +26,13 @@ export const bar = 42;
     "name": "@my/app"
 }
 
-/* --- path: ./my_app/tsconfig.json --- */
+/* --- path: my_app/tsconfig.json --- */
 /* --- global: FILE_PATH=tsconfig.json --- */
 /* --- global: PROJECT_NAME=my_app --- */
 
 {}
 
-/* --- path: ./my_app/src/index.ts --- */
+/* --- path: my_app/src/index.ts --- */
 /* --- global: FILE_PATH=src/index.ts --- */
 /* --- global: PROJECT_NAME=my_app --- */
 

--- a/languages/tree-sitter-stack-graphs-typescript/test/projects/baseurl-to-subdir.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/projects/baseurl-to-subdir.ts
@@ -1,4 +1,4 @@
-/* --- path: ./tsconfig.json --- */
+/* --- path: tsconfig.json --- */
 {
     "compilerOptions": {
         "composite": true,
@@ -6,9 +6,9 @@
     }
 }
 
-/* --- path: ./src/foo.ts --- */
+/* --- path: src/foo.ts --- */
 export const bar = 42;
 
-/* --- path: ./src/index.ts --- */
+/* --- path: src/index.ts --- */
 import { bar } from "foo";
 //       ^ defined: 10

--- a/languages/tree-sitter-stack-graphs-typescript/test/projects/composite-project.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/projects/composite-project.ts
@@ -1,13 +1,13 @@
-/* --- path: ./tsconfig.json --- */
+/* --- path: tsconfig.json --- */
 {
     "compilerOptions": {
         "composite": true,
     }
 }
 
-/* --- path: ./src/foo.ts --- */
+/* --- path: src/foo.ts --- */
 export const bar = 42;
 
-/* --- path: ./src/index.ts --- */
+/* --- path: src/index.ts --- */
 import { bar } from "./foo";
 //       ^ defined: 9

--- a/languages/tree-sitter-stack-graphs-typescript/test/projects/declarations-are-ignored.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/projects/declarations-are-ignored.ts
@@ -1,12 +1,12 @@
-/* --- path: ./tsconfig.json --- */
+/* --- path: tsconfig.json --- */
 {
 }
 
-/* --- path: ./src/foo.ts --- */
+/* --- path: src/foo.ts --- */
 export const bar = 42;
 
-/* --- path: ./src/index.ts --- */
+/* --- path: src/index.ts --- */
 import { bar } from "./foo";
 //       ^ defined: 6
 
-/* --- path: ./types/index.d.ts --- */
+/* --- path: types/index.d.ts --- */

--- a/languages/tree-sitter-stack-graphs-typescript/test/projects/exclude-second-subdir.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/projects/exclude-second-subdir.ts
@@ -1,13 +1,13 @@
-/* --- path: ./tsconfig.json --- */
+/* --- path: tsconfig.json --- */
 {
     "exclude": ["test/**/*"]
 }
 
-/* --- path: ./src/foo.ts --- */
+/* --- path: src/foo.ts --- */
 export const bar = 42;
 
-/* --- path: ./src/index.ts --- */
+/* --- path: src/index.ts --- */
 import { bar } from "./foo";
 //       ^ defined: 7
 
-/* --- path: ./test/index.ts --- */
+/* --- path: test/index.ts --- */

--- a/languages/tree-sitter-stack-graphs-typescript/test/projects/explicit-root-dir.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/projects/explicit-root-dir.ts
@@ -1,13 +1,13 @@
-/* --- path: ./tsconfig.json --- */
+/* --- path: tsconfig.json --- */
 {
     "compilerOptions": {
         "rootDir": "."
     }
 }
 
-/* --- path: ./core/foo.ts --- */
+/* --- path: core/foo.ts --- */
 export const bar = 42;
 
-/* --- path: ./core/index.ts --- */
+/* --- path: core/index.ts --- */
 import { bar } from "./foo";
 //       ^ defined: 9

--- a/languages/tree-sitter-stack-graphs-typescript/test/projects/import-from-rootdirs-subdir.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/projects/import-from-rootdirs-subdir.ts
@@ -1,4 +1,4 @@
-/* --- path: ./tsconfig.json --- */
+/* --- path: tsconfig.json --- */
 {
     "compilerOptions": {
         "rootDirs": [
@@ -8,13 +8,13 @@
     }
 }
 
-/* --- path: ./src/core/index.ts --- */
+/* --- path: src/core/index.ts --- */
 import { bar } from "./foo/baz";
 //       ^ defined: 16
 
-/* --- path: ./src/util/foo/baz.ts --- */
+/* --- path: src/util/foo/baz.ts --- */
 export const bar = 42;
 
-/* --- path: ./src/util/index.ts --- */
+/* --- path: src/util/index.ts --- */
 
-/* --- path: ./src/index.ts --- */
+/* --- path: src/index.ts --- */

--- a/languages/tree-sitter-stack-graphs-typescript/test/projects/import-from-rootdirs.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/projects/import-from-rootdirs.ts
@@ -1,4 +1,4 @@
-/* --- path: ./tsconfig.json --- */
+/* --- path: tsconfig.json --- */
 {
     "compilerOptions": {
         "rootDirs": [
@@ -8,13 +8,13 @@
     }
 }
 
-/* --- path: ./src/core/index.ts --- */
+/* --- path: src/core/index.ts --- */
 import { bar } from "./foo";
 //       ^ defined: 16
 
-/* --- path: ./src/util/foo.ts --- */
+/* --- path: src/util/foo.ts --- */
 export const bar = 42;
 
-/* --- path: ./src/util/index.ts --- */
+/* --- path: src/util/index.ts --- */
 
-/* --- path: ./src/index.ts --- */
+/* --- path: src/index.ts --- */

--- a/languages/tree-sitter-stack-graphs-typescript/test/projects/import-with-own-project-baseurl.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/projects/import-with-own-project-baseurl.ts
@@ -1,4 +1,4 @@
-/* --- path: ./tsconfig.json --- */
+/* --- path: tsconfig.json --- */
 /* --- global: PROJECT_NAME=a --- */
 {
     "compilerOptions": {
@@ -7,11 +7,11 @@
     }
 }
 
-/* --- path: ./src/foo.ts --- */
+/* --- path: src/foo.ts --- */
 /* --- global: PROJECT_NAME=a --- */
 export const bar = 42;
 
-/* --- path: ./src/index.ts --- */
+/* --- path: src/index.ts --- */
 /* --- global: PROJECT_NAME=a --- */
 import { bar } from "foo";
 //       ^ defined: 12

--- a/languages/tree-sitter-stack-graphs-typescript/test/projects/include-one-subdir.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/projects/include-one-subdir.ts
@@ -1,13 +1,13 @@
-/* --- path: ./tsconfig.json --- */
+/* --- path: tsconfig.json --- */
 {
     "include": ["src/**/*"]
 }
 
-/* --- path: ./src/foo.ts --- */
+/* --- path: src/foo.ts --- */
 export const bar = 42;
 
-/* --- path: ./src/index.ts --- */
+/* --- path: src/index.ts --- */
 import { bar } from "./foo";
 //       ^ defined: 7
 
-/* --- path: ./test/index.ts --- */
+/* --- path: test/index.ts --- */

--- a/languages/tree-sitter-stack-graphs-typescript/test/projects/invalid-paths-mappings.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/projects/invalid-paths-mappings.ts
@@ -1,4 +1,4 @@
-/* --- path: ./tsconfig.json --- */
+/* --- path: tsconfig.json --- */
 {
     "compilerOptions": {
         "paths": {

--- a/languages/tree-sitter-stack-graphs-typescript/test/projects/js-sources-are-ignored.ts.skip
+++ b/languages/tree-sitter-stack-graphs-typescript/test/projects/js-sources-are-ignored.ts.skip
@@ -1,12 +1,12 @@
-/* --- path: ./tsconfig.json --- */
+/* --- path: tsconfig.json --- */
 {
 }
 
-/* --- path: ./lib/index.js --- */
+/* --- path: lib/index.js --- */
 
-/* --- path: ./src/foo.ts --- */
+/* --- path: src/foo.ts --- */
 export const bar = 42;
 
-/* --- path: ./src/index.ts --- */
+/* --- path: src/index.ts --- */
 import { bar } from "./foo";
 //       ^ defined: 8

--- a/languages/tree-sitter-stack-graphs-typescript/test/projects/js-sources-can-be-allowed.ts.skip
+++ b/languages/tree-sitter-stack-graphs-typescript/test/projects/js-sources-can-be-allowed.ts.skip
@@ -1,15 +1,15 @@
-/* --- path: ./tsconfig.json --- */
+/* --- path: tsconfig.json --- */
 {
     "compilerOptions": {
         "allowJs": true
     }
 }
 
-/* --- path: ./lib/index.js --- */
+/* --- path: lib/index.js --- */
 
-/* --- path: ./src/foo.ts --- */
+/* --- path: src/foo.ts --- */
 export const bar = 42;
 
-/* --- path: ./src/index.ts --- */
+/* --- path: src/index.ts --- */
 import { bar } from "./foo";
 //       ^ defined: 11

--- a/languages/tree-sitter-stack-graphs-typescript/test/projects/non-relative-single-module-remap.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/projects/non-relative-single-module-remap.ts
@@ -1,4 +1,4 @@
-/* --- path: ./tsconfig.json --- */
+/* --- path: tsconfig.json --- */
 {
     "compilerOptions": {
         "composite": true,
@@ -9,9 +9,9 @@
     }
 }
 
-/* --- path: ./lib/the_foo.ts --- */
+/* --- path: lib/the_foo.ts --- */
 export const bar = 42;
 
-/* --- path: ./src/index.ts --- */
+/* --- path: src/index.ts --- */
 import { bar } from "foo";
 //       ^ defined: 13

--- a/languages/tree-sitter-stack-graphs-typescript/test/projects/non-relative-star-remap.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/projects/non-relative-star-remap.ts
@@ -1,4 +1,4 @@
-/* --- path: ./tsconfig.json --- */
+/* --- path: tsconfig.json --- */
 {
     "compilerOptions": {
         "composite": true,
@@ -9,9 +9,9 @@
     }
 }
 
-/* --- path: ./lib/foo.ts --- */
+/* --- path: lib/foo.ts --- */
 export const bar = 42;
 
-/* --- path: ./src/index.ts --- */
+/* --- path: src/index.ts --- */
 import { bar } from "foo";
 //       ^ defined: 13

--- a/languages/tree-sitter-stack-graphs-typescript/test/projects/non-relative-star-remaps.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/projects/non-relative-star-remaps.ts
@@ -1,4 +1,4 @@
-/* --- path: ./tsconfig.json --- */
+/* --- path: tsconfig.json --- */
 {
     "compilerOptions": {
         "composite": true,
@@ -9,9 +9,9 @@
     }
 }
 
-/* --- path: ./ext/foo.ts --- */
+/* --- path: ext/foo.ts --- */
 export const bar = 42;
 
-/* --- path: ./src/index.ts --- */
+/* --- path: src/index.ts --- */
 import { bar } from "foo";
 //       ^ defined: 13

--- a/languages/tree-sitter-stack-graphs-typescript/test/projects/one-file-in-subdir.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/projects/one-file-in-subdir.ts
@@ -1,13 +1,13 @@
-/* --- path: ./tsconfig.json --- */
+/* --- path: tsconfig.json --- */
 {
     "files": ["src/index.ts"]
 }
 
-/* --- path: ./src/foo.ts --- */
+/* --- path: src/foo.ts --- */
 export const bar = 42;
 
-/* --- path: ./src/index.ts --- */
+/* --- path: src/index.ts --- */
 import { bar } from "./foo";
 //       ^ defined: 7
 
-/* --- path: ./test/index.ts --- */
+/* --- path: test/index.ts --- */

--- a/languages/tree-sitter-stack-graphs-typescript/test/projects/package-dependency-with-nested-source-root.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/projects/package-dependency-with-nested-source-root.ts
@@ -1,22 +1,22 @@
-/* --- path: ./my_lib/package.json --- */
+/* --- path: my_lib/package.json --- */
 /* --- global: FILE_PATH=package.json --- */
 /* --- global: PROJECT_NAME=my_lib --- */
 {
     "name": "@my/lib"
 }
 
-/* --- path: ./my_lib/tsconfig.json --- */
+/* --- path: my_lib/tsconfig.json --- */
 /* --- global: FILE_PATH=tsconfig.json --- */
 /* --- global: PROJECT_NAME=my_lib --- */
 {
 }
 
-/* --- path: ./my_lib/src/foo.ts --- */
+/* --- path: my_lib/src/foo.ts --- */
 /* --- global: FILE_PATH=src/foo.ts --- */
 /* --- global: PROJECT_NAME=my_lib --- */
 export const bar = 42;
 
-/* --- path: ./my_app/package.json --- */
+/* --- path: my_app/package.json --- */
 /* --- global: FILE_PATH=package.json --- */
 /* --- global: PROJECT_NAME=my_app --- */
 {
@@ -26,13 +26,13 @@ export const bar = 42;
     }
 }
 
-/* --- path: ./my_app/tsconfig.json --- */
+/* --- path: my_app/tsconfig.json --- */
 /* --- global: FILE_PATH=tsconfig.json --- */
 /* --- global: PROJECT_NAME=my_app --- */
 {
 }
 
-/* --- path: ./my_app/src/index.ts --- */
+/* --- path: my_app/src/index.ts --- */
 /* --- global: FILE_PATH=src/index.ts --- */
 /* --- global: PROJECT_NAME=my_app --- */
 import { bar } from "@my/lib/foo";

--- a/languages/tree-sitter-stack-graphs-typescript/test/projects/relative-import.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/projects/relative-import.ts
@@ -1,13 +1,13 @@
-/* --- path: ./tsconfig.json --- */
+/* --- path: tsconfig.json --- */
 {
     "compilerOptions": {
         "composite": true
     }
 }
 
-/* --- path: ./src/foo.ts --- */
+/* --- path: src/foo.ts --- */
 export const bar = 42;
 
-/* --- path: ./src/index.ts --- */
+/* --- path: src/index.ts --- */
 import { bar } from "./foo";
 //       ^ defined: 9

--- a/languages/tree-sitter-stack-graphs-typescript/test/projects/relative-single-module-remap.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/projects/relative-single-module-remap.ts
@@ -1,4 +1,4 @@
-/* --- path: ./tsconfig.json --- */
+/* --- path: tsconfig.json --- */
 {
     "compilerOptions": {
         "composite": true,
@@ -8,9 +8,9 @@
     }
 }
 
-/* --- path: ./lib/the_foo.ts --- */
+/* --- path: lib/the_foo.ts --- */
 export const bar = 42;
 
-/* --- path: ./src/index.ts --- */
+/* --- path: src/index.ts --- */
 import { bar } from "foo";
 //       ^ defined: 12

--- a/languages/tree-sitter-stack-graphs-typescript/test/projects/relative-star-remap.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/projects/relative-star-remap.ts
@@ -1,4 +1,4 @@
-/* --- path: ./tsconfig.json --- */
+/* --- path: tsconfig.json --- */
 {
     "compilerOptions": {
         "composite": true,
@@ -8,9 +8,9 @@
     }
 }
 
-/* --- path: ./lib/foo.ts --- */
+/* --- path: lib/foo.ts --- */
 export const bar = 42;
 
-/* --- path: ./src/index.ts --- */
+/* --- path: src/index.ts --- */
 import { bar } from "foo";
 //       ^ defined: 12

--- a/languages/tree-sitter-stack-graphs-typescript/test/projects/remap-with-baseurl.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/projects/remap-with-baseurl.ts
@@ -1,4 +1,4 @@
-/* --- path: ./tsconfig.json --- */
+/* --- path: tsconfig.json --- */
 {
     "compilerOptions": {
         "composite": true,
@@ -9,9 +9,9 @@
     }
 }
 
-/* --- path: ./src/util_impl/foo.ts --- */
+/* --- path: src/util_impl/foo.ts --- */
 export const bar = 42;
 
-/* --- path: ./src/index.ts --- */
+/* --- path: src/index.ts --- */
 import { bar } from "util/foo";
 //       ^ defined: 13

--- a/languages/tree-sitter-stack-graphs-typescript/test/projects/sources-in-multiple-subdirs.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/projects/sources-in-multiple-subdirs.ts
@@ -1,12 +1,12 @@
-/* --- path: ./tsconfig.json --- */
+/* --- path: tsconfig.json --- */
 {
 }
 
-/* --- path: ./src/foo.ts --- */
+/* --- path: src/foo.ts --- */
 export const bar = 42;
 
-/* --- path: ./src/index.ts --- */
+/* --- path: src/index.ts --- */
 import { bar } from "./foo";
 //       ^ defined: 6
 
-/* --- path: ./test/index.ts --- */
+/* --- path: test/index.ts --- */

--- a/languages/tree-sitter-stack-graphs-typescript/test/projects/sources-in-one-subdir.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/projects/sources-in-one-subdir.ts
@@ -1,10 +1,10 @@
-/* --- path: ./tsconfig.json --- */
+/* --- path: tsconfig.json --- */
 {
 }
 
-/* --- path: ./src/foo.ts --- */
+/* --- path: src/foo.ts --- */
 export const bar = 42;
 
-/* --- path: ./src/index.ts --- */
+/* --- path: src/index.ts --- */
 import { bar } from "./foo";
 //       ^ defined: 6


### PR DESCRIPTION
Adds two test for cases that were missing.

Also, cleanup the multifile tests to ensure fragment paths are normalized.
