### PR TITLE
'this' in class methods can see the methods and fields

### DIFF
--- a/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
@@ -257,6 +257,7 @@ inherit .import_statement
 inherit .pkg_pop
 inherit .pkg_push
 inherit .return_or_yield
+inherit .containing_class_value
 
 
 
@@ -357,6 +358,10 @@ inherit .return_or_yield
     node @prog.builtins_Regex_prototype
     node @prog.builtins_arguments_prototype
     node @prog.builtins_empty_object
+    ; !!!! HACK
+    ; stack graphs currently make it impossible to test if an inherited variable
+    ; like this is defined or not
+    let @prog.containing_class_value = @prog.builtins_null
 
 }
 
@@ -1429,6 +1434,7 @@ inherit .return_or_yield
 
   node @name.pop
   node @class_decl.class_value
+  let @class_decl.containing_class_value = @class_decl.class_value
   node guard_prototype
   node @class_decl.prototype
   node @class_decl.constructor
@@ -2382,6 +2388,14 @@ inherit .return_or_yield
   ; this is a lookup, ie a push
   attr (@this.value) symbol_reference = "this", source_node = @this
   edge @this.value -> @this.before_scope
+
+  node pop_this
+  attr (pop_this) symbol_definition = "this"
+  node guard_prototype
+  attr (guard_prototype) push_symbol = "GUARD:PROTOTYPE"
+  edge @this.value -> pop_this
+  edge pop_this -> guard_prototype
+  edge guard_prototype -> @this.containing_class_value
 }
 
 

--- a/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
@@ -3464,6 +3464,7 @@ inherit .containing_class_value
   body:(_)@body)@class {
 
   node @class.class_value
+  let @class.containing_class_value = @class.class_value
   node guard_prototype
   node @class.prototype
   node @class.constructor

--- a/languages/tree-sitter-stack-graphs-javascript/test/computation_flow/class_declaration_fields_and_methods_visible_in_other_methods.js
+++ b/languages/tree-sitter-stack-graphs-javascript/test/computation_flow/class_declaration_fields_and_methods_visible_in_other_methods.js
@@ -6,6 +6,6 @@ class Foo {
         //   ^ defined: 2
 
         this.baz();
-        //   ^ defined: 2
+        //   ^ defined: 3
     }
 }

--- a/languages/tree-sitter-stack-graphs-javascript/test/computation_flow/class_declaration_fields_and_methods_visible_in_other_methods.js
+++ b/languages/tree-sitter-stack-graphs-javascript/test/computation_flow/class_declaration_fields_and_methods_visible_in_other_methods.js
@@ -9,3 +9,15 @@ class Foo {
         //   ^ defined: 3
     }
 }
+
+(class {
+    bar = 1;
+    baz() { }
+    quux() {
+        this.bar;
+        //   ^ defined: 14
+
+        this.baz();
+        //   ^ defined: 15
+    }
+});

--- a/languages/tree-sitter-stack-graphs-javascript/test/computation_flow/class_declaration_fields_and_methods_visible_in_other_methods.js
+++ b/languages/tree-sitter-stack-graphs-javascript/test/computation_flow/class_declaration_fields_and_methods_visible_in_other_methods.js
@@ -1,0 +1,11 @@
+class Foo {
+    bar = 1;
+    baz() { }
+    quux() {
+        this.bar;
+        //   ^ defined: 2
+
+        this.baz();
+        //   ^ defined: 2
+    }
+}


### PR DESCRIPTION
Makes `this` refer correctly in class definitions, making the following test pass:

```javascript
class Foo {
    bar = 1;
    baz() { }
    quux() {
        this.bar;
        //   ^ defined: 2

        this.baz();
        //   ^ defined: 3
    }
}

(class {
    bar = 1;
    baz() { }
    quux() {
        this.bar;
        //   ^ defined: 14

        this.baz();
        //   ^ defined: 15
    }
});
```