### PR TITLE
Nested function returns

### DIFF
--- a/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
@@ -2818,7 +2818,7 @@ inherit .return_or_yield
   ; function values have return nodes which need to be visible for returns
   attr (fun_value_return) pop_symbol = "GUARD:RETURN"
   edge fun_value_call -> fun_value_return
-  let @body.return_or_yield = fun_value_return
+  edge fun_value_return -> @fun.return_or_yield
 
   ; function values have this nodes which need to be visible for method calls
   attr (fun_value_this) push_symbol = "this"

--- a/languages/tree-sitter-stack-graphs-javascript/test/base_syntax.js
+++ b/languages/tree-sitter-stack-graphs-javascript/test/base_syntax.js
@@ -45,6 +45,7 @@ undefined;
 [];
 [1, 2, 3];
 function () { return; };
+function () { return function () { }; };
 () => { };
 () => () => { };
 function* () { yield 1; };

--- a/languages/tree-sitter-stack-graphs-javascript/test/base_syntax.js
+++ b/languages/tree-sitter-stack-graphs-javascript/test/base_syntax.js
@@ -46,6 +46,7 @@ undefined;
 [1, 2, 3];
 function () { return; };
 () => { };
+() => () => { };
 function* () { yield 1; };
 foo();
 foo(bar);


### PR DESCRIPTION
This PR resolves duplicate variable errors in relation to nested functions in JavaScript. It partially addresses https://github.com/github/aleph/issues/3205.