### PR TITLE
fix: ignore .ts and .js extensions form imports

### DIFF
--- a/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
@@ -260,7 +260,7 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
 
   ; expose globals
   edge proj_scope -> @prog.globals
-  
+
   var mod_scope = proj_scope
   if (not (is-empty @imexs)) {
     ; module definition
@@ -540,10 +540,9 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
 
   ; module reference
   var mod_scope = mod_ref__ns
-  scan (path-normalize mod_path) {
-    ; ignore .js and .ts extensions on imports, as ts allows this
-    ; this might lead to false positives
-    "([^/|(\.j|ts)]+)/?" {
+  ; normalize path and remove the extension as we want to match 'foo', 'foo.js', 'foo.ts', etc.
+  scan (path-remove-ext (path-normalize mod_path)) {
+    "([^/]+)/?" {
       node mod_ref
       attr (mod_ref) push_symbol = $1
       edge mod_ref -> mod_scope

--- a/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
@@ -541,7 +541,7 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
   ; module reference
   var mod_scope = mod_ref__ns
   ; normalize path and remove the extension as we want to match 'foo', 'foo.js', 'foo.ts', etc.
-  scan (path-remove-ext (path-normalize mod_path)) {
+  scan (path-normalize (replace mod_path "\.(js|ts|jsx|tsx)$" "")) {
     "([^/]+)/?" {
       node mod_ref
       attr (mod_ref) push_symbol = $1

--- a/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
@@ -260,7 +260,7 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
 
   ; expose globals
   edge proj_scope -> @prog.globals
-
+  
   var mod_scope = proj_scope
   if (not (is-empty @imexs)) {
     ; module definition
@@ -541,7 +541,9 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
   ; module reference
   var mod_scope = mod_ref__ns
   scan (path-normalize mod_path) {
-    "([^/]+)/?" {
+    ; ignore .js and .ts extensions on imports, as ts allows this
+    ; this might lead to false positives
+    "([^/|(\.j|ts)]+)/?" {
       node mod_ref
       attr (mod_ref) push_symbol = $1
       edge mod_ref -> mod_scope

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-extension-js.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-extension-js.ts
@@ -1,0 +1,6 @@
+/* --- path: src/foo.ts --- */
+export const bar = 42;
+
+/* --- path: src/index.ts --- */
+import { bar } from "./foo.js";
+//       ^ defined: 2

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-extension-none.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-extension-none.ts
@@ -1,0 +1,6 @@
+/* --- path: src/foo.ts --- */
+export const bar = 42;
+
+/* --- path: src/index.ts --- */
+import { bar } from "./foo";
+//       ^ defined: 2

--- a/languages/tree-sitter-stack-graphs-typescript/test/modules/import-extension-ts.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/modules/import-extension-ts.ts
@@ -1,0 +1,6 @@
+/* --- path: src/foo.ts --- */
+export const bar = 42;
+
+/* --- path: src/index.ts --- */
+import { bar } from "./foo.ts";
+//       ^ defined: 2

--- a/tree-sitter-stack-graphs/src/functions.rs
+++ b/tree-sitter-stack-graphs/src/functions.rs
@@ -43,10 +43,6 @@ pub mod path {
             path_fn(|p| normalize(p).map(|p| p.as_os_str().to_os_string())),
         );
         functions.add("path-split".into(), PathSplit);
-        functions.add(
-            "path-remove-ext".into(),
-            path_fn(|p| remove_extension(p).map(|p| p.as_os_str().to_os_string())),
-        );
     }
 
     pub fn path_fn<F>(f: F) -> impl Function
@@ -162,38 +158,5 @@ pub mod path {
             }
         }
         Some(ret)
-    }
-
-    /// Removes the extension from a path.
-    /// eg. `foo/bar.rs` -> `foo/bar`
-    /// eg. `foo/bar` -> `foo/bar`
-    /// eg. `foo/bar.rs.bak` -> `foo/bar.rs`
-    pub fn remove_extension(path: &Path) -> Option<PathBuf> {
-        path.extension()
-            .map_or(Some(path.into()), |_| path.with_extension("").into())
-    }
-
-    #[test]
-    fn test_remove_extension() {
-        assert_eq!(
-            remove_extension(Path::new("foo/bar.rs")),
-            Some(PathBuf::from("foo/bar"))
-        );
-        assert_eq!(
-            remove_extension(Path::new("foo/bar")),
-            Some(PathBuf::from("foo/bar"))
-        );
-        assert_eq!(
-            remove_extension(Path::new("foo/bar.rs.bak")),
-            Some(PathBuf::from("foo/bar.rs"))
-        );
-        assert_eq!(
-            remove_extension(Path::new("foo")),
-            Some(PathBuf::from("foo"))
-        );
-        assert_eq!(
-            remove_extension(Path::new("foo.rs")),
-            Some(PathBuf::from("foo"))
-        );
     }
 }

--- a/tree-sitter-stack-graphs/src/functions.rs
+++ b/tree-sitter-stack-graphs/src/functions.rs
@@ -43,6 +43,10 @@ pub mod path {
             path_fn(|p| normalize(p).map(|p| p.as_os_str().to_os_string())),
         );
         functions.add("path-split".into(), PathSplit);
+        functions.add(
+            "path-remove-ext".into(),
+            path_fn(|p| remove_extension(p).map(|p| p.as_os_str().to_os_string())),
+        );
     }
 
     pub fn path_fn<F>(f: F) -> impl Function
@@ -158,5 +162,38 @@ pub mod path {
             }
         }
         Some(ret)
+    }
+
+    /// Removes the extension from a path.
+    /// eg. `foo/bar.rs` -> `foo/bar`
+    /// eg. `foo/bar` -> `foo/bar`
+    /// eg. `foo/bar.rs.bak` -> `foo/bar.rs`
+    pub fn remove_extension(path: &Path) -> Option<PathBuf> {
+        path.extension()
+            .map_or(Some(path.into()), |_| path.with_extension("").into())
+    }
+
+    #[test]
+    fn test_remove_extension() {
+        assert_eq!(
+            remove_extension(Path::new("foo/bar.rs")),
+            Some(PathBuf::from("foo/bar"))
+        );
+        assert_eq!(
+            remove_extension(Path::new("foo/bar")),
+            Some(PathBuf::from("foo/bar"))
+        );
+        assert_eq!(
+            remove_extension(Path::new("foo/bar.rs.bak")),
+            Some(PathBuf::from("foo/bar.rs"))
+        );
+        assert_eq!(
+            remove_extension(Path::new("foo")),
+            Some(PathBuf::from("foo"))
+        );
+        assert_eq!(
+            remove_extension(Path::new("foo.rs")),
+            Some(PathBuf::from("foo"))
+        );
     }
 }


### PR DESCRIPTION
Simple quick fix for #435, this can be evolved further but I believe will work in most currently broken cases.