### PR TITLE
Dependency version cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,17 @@ jobs:
     strategy:
       matrix:
         rust: [stable]
+    env:
+      # cargo hack does not use the default-members in Cargo.toml, so we restrict to those explicitly
+      CARGO_HACK: cargo hack -p lsp-positions -p stack-graphs -p tree-sitter-stack-graphs --feature-powerset --exclude-features copious-debugging
 
     steps:
       - name: Install Rust environment
         uses: hecrj/setup-rust-action@v1
         with:
           rust-version: ${{ matrix.rust }}
+      - name: Install cargo-hack
+        run: cargo install cargo-hack
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Check formatting
@@ -36,28 +41,24 @@ jobs:
           key: ${{ runner.OS }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.OS }}-cargo-
+      - name: Build library (all feature combinations)
+        run: ${{ env.CARGO_HACK }} --no-dev-deps build
+      - name: Run test suite (all feature combinations)
+        run: ${{ env.CARGO_HACK }} test
+      - name: Run test suite with all optimizations (default features)
+        run: cargo test --release
       - name: Install cargo-valgrind
         run: |
           sudo apt-get update
           sudo apt-get install -y valgrind
           cargo install cargo-valgrind
-      - name: Build library
-        run: cargo build
+      - name: Run test suite under valgrind (default features)
+        # We only need to use valgrind to test the crates that have C bindings.
+        run: cargo valgrind test -p stack-graphs
       - name: Ensure C headers are up to date
         run: |
           script/cbindgen
           test -z "$(git status --porcelain)"
-      - name: Run test suite
-        run: cargo test
-      - name: Run test suite under valgrind
-        # We only need to use valgrind to test the crates that have C bindings.
-        run: cargo valgrind test -p stack-graphs
-      - name: Run lsp-positions tests without tree-sitter
-        run: cargo test -p lsp-positions --no-default-features
-      - name: Run test suite with all features enabled
-        run: cargo test --all-features
-      - name: Run test suite with all optimizations
-        run: cargo test --release
 
   test-init:
     needs: [test-rust]
@@ -112,6 +113,8 @@ jobs:
         uses: hecrj/setup-rust-action@v1
         with:
           rust-version: ${{ matrix.rust }}
+      - name: Install cargo-hack
+        run: cargo install cargo-hack
       - name: Cache dependencies
         uses: actions/cache@v3
         with:
@@ -123,10 +126,10 @@ jobs:
             ${{ runner.OS }}-cargo-
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Build
-        run: cargo build -p ${{ matrix.language }}
-      - name: Test
-        run: cargo test -p ${{ matrix.language }}
+      - name: Build (all feature combinations)
+        run: cargo hack -p ${{ matrix.language }} --feature-powerset build
+      - name: Test (all features)
+        run: cargo test -p ${{ matrix.language }} --all-features
 
   test-cli:
     runs-on: ubuntu-latest

--- a/languages/tree-sitter-stack-graphs-java/Cargo.toml
+++ b/languages/tree-sitter-stack-graphs-java/Cargo.toml
@@ -41,8 +41,8 @@ cli = ["anyhow", "clap", "tree-sitter-stack-graphs/cli"]
 anyhow = { version = "1.0", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 tree-sitter-java = { version = "=0.20.0" }
-tree-sitter-stack-graphs = { version = "0.7", path = "../../tree-sitter-stack-graphs" }
+tree-sitter-stack-graphs = { version = "0.8", path = "../../tree-sitter-stack-graphs" }
 
 [dev-dependencies]
 anyhow = { version = "1.0" }
-tree-sitter-stack-graphs = { version = "0.7", path = "../../tree-sitter-stack-graphs", features = ["cli"] }
+tree-sitter-stack-graphs = { version = "0.8", path = "../../tree-sitter-stack-graphs", features = ["cli"] }

--- a/languages/tree-sitter-stack-graphs-java/Cargo.toml
+++ b/languages/tree-sitter-stack-graphs-java/Cargo.toml
@@ -23,6 +23,7 @@ keywords = ["tree-sitter", "stack-graphs", "java"]
 [[bin]]
 name = "tree-sitter-stack-graphs-java"
 path = "rust/bin.rs"
+required-features = ["cli"]
 
 [lib]
 path = "rust/lib.rs"
@@ -33,8 +34,15 @@ name = "test"
 path = "rust/test.rs"
 harness = false # need to provide own main function to handle running tests
 
+[features]
+cli = ["anyhow", "clap", "tree-sitter-stack-graphs/cli"]
+
 [dependencies]
-anyhow = "1.0"
-clap = { version = "4", features = ["derive"] }
-tree-sitter-stack-graphs = { version = "0.7", path = "../../tree-sitter-stack-graphs", features=["cli"] }
+anyhow = { version = "1.0", optional = true }
+clap = { version = "4", features = ["derive"], optional = true }
 tree-sitter-java = { version = "=0.20.0" }
+tree-sitter-stack-graphs = { version = "0.7", path = "../../tree-sitter-stack-graphs" }
+
+[dev-dependencies]
+anyhow = { version = "1.0" }
+tree-sitter-stack-graphs = { version = "0.7", path = "../../tree-sitter-stack-graphs", features = ["cli"] }

--- a/languages/tree-sitter-stack-graphs-javascript/Cargo.toml
+++ b/languages/tree-sitter-stack-graphs-javascript/Cargo.toml
@@ -31,9 +31,9 @@ clap = { version = "4", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 stack-graphs = { version = "0.12", path = "../../stack-graphs" }
-tree-sitter-stack-graphs = { version = "0.7", path = "../../tree-sitter-stack-graphs" }
+tree-sitter-stack-graphs = { version = "0.8", path = "../../tree-sitter-stack-graphs" }
 tree-sitter-javascript = { git = "https://github.com/tree-sitter/tree-sitter-javascript", rev = "5720b249490b3c17245ba772f6be4a43edb4e3b7" }
 
 [dev-dependencies]
 anyhow = "1.0"
-tree-sitter-stack-graphs = { version = "0.7", path = "../../tree-sitter-stack-graphs", features = ["cli"] }
+tree-sitter-stack-graphs = { version = "0.8", path = "../../tree-sitter-stack-graphs", features = ["cli"] }

--- a/languages/tree-sitter-stack-graphs-python/Cargo.toml
+++ b/languages/tree-sitter-stack-graphs-python/Cargo.toml
@@ -30,9 +30,9 @@ cli = ["anyhow", "clap", "tree-sitter-stack-graphs/cli"]
 [dependencies]
 anyhow = { version = "1.0", optional = true }
 clap = { version = "4", optional = true, features = ["derive"] }
-tree-sitter-stack-graphs = { version = "0.7", path = "../../tree-sitter-stack-graphs" }
+tree-sitter-stack-graphs = { version = "0.8", path = "../../tree-sitter-stack-graphs" }
 tree-sitter-python = "=0.20.4"
 
 [dev-dependencies]
 anyhow = "1.0"
-tree-sitter-stack-graphs = { version = "0.7", path = "../../tree-sitter-stack-graphs", features = ["cli"] }
+tree-sitter-stack-graphs = { version = "0.8", path = "../../tree-sitter-stack-graphs", features = ["cli"] }

--- a/languages/tree-sitter-stack-graphs-typescript/Cargo.toml
+++ b/languages/tree-sitter-stack-graphs-typescript/Cargo.toml
@@ -33,10 +33,10 @@ glob = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 stack-graphs = { version = ">=0.11, <=0.12", path = "../../stack-graphs" }
-tree-sitter-stack-graphs = { version = "0.7", path = "../../tree-sitter-stack-graphs" }
+tree-sitter-stack-graphs = { version = "0.8", path = "../../tree-sitter-stack-graphs" }
 tree-sitter-typescript = "=0.20.2"
 tsconfig = "0.1.0"
 
 [dev-dependencies]
 anyhow = { version = "1.0" }
-tree-sitter-stack-graphs = { version = "0.7", path = "../../tree-sitter-stack-graphs", features = ["cli"] }
+tree-sitter-stack-graphs = { version = "0.8", path = "../../tree-sitter-stack-graphs", features = ["cli"] }

--- a/lsp-positions/CHANGELOG.md
+++ b/lsp-positions/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.3.3 -- 2024-03-05
+
+The `tree-sitter` dependency version was updated to fix install problems.
+
 ## v0.3.2 -- 2023-06-08
 
 ### Added

--- a/lsp-positions/Cargo.toml
+++ b/lsp-positions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lsp-positions"
-version = "0.3.2"
+version = "0.3.3"
 description = "LSP-compatible character positions"
 homepage = "https://github.com/github/stack-graphs/tree/main/lsp-positions"
 repository = "https://github.com/github/stack-graphs/"

--- a/lsp-positions/Cargo.toml
+++ b/lsp-positions/Cargo.toml
@@ -22,7 +22,9 @@ tree-sitter = ["dep:tree-sitter"]
 
 [dependencies]
 memchr = "2.4"
-tree-sitter = { version=">= 0.19", optional=true }
-unicode-segmentation = { version="1.8" }
-serde = { version="1", optional=true, features=["derive"] }
-bincode = { version="2.0.0-rc.3", optional=true }
+tree-sitter = { version = "0.20", optional = true } # keep the same minor version as the tree-sitter
+                                                    # dependency of tree-sitter-stack-graphs to prevent
+                                                    # install problems
+unicode-segmentation = { version = "1.8" }
+serde = { version = "1", features = ["derive"], optional = true }
+bincode = { version = "2.0.0-rc.3", optional = true }

--- a/stack-graphs/Cargo.toml
+++ b/stack-graphs/Cargo.toml
@@ -25,12 +25,12 @@ test = false
 
 [dependencies]
 bincode = { version = "2.0.0-rc.3", optional = true }
-bitvec = "1.0"
-controlled-option = "0.4"
+bitvec = "1.0.1"
+controlled-option = "0.4.1"
 either = "1.6"
 enumset = "1.1"
 fxhash = "0.2"
-itertools = "0.10"
+itertools = "0.10.2"
 libc = "0.2"
 lsp-positions = { version = "0.3", path = "../lsp-positions" }
 rusqlite = { version = "0.28", optional = true, features = ["bundled", "functions"] }
@@ -42,7 +42,6 @@ thiserror = { version = "1.0" }
 
 [dev-dependencies]
 assert-json-diff = "2"
-itertools = "0.10"
 maplit = "1.0"
 pretty_assertions = "0.7"
 serde_json = { version = "1.0" }

--- a/tree-sitter-stack-graphs/CHANGELOG.md
+++ b/tree-sitter-stack-graphs/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## v0.8.0 -- 2024-03-05
+
+The `tree-sitter` dependency version was updated to fix install problems.
 
 ### Library
 

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -49,12 +49,12 @@ lsp = [
 ]
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.4"
 base64 = { version = "0.21", optional = true }
 capture-it = { version = "0.3", optional = true }
 clap = { version = "4", optional = true, features = ["derive"] }
 colored = { version = "2.0", optional = true }
-controlled-option = ">=0.4"
+controlled-option = "0.4.1"
 crossbeam-channel = { version = "0.5", optional = true }
 dialoguer = { version = "0.10", optional = true }
 dirs = { version = "5", optional = true }
@@ -69,12 +69,13 @@ regex = "1"
 rust-ini = "0.18"
 serde_json = { version="1.0", optional=true }
 sha1 = { version="0.10", optional=true }
-stack-graphs = { version=">=0.11, <=0.12", path="../stack-graphs" }
+stack-graphs = { version="0.12", path="../stack-graphs" }
 thiserror = "1.0"
 time = { version = "0.3", optional = true }
 tokio = { version = "1.26", optional = true, features = ["io-std", "rt", "rt-multi-thread"] }
 tower-lsp = { version = "0.19", optional = true }
-tree-sitter = ">= 0.19"
+tree-sitter = "0.20" # keep the same minor version as the tree-sitter dependency
+                     # of tree-sitter-graph to prevent install problems
 tree-sitter-config = { version = "0.19", optional = true }
 tree-sitter-graph = "0.11"
 tree-sitter-loader = "0.20"

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-stack-graphs"
-version = "0.7.1"
+version = "0.8.0"
 description = "Create stack graphs using tree-sitter parsers"
 homepage = "https://github.com/github/stack-graphs/tree/main/tree-sitter-stack-graphs"
 repository = "https://github.com/github/stack-graphs/"

--- a/tree-sitter-stack-graphs/README.md
+++ b/tree-sitter-stack-graphs/README.md
@@ -14,7 +14,7 @@ To use this library, add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tree-sitter-stack-graphs = "0.7"
+tree-sitter-stack-graphs = "0.8"
 ```
 
 Check out our [documentation](https://docs.rs/tree-sitter-stack-graphs/*/) for more details on how to use this library.


### PR DESCRIPTION
Tweak the dependencies to prevent install problems such as those reported in #407.

The main change is to ensure that all `tree-sitter` have the same minor version, which prevents the Cargo resolver picking multiple versions for different crates.

The underlying problem is that there seems to be no way to teel Cargo that two transitive dependencies of the same crate should be the same version. However, if types from that crate are part of the API, things break if values are passed from one to the other. So far, the only solution I've found is to ensure that if the minor versions are the same, the resolver will only pick one patch version, thus ensuring the same version is used everywhere. (For non-zero major versions it might be enough if the major version is the same?)

Main changes:

- Change `tree-sitter` dependency versions to ensure they all use the same minor version.
- Use `cargo hack` to test all feature combinations.
- Introduced `cli` feature for `tree-sitter-stack-graphs-java` so the CLI is not included by default anymore.
- Bump versions of `lsp-positions` and `tree-sitter-stack-graphs`.