### PR TITLE
"undefined" can be the name of a parameter, too

### DIFF
--- a/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
@@ -2412,6 +2412,9 @@ inherit .return_or_yield
 
   ; the value of undefined is the undefined primitive
   edge @undefined.value -> @undefined.builtins_undefined
+
+  ; HACK: `undefined` is a perfectly cromulent name for a parameter, but the parser thinks it means this node instead. For the moment, work around the problem this causes by giving all `undefined` nodes covalues like parameters enjoy.
+  node @undefined.covalue
 }
 
 

--- a/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
@@ -2413,7 +2413,7 @@ inherit .return_or_yield
   ; the value of undefined is the undefined primitive
   edge @undefined.value -> @undefined.builtins_undefined
 
-  ; HACK: `undefined` is a perfectly cromulent name for a parameter, but the parser thinks it means this node instead. For the moment, work around the problem this causes by giving all `undefined` nodes covalues like parameters enjoy.
+  ; !!!! HACK: `undefined` is a perfectly cromulent name for a parameter, but the parser thinks it means this node instead. For the moment, work around the problem this causes by giving all `undefined` nodes covalues like parameters enjoy.
   node @undefined.covalue
 }
 

--- a/languages/tree-sitter-stack-graphs-javascript/test/base_syntax.js
+++ b/languages/tree-sitter-stack-graphs-javascript/test/base_syntax.js
@@ -9,6 +9,7 @@ var x;
 let x;
 function foo() { }
 function foo(a) { }
+function foo(undefined) { }
 function* foo() { }
 class Foo { }
 { }

--- a/languages/tree-sitter-stack-graphs-javascript/test/base_syntax.js
+++ b/languages/tree-sitter-stack-graphs-javascript/test/base_syntax.js
@@ -8,6 +8,7 @@ debugger;
 var x;
 let x;
 function foo() { }
+function foo(a) { }
 function* foo() { }
 class Foo { }
 { }


### PR DESCRIPTION
When your function has a parameter named `undefined`, the parser makes it into an `(undefined)` node, distinct from all other parameters, and it doesn't get a `covalue`. This should probably be fixed in the parser, but in the interest of expedience (you'd be surprised/impressed/dismayed at how often this arises), we can work around the problem in the interim by just letting `(undefined)` sub in for a param—or, otherwise put: if it walks like a parameter, and it quacks like a parameter, it had better have a covalue like a parameter.

https://github.com/github/aleph/issues/3205