### PR TITLE
Release stack-graphs v0.13.0 and tree-sitter-stack-graphs v0.8.1

### DIFF
--- a/languages/tree-sitter-stack-graphs-javascript/Cargo.toml
+++ b/languages/tree-sitter-stack-graphs-javascript/Cargo.toml
@@ -30,7 +30,7 @@ anyhow = { version = "1.0", optional = true }
 clap = { version = "4", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-stack-graphs = { version = "0.12", path = "../../stack-graphs" }
+stack-graphs = { version = "0.13", path = "../../stack-graphs" }
 tree-sitter-stack-graphs = { version = "0.8", path = "../../tree-sitter-stack-graphs" }
 tree-sitter-javascript = { git = "https://github.com/tree-sitter/tree-sitter-javascript", rev = "5720b249490b3c17245ba772f6be4a43edb4e3b7" }
 

--- a/languages/tree-sitter-stack-graphs-typescript/Cargo.toml
+++ b/languages/tree-sitter-stack-graphs-typescript/Cargo.toml
@@ -32,7 +32,7 @@ clap = { version = "4", optional = true }
 glob = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-stack-graphs = { version = ">=0.11, <=0.12", path = "../../stack-graphs" }
+stack-graphs = { version = "0.13", path = "../../stack-graphs" }
 tree-sitter-stack-graphs = { version = "0.8", path = "../../tree-sitter-stack-graphs" }
 tree-sitter-typescript = "=0.20.2"
 tsconfig = "0.1.0"

--- a/stack-graphs/CHANGELOG.md
+++ b/stack-graphs/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.13.0 -- 2024-03-06
+
+### Added
+
+- New type `StitcherConfig` to specify configuration flags that control stitching.
+- Path stiching statistics can now be collected during stitching for debugging purposes. Disabled by default and can be enabled with `StitcherConfig`.
+- A method `StackGraph::set_edge_precedence` that allows changing the precendence of an existing edge in a stack graph.
+- A method `StackGraph::incoming_edge_degree` that returns the number of edges ending in a given node.
+- A method `Database::get_incoming_path_degree` that returns the number of partial paths in the database ending in a given node.
+- Cycle detection improved by using incoming path or edge degrees to reduce the amount of data to keep in memory.
+- Visualization uses different colors for nodes of different files, which makes understanding multi-file graphs easier.
+
+### Changed
+
+- Methods and types that do stitching in their implementation now require a `StitcherConfig` value. These include `Assertion::run`, `ForwardPartialPathStitcher::find_*`, and `Test::run`.
+- The SQLite storage data encoding and queries changed to improve performance.
+
+### Removed
+
+- Method `StackGraph::remove_edge` has been removed.
+
+### Fixed
+
+- A panic when using an arena after `Arena::clear` or `SupplementalArena::clear` was called.
+- Missing candidates when looking up root paths in a `Database`.
+
 ## v0.12.0 -- 2023-07-27
 
 ### Added

--- a/stack-graphs/Cargo.toml
+++ b/stack-graphs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stack-graphs"
-version = "0.12.0"
+version = "0.13.0"
 description = "Name binding for arbitrary programming languages"
 homepage = "https://github.com/github/stack-graphs/tree/main/stack-graphs"
 repository = "https://github.com/github/stack-graphs/"

--- a/stack-graphs/README.md
+++ b/stack-graphs/README.md
@@ -9,7 +9,7 @@ To use this library, add the following to your `Cargo.toml`:
 
 ``` toml
 [dependencies]
-stack-graphs = "0.12"
+stack-graphs = "0.13"
 ```
 
 Check out our [documentation](https://docs.rs/stack-graphs/) for more details on

--- a/stack-graphs/src/graph.rs
+++ b/stack-graphs/src/graph.rs
@@ -1307,7 +1307,7 @@ impl StackGraph {
         }
     }
 
-    /// Removes an edge from the stack graph.
+    /// Sets edge precedence of the given edge.
     pub fn set_edge_precedence(
         &mut self,
         source: Handle<Node>,

--- a/tree-sitter-stack-graphs/CHANGELOG.md
+++ b/tree-sitter-stack-graphs/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.8.1 -- 2024-03-06
+
+The `stack-graphs` dependency was updated to `v0.13` to fix the build problems of the `v0.8.0` release.
+
 ## v0.8.0 -- 2024-03-05
 
 The `tree-sitter` dependency version was updated to fix install problems.

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-stack-graphs"
-version = "0.8.0"
+version = "0.8.1"
 description = "Create stack graphs using tree-sitter parsers"
 homepage = "https://github.com/github/stack-graphs/tree/main/tree-sitter-stack-graphs"
 repository = "https://github.com/github/stack-graphs/"
@@ -69,7 +69,7 @@ regex = "1"
 rust-ini = "0.18"
 serde_json = { version="1.0", optional=true }
 sha1 = { version="0.10", optional=true }
-stack-graphs = { version="0.12", path="../stack-graphs" }
+stack-graphs = { version="0.13", path="../stack-graphs" }
 thiserror = "1.0"
 time = { version = "0.3", optional = true }
 tokio = { version = "1.26", optional = true, features = ["io-std", "rt", "rt-multi-thread"] }


### PR DESCRIPTION
I botched yesterdays release of `tree-sitter-stack-graphs` because it depended on unreleased changes in `stack-graphs`. Fix this be releasing both this time.
