### PR TITLE
Comments around keywords in `if`

### DIFF
--- a/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
@@ -1714,7 +1714,7 @@ inherit .return_or_yield
 }
 
 (else_clause
-  (_)@inner)@else_clause {
+  . (_)@inner)@else_clause {
 
     let @else_clause.hoist_point = @inner.before_scope
 

--- a/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
@@ -1708,6 +1708,11 @@ inherit .return_or_yield
     edge @if_stmt.after_scope -> @alternative.after_scope
 }
 
+(else_clause)@else_clause {
+    node @else_clause.after_scope
+    node @else_clause.before_scope
+}
+
 (else_clause
   (_)@inner)@else_clause {
 
@@ -1716,8 +1721,6 @@ inherit .return_or_yield
 }
 
 (else_clause (_)@inner)@else_clause {
-    node @else_clause.after_scope
-    node @else_clause.before_scope
     ; scopes flow in and right back out
     edge @inner.before_scope -> @else_clause.before_scope
     edge @else_clause.after_scope -> @inner.after_scope

--- a/languages/tree-sitter-stack-graphs-javascript/test/base_syntax.js
+++ b/languages/tree-sitter-stack-graphs-javascript/test/base_syntax.js
@@ -12,6 +12,11 @@ function* foo() { }
 class Foo { }
 { }
 if (true) { }
+if (true) { } else { }
+if (/**/ true) /**/ { } else /**/ { }
+if (true) return;
+if (true) return; else return;
+if (/**/ true) /**/ return; else /**/ return;
 switch (x) { }
 for (x; y; z) { }
 for (x in xs) { }


### PR DESCRIPTION
This PR addresses errors arising in `if`/`else` blocks when comments are added around the keywords. It partially fixes https://github.com/github/aleph/issues/3205.