### PR TITLE
Class static blocks

### DIFF
--- a/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
@@ -1693,9 +1693,11 @@ inherit .containing_class_value
   edge @property.pop -> @value.value
 }
 
-(class_static_block) @static_block {
+(class_static_block body: (_) @body) @static_block {
   node @static_block.before_scope
   node @static_block.after_scope
+
+  edge @body.before_scope -> @static_block.before_scope
 }
 
 

--- a/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
@@ -1698,6 +1698,8 @@ inherit .containing_class_value
   node @static_block.after_scope
 
   edge @body.before_scope -> @static_block.before_scope
+
+  edge @static_block.after_scope -> @static_block.before_scope
 }
 
 

--- a/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
@@ -1693,6 +1693,11 @@ inherit .containing_class_value
   edge @property.pop -> @value.value
 }
 
+(class_static_block) @static_block {
+  node @static_block.before_scope
+  node @static_block.after_scope
+}
+
 
 
 ;; #### Statement Block

--- a/languages/tree-sitter-stack-graphs-javascript/test/base_syntax.js
+++ b/languages/tree-sitter-stack-graphs-javascript/test/base_syntax.js
@@ -13,6 +13,7 @@ function foo(undefined) { }
 function* foo() { }
 class Foo {
     #x = null;
+    static {}
 }
 @Foo class Bar { }
 @Foo.Quux class Bar { }


### PR DESCRIPTION
JavaScript allows you to have `static` blocks of code in class scope which need to participate in name resolution. Easy enough.