### PR TITLE
Skip failed files during indexing instead of aborting the whole index operation

### DIFF
--- a/tree-sitter-stack-graphs/CHANGELOG.md
+++ b/tree-sitter-stack-graphs/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.8.2 -- unreleased
+
+### CLI
+
+#### Changed
+
+- Failure to index a file will not abort indexing anymore, but simply mark the file as failed, as we already do for files with parse errors.
+
 ## v0.8.1 -- 2024-03-06
 
 The `stack-graphs` dependency was updated to `v0.13` to fix the build problems of the `v0.8.0` release.

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-stack-graphs"
-version = "0.8.1"
+version = "0.8.2"
 description = "Create stack graphs using tree-sitter parsers"
 homepage = "https://github.com/github/stack-graphs/tree/main/tree-sitter-stack-graphs"
 repository = "https://github.com/github/stack-graphs/"

--- a/tree-sitter-stack-graphs/src/cli/index.rs
+++ b/tree-sitter-stack-graphs/src/cli/index.rs
@@ -355,23 +355,15 @@ impl<'a> Indexer<'a> {
         if let Err(err) = result {
             match err.inner {
                 BuildError::Cancelled(_) => {
-                    file_status.warning("parsing timed out", None);
+                    file_status.warning("timed out", None);
                     self.db
-                        .store_error_for_file(source_path, &tag, "parsing timed out")?;
-                    return Ok(());
-                }
-                BuildError::ParseErrors { .. } => {
-                    file_status.failure("parsing failed", Some(&err.display_pretty()));
-                    self.db.store_error_for_file(
-                        source_path,
-                        &tag,
-                        &format!("parsing failed: {}", err.inner),
-                    )?;
+                        .store_error_for_file(source_path, &tag, "timed out")?;
                     return Ok(());
                 }
                 _ => {
-                    file_status.failure("failed to build stack graph", Some(&err.display_pretty()));
-                    return Err(IndexError::StackGraph);
+                    file_status.failure("failed", Some(&err.display_pretty()));
+                    self.db.store_error_for_file(source_path, &tag, "failed")?;
+                    return Ok(());
                 }
             }
         };


### PR DESCRIPTION
Running an `index` command in the CLI would abort if stack graph construction for one of the indexed failes failed.
This may be fine when debugging a spec, but too punitive for users, who would like as much partial information as possible in the database, even if some files are not covered by the spec, or bugs exist.
This PR changes the behavior to mark those files as failed (as we already do for files with parse errors) but continue with the remaining files.

Fixes #418.

Note that I've also bumped the version already, even though I'm not sure if I'll release right away or not.
In the past we'd only bump the version right before a release, which sometimes resulted in confusing situations when depending on the repo instead of released version.
The versions would still be comaptible, even thought he source already contained incompatible changes.
My idea is to make sure the version in the source always reflects the changes w.r.t. the last release.
