### PR TITLE
Cache partial paths for builtins when running tests

### DIFF
--- a/stack-graphs/src/graph.rs
+++ b/stack-graphs/src/graph.rs
@@ -1497,12 +1497,16 @@ impl StackGraph {
 
     /// Copies the given stack graph into this stack graph. Panics if any of the files
     /// in the other stack graph are already defined in the current one.
-    pub fn add_from_graph(&mut self, other: &StackGraph) -> Result<(), Handle<File>> {
+    pub fn add_from_graph(
+        &mut self,
+        other: &StackGraph,
+    ) -> Result<Vec<Handle<File>>, Handle<File>> {
         let mut files = HashMap::new();
         for other_file in other.iter_files() {
             let file = self.add_file(other[other_file].name())?;
             files.insert(other_file, file);
         }
+        let files = files;
         let node_id = |other_node_id: NodeID| {
             if other_node_id.is_root() {
                 NodeID::root()
@@ -1645,7 +1649,7 @@ impl StackGraph {
                 }
             }
         }
-        Ok(())
+        Ok(files.into_values().collect())
     }
 }
 

--- a/tree-sitter-stack-graphs/CHANGELOG.md
+++ b/tree-sitter-stack-graphs/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### CLI
 
+#### Added
+
+- Tests run faster for languages with builtins sources by caching the partial paths for the builtins.
+
 #### Changed
 
 - Failure to index a file will not abort indexing anymore, but simply mark the file as failed, as we already do for files with parse errors.


### PR DESCRIPTION
When running tests, we would recompute the partial paths for the builtins for every test, even though they don't change.

This PR introduces a cache in the test runner that stores the partial paths in serialized form, and loads those into the test database. This takes ~30% of the TypeScript test time on my machine.
