### PR TITLE
JSX expressions can contain comments

### DIFF
--- a/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
@@ -3675,10 +3675,14 @@ inherit .return_or_yield
 
 }
 
-(jsx_expression (_)?@child)@jsx_expression {
+(jsx_expression)@jsx_expression {
 
   node @jsx_expression.before_scope
   node @jsx_expression.after_scope
+
+}
+
+(jsx_expression (_)?@child)@jsx_expression {
 
   if none @child {
     edge @jsx_expression.after_scope -> @jsx_expression.before_scope

--- a/languages/tree-sitter-stack-graphs-javascript/test/base_syntax.js
+++ b/languages/tree-sitter-stack-graphs-javascript/test/base_syntax.js
@@ -77,5 +77,5 @@ class { };
     <quux0.quux1.quux2 />
     <>doo</>
     {garply}
-    {}
+    { }
 </foo>

--- a/languages/tree-sitter-stack-graphs-javascript/test/base_syntax.js
+++ b/languages/tree-sitter-stack-graphs-javascript/test/base_syntax.js
@@ -78,4 +78,5 @@ class { };
     <>doo</>
     {garply}
     { }
+    {/**/x}
 </foo>

--- a/languages/tree-sitter-stack-graphs-javascript/test/base_syntax.js
+++ b/languages/tree-sitter-stack-graphs-javascript/test/base_syntax.js
@@ -77,4 +77,5 @@ class { };
     <quux0.quux1.quux2 />
     <>doo</>
     {garply}
+    {}
 </foo>


### PR DESCRIPTION
JSX expressions containing comments as well as real actual expressions™ run into duplicate variables because the containing node now has multiple children, where the rules expected only one. Easy fix.

https://github.com/github/aleph/issues/3205