### PR TITLE
Comments in computed property names

### DIFF
--- a/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
@@ -2582,10 +2582,13 @@ inherit .containing_class_value
 
 ; pairs
 
-(computed_property_name (_)@expr)@computed_property_name {
-
+(computed_property_name)@computed_property_name {
     node @computed_property_name.after_scope
     node @computed_property_name.before_scope
+}
+
+(computed_property_name (_)@expr)@computed_property_name {
+
     edge @expr.before_scope -> @computed_property_name.before_scope
     edge @computed_property_name.after_scope -> @expr.after_scope
 

--- a/languages/tree-sitter-stack-graphs-javascript/test/base_syntax.js
+++ b/languages/tree-sitter-stack-graphs-javascript/test/base_syntax.js
@@ -13,6 +13,7 @@ function foo(undefined) { }
 function* foo() { }
 class Foo {
     #x = null;
+    get [/**/ foo]() {}
 }
 @Foo class Bar { }
 @Foo.Quux class Bar { }


### PR DESCRIPTION
Computed property names can contain comments, which results in multiple matches despite the fact that there's only the one (expression) node in there that we care about.