### PR TITLE
Field declarations for private properties receive scopes

### DIFF
--- a/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
@@ -1661,11 +1661,14 @@ inherit .containing_class_value
 
 
 
+(field_definition)@field_def {
+  node @field_def.after_scope
+  node @field_def.before_scope
+}
+
 (field_definition
   property:(property_identifier)@property)@field_def {
 
-  node @field_def.after_scope
-  node @field_def.before_scope
   node @property.pop
   node property_pop_dot
   

--- a/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
@@ -1667,7 +1667,7 @@ inherit .containing_class_value
 }
 
 (field_definition
-  property:(property_identifier)@property)@field_def {
+  property:(_)@property)@field_def {
 
   node @property.pop
   node property_pop_dot

--- a/languages/tree-sitter-stack-graphs-javascript/test/base_syntax.js
+++ b/languages/tree-sitter-stack-graphs-javascript/test/base_syntax.js
@@ -11,7 +11,9 @@ function foo() { }
 function foo(a) { }
 function foo(undefined) { }
 function* foo() { }
-class Foo { }
+class Foo {
+    #x = null;
+}
 @Foo class Bar { }
 @Foo.Quux class Bar { }
 @Foo() class Bar { }


### PR DESCRIPTION
This addresses some errors seen in the logs.