### PR TITLE
Remove Extraneous New Expr Edges

### DIFF
--- a/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
@@ -3184,9 +3184,6 @@ inherit .return_or_yield
   edge @new_expr.value -> new_expr_guard_this
   edge new_expr_guard_this -> new_expr_call
 
-  ; value coming from the field decls in the class
-  edge @new_expr.value -> @constructor.value
-
   ; value also coming from the prototype
   node guard_prototype
   attr (guard_prototype) push_symbol = "GUARD:PROTOTYPE"

--- a/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
@@ -4476,7 +4476,7 @@ inherit .return_or_yield
   edge pop_default_guard -> @right.value
 
   ;; For ES6 interoperability, expose members as named exports
-  attr (pop_dot) pop_symbol = "GAURD:MEMBER"
+  attr (pop_dot) pop_symbol = "GUARD:MEMBER"
   edge @assignment_expr.exports -> pop_dot
   edge pop_dot -> @right.value
 


### PR DESCRIPTION
This PR removes extraneous edges in the graphs for `new_expression`. This was causing a bug in the VEA Living Spec test case https://github.com/github/living-spec-vea/tree/main/vulnerabilities_in_class_definition. Once this PR is merged, that test should pass as expected.