### PR TITLE
fix: python imports

### DIFF
--- a/languages/tree-sitter-stack-graphs-python/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-python/src/stack-graphs.tsg
@@ -13,6 +13,7 @@
 ;; ^^^^^^^^^^^^^^^^
 
 global FILE_PATH
+global ROOT_PATH
 global ROOT_NODE
 global JUMP_TO_SCOPE_NODE
 
@@ -272,7 +273,9 @@ inherit .parent_module
   node grandparent_module_ref_node
   var grandparent_module_ref = grandparent_module_ref_node
 
-  scan FILE_PATH {
+  ; get the file path relative to the root path
+  let rel_path = (replace FILE_PATH ROOT_PATH "")
+  scan rel_path {
     "([^/]+)/"
     {
       node def_dot

--- a/languages/tree-sitter-stack-graphs-python/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-python/src/stack-graphs.tsg
@@ -13,7 +13,7 @@
 ;; ^^^^^^^^^^^^^^^^
 
 global FILE_PATH
-global ROOT_PATH
+global ROOT_PATH = ""
 global ROOT_NODE
 global JUMP_TO_SCOPE_NODE
 

--- a/languages/tree-sitter-stack-graphs-python/test/root_path.py
+++ b/languages/tree-sitter-stack-graphs-python/test/root_path.py
@@ -1,0 +1,21 @@
+# ------ path: foo/bar/module.py -----------#
+# ------ global: ROOT_PATH=foo/bar  -----------#
+
+foo = 42
+
+# ------ path: foo/bar/baz/module.py -----------#
+# ------ global: ROOT_PATH=foo/bar  -----------#
+
+bar = "hello"
+
+# ------ path: foo/bar/main.py -------------#
+# ------ global: ROOT_PATH=foo/bar  -----------#
+
+from module import foo
+from baz.module import bar
+
+print(foo)
+#     ^ defined: 4, 14
+
+print(bar)
+#     ^ defined: 9, 15

--- a/tree-sitter-stack-graphs/src/cli/index.rs
+++ b/tree-sitter-stack-graphs/src/cli/index.rs
@@ -42,6 +42,7 @@ use crate::BuildError;
 use crate::CancelAfterDuration;
 use crate::CancellationFlag;
 use crate::NoCancellation;
+use crate::{FILE_PATH_VAR, ROOT_PATH_VAR};
 
 #[derive(Args)]
 pub struct IndexArgs {
@@ -428,19 +429,19 @@ impl<'a> Indexer<'a> {
         cancellation_flag: &dyn CancellationFlag,
     ) -> std::result::Result<(), BuildErrorWithSource<'b>> {
         let relative_source_path = source_path.strip_prefix(source_root).unwrap();
-        // here the file should also have stripped the source_root from its path
         if let Some(lc) = lcs.primary {
-            let globals = Variables::new();
+            let mut globals = Variables::new();
+
+            globals
+                .add(FILE_PATH_VAR.into(), source_path.to_str().unwrap().into())
+                .expect("failed to add file path variable");
+
+            globals
+                .add(ROOT_PATH_VAR.into(), source_root.to_str().unwrap().into())
+                .expect("failed to add root path variable");
+
             lc.sgl
-                .build_stack_graph_into(
-                    graph,
-                    file,
-                    source,
-                    source_path,
-                    source_root,
-                    &globals,
-                    cancellation_flag,
-                )
+                .build_stack_graph_into(graph, file, source, &globals, cancellation_flag)
                 .map_err(|inner| BuildErrorWithSource {
                     inner,
                     source_path: source_path.to_path_buf(),

--- a/tree-sitter-stack-graphs/src/cli/index.rs
+++ b/tree-sitter-stack-graphs/src/cli/index.rs
@@ -428,10 +428,19 @@ impl<'a> Indexer<'a> {
         cancellation_flag: &dyn CancellationFlag,
     ) -> std::result::Result<(), BuildErrorWithSource<'b>> {
         let relative_source_path = source_path.strip_prefix(source_root).unwrap();
+        // here the file should also have stripped the source_root from its path
         if let Some(lc) = lcs.primary {
             let globals = Variables::new();
             lc.sgl
-                .build_stack_graph_into(graph, file, source, &globals, cancellation_flag)
+                .build_stack_graph_into(
+                    graph,
+                    file,
+                    source,
+                    source_path,
+                    source_root,
+                    &globals,
+                    cancellation_flag,
+                )
                 .map_err(|inner| BuildErrorWithSource {
                     inner,
                     source_path: source_path.to_path_buf(),

--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -321,6 +321,8 @@ impl TestArgs {
                     &mut test.graph,
                     test_fragment.file,
                     &test_fragment.source,
+                    &test_fragment.path,
+                    &test_fragment.root_path,
                     &globals,
                     cancellation_flag.as_ref(),
                 )

--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -318,15 +318,17 @@ impl TestArgs {
             )? {
                 globals.clear();
 
-                // Add FILE_PATH to variables
-                globals
-                    .add(
-                        FILE_PATH_VAR.into(),
-                        test_fragment.path.to_str().unwrap().into(),
-                    )
-                    .expect("failed to add file path variable");
-
                 test_fragment.add_globals_to(&mut globals);
+
+                if globals.get(&FILE_PATH_VAR.into()).is_none() {
+                    globals
+                        .add(
+                            FILE_PATH_VAR.into(),
+                            test_fragment.path.to_str().unwrap().into(),
+                        )
+                        .expect("failed to add file path variable");
+                }
+
                 lc.sgl.build_stack_graph_into(
                     &mut test.graph,
                     test_fragment.file,

--- a/tree-sitter-stack-graphs/src/cli/test.rs
+++ b/tree-sitter-stack-graphs/src/cli/test.rs
@@ -43,6 +43,7 @@ use crate::test::Test;
 use crate::test::TestResult;
 use crate::CancelAfterDuration;
 use crate::CancellationFlag;
+use crate::FILE_PATH_VAR;
 
 #[derive(Args)]
 #[clap(after_help = r#"PATH SPECIFICATIONS:
@@ -316,13 +317,20 @@ impl TestArgs {
                 &mut Some(test_fragment.source.as_ref()),
             )? {
                 globals.clear();
+
+                // Add FILE_PATH to variables
+                globals
+                    .add(
+                        FILE_PATH_VAR.into(),
+                        test_fragment.path.to_str().unwrap().into(),
+                    )
+                    .expect("failed to add file path variable");
+
                 test_fragment.add_globals_to(&mut globals);
                 lc.sgl.build_stack_graph_into(
                     &mut test.graph,
                     test_fragment.file,
                     &test_fragment.source,
-                    &test_fragment.path,
-                    &test_fragment.root_path,
                     &globals,
                     cancellation_flag.as_ref(),
                 )

--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -435,10 +435,16 @@ static SCOPE_ATTRS: Lazy<HashSet<&'static str>> =
 static PRECEDENCE_ATTR: &'static str = "precedence";
 
 // Global variables
-static ROOT_NODE_VAR: &'static str = "ROOT_NODE";
-static JUMP_TO_SCOPE_NODE_VAR: &'static str = "JUMP_TO_SCOPE_NODE";
-static FILE_PATH_VAR: &'static str = "FILE_PATH";
-static ROOT_PATH_VAR: &'static str = "ROOT_PATH";
+/// Name of the variable used to pass the root node.
+pub const ROOT_NODE_VAR: &'static str = "ROOT_NODE";
+/// Name of the variable used to pass the jump-to-scope node.
+pub const JUMP_TO_SCOPE_NODE_VAR: &'static str = "JUMP_TO_SCOPE_NODE";
+/// Name of the variable used to pass the file path.
+/// If a root path is given, it should be a descendant the root path.
+pub const FILE_PATH_VAR: &'static str = "FILE_PATH";
+/// Name of the variable used to pass the root path.
+/// If given, should be an ancestor of the file path.
+pub const ROOT_PATH_VAR: &'static str = "ROOT_PATH";
 
 /// Holds information about how to construct stack graphs for a particular language.
 pub struct StackGraphLanguage {
@@ -648,11 +654,6 @@ impl<'a> Builder<'a> {
         globals
             .add(JUMP_TO_SCOPE_NODE_VAR.into(), jump_to_scope_node.into())
             .expect("Failed to set JUMP_TO_SCOPE_NODE");
-
-        // FILE_PATH is mandatory
-        globals
-            .get(&FILE_PATH_VAR.into())
-            .expect("FILE_PATH not set");
 
         let mut config = ExecutionConfig::new(&self.sgl.functions, &globals)
             .lazy(true)

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -31,6 +31,8 @@ use crate::FileAnalyzer;
 use crate::StackGraphLanguage;
 use crate::FILE_PATH_VAR;
 
+const BUILTINS_FILENAME: &str = "<builtins>";
+
 pub static DEFAULT_TSG_PATHS: Lazy<Vec<LoadPath>> =
     Lazy::new(|| vec![LoadPath::Grammar("queries/stack-graphs".into())]);
 pub static DEFAULT_BUILTINS_PATHS: Lazy<Vec<LoadPath>> =
@@ -77,18 +79,14 @@ impl LanguageConfiguration {
         if let Some((builtins_path, builtins_source)) = builtins_source {
             let mut builtins_globals = Variables::new();
 
-            let builtins_path_var = Path::new("<builtins>");
             builtins_globals
-                .add(
-                    FILE_PATH_VAR.into(),
-                    builtins_path_var.to_str().unwrap().into(),
-                )
+                .add(FILE_PATH_VAR.into(), BUILTINS_FILENAME.into())
                 .expect("failed to add file path variable");
 
             if let Some(builtins_config) = builtins_config {
                 Loader::load_globals_from_config_str(builtins_config, &mut builtins_globals)?;
             }
-            let file = builtins.add_file("<builtins>").unwrap();
+            let file = builtins.add_file(BUILTINS_FILENAME).unwrap();
             sgl.build_stack_graph_into(
                 &mut builtins,
                 file,
@@ -341,7 +339,7 @@ impl Loader {
         let mut globals = Variables::new();
 
         globals
-            .add(FILE_PATH_VAR.into(), path.to_str().unwrap().into())
+            .add(FILE_PATH_VAR.into(), BUILTINS_FILENAME.into())
             .expect("failed to add file path variable");
 
         Self::load_globals_from_config_str(&config, &mut globals)?;

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -79,13 +79,16 @@ impl LanguageConfiguration {
         if let Some((builtins_path, builtins_source)) = builtins_source {
             let mut builtins_globals = Variables::new();
 
-            builtins_globals
-                .add(FILE_PATH_VAR.into(), BUILTINS_FILENAME.into())
-                .expect("failed to add file path variable");
-
             if let Some(builtins_config) = builtins_config {
                 Loader::load_globals_from_config_str(builtins_config, &mut builtins_globals)?;
             }
+
+            if builtins_globals.get(&FILE_PATH_VAR.into()).is_some() {
+                builtins_globals
+                    .add(FILE_PATH_VAR.into(), BUILTINS_FILENAME.into())
+                    .expect("failed to add file path variable");
+            }
+
             let file = builtins.add_file(BUILTINS_FILENAME).unwrap();
             sgl.build_stack_graph_into(
                 &mut builtins,
@@ -337,11 +340,14 @@ impl Loader {
         let file = graph.add_file(&file_name).unwrap();
         let mut globals = Variables::new();
 
-        globals
-            .add(FILE_PATH_VAR.into(), BUILTINS_FILENAME.into())
-            .expect("failed to add file path variable");
-
         Self::load_globals_from_config_str(&config, &mut globals)?;
+
+        if globals.get(&FILE_PATH_VAR.into()).is_some() {
+            globals
+                .add(FILE_PATH_VAR.into(), BUILTINS_FILENAME.into())
+                .expect("failed to add file path variable");
+        }
+
         sgl.build_stack_graph_into(graph, file, &source, &globals, cancellation_flag)
             .map_err(|err| LoadError::Builtins {
                 inner: err,

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -342,7 +342,7 @@ impl Loader {
 
         Self::load_globals_from_config_str(&config, &mut globals)?;
 
-        if globals.get(&FILE_PATH_VAR.into()).is_some() {
+        if globals.get(&FILE_PATH_VAR.into()).is_none() {
             globals
                 .add(FILE_PATH_VAR.into(), BUILTINS_FILENAME.into())
                 .expect("failed to add file path variable");

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -334,8 +334,7 @@ impl Loader {
         cancellation_flag: &dyn CancellationFlag,
     ) -> Result<(), LoadError<'a>> {
         let file_name = path.to_string_lossy();
-        let file: stack_graphs::arena::Handle<stack_graphs::graph::File> =
-            graph.add_file(&file_name).unwrap();
+        let file = graph.add_file(&file_name).unwrap();
         let mut globals = Variables::new();
 
         globals

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -83,7 +83,7 @@ impl LanguageConfiguration {
                 Loader::load_globals_from_config_str(builtins_config, &mut builtins_globals)?;
             }
 
-            if builtins_globals.get(&FILE_PATH_VAR.into()).is_some() {
+            if builtins_globals.get(&FILE_PATH_VAR.into()).is_none() {
                 builtins_globals
                     .add(FILE_PATH_VAR.into(), BUILTINS_FILENAME.into())
                     .expect("failed to add file path variable");

--- a/tree-sitter-stack-graphs/src/test.rs
+++ b/tree-sitter-stack-graphs/src/test.rs
@@ -157,6 +157,7 @@ pub struct Test {
 pub struct TestFragment {
     pub file: Handle<File>,
     pub path: PathBuf,
+    pub root_path: PathBuf,
     pub source: String,
     pub assertions: Vec<Assertion>,
     pub globals: HashMap<String, String>,
@@ -180,6 +181,7 @@ impl Test {
         let mut prev_source = String::new();
         let mut line_files = Vec::new();
         let mut line_count = 0;
+        let default_root_path = PathBuf::from("");
         for (current_line_number, current_line) in
             PositionedSubstring::lines_iter(source).enumerate()
         {
@@ -202,6 +204,7 @@ impl Test {
                     fragments.push(TestFragment {
                         file,
                         path: current_path,
+                        root_path: default_root_path.clone(),
                         source: current_source,
                         assertions: Vec::new(),
                         globals: current_globals,
@@ -254,6 +257,7 @@ impl Test {
             fragments.push(TestFragment {
                 file,
                 path: current_path,
+                root_path: default_root_path.clone(),
                 source: current_source,
                 assertions: Vec::new(),
                 globals: current_globals,

--- a/tree-sitter-stack-graphs/src/test.rs
+++ b/tree-sitter-stack-graphs/src/test.rs
@@ -157,7 +157,6 @@ pub struct Test {
 pub struct TestFragment {
     pub file: Handle<File>,
     pub path: PathBuf,
-    pub root_path: PathBuf,
     pub source: String,
     pub assertions: Vec<Assertion>,
     pub globals: HashMap<String, String>,
@@ -181,7 +180,6 @@ impl Test {
         let mut prev_source = String::new();
         let mut line_files = Vec::new();
         let mut line_count = 0;
-        let default_root_path = PathBuf::from("");
         for (current_line_number, current_line) in
             PositionedSubstring::lines_iter(source).enumerate()
         {
@@ -204,7 +202,6 @@ impl Test {
                     fragments.push(TestFragment {
                         file,
                         path: current_path,
-                        root_path: default_root_path.clone(),
                         source: current_source,
                         assertions: Vec::new(),
                         globals: current_globals,
@@ -257,7 +254,6 @@ impl Test {
             fragments.push(TestFragment {
                 file,
                 path: current_path,
-                root_path: default_root_path.clone(),
                 source: current_source,
                 assertions: Vec::new(),
                 globals: current_globals,

--- a/tree-sitter-stack-graphs/tests/it/builder.rs
+++ b/tree-sitter-stack-graphs/tests/it/builder.rs
@@ -5,6 +5,8 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+use std::path::Path;
+
 use stack_graphs::graph::StackGraph;
 use tree_sitter_graph::Variables;
 use tree_sitter_stack_graphs::NoCancellation;
@@ -22,15 +24,27 @@ fn can_support_preexisting_nodes() {
     "#;
     let python = "pass";
 
+    let file_name = "test.py";
+    let source_path = Path::new(file_name);
+    let source_root = Path::new("");
+
     let mut graph = StackGraph::new();
-    let file = graph.get_or_create_file("test.py");
+    let file = graph.get_or_create_file(file_name);
     let node_id = graph.new_node_id(file);
     let _preexisting_node = graph.add_scope_node(node_id, true).unwrap();
 
     let globals = Variables::new();
     let language = StackGraphLanguage::from_str(tree_sitter_python::language(), tsg).unwrap();
     language
-        .build_stack_graph_into(&mut graph, file, python, &globals, &NoCancellation)
+        .build_stack_graph_into(
+            &mut graph,
+            file,
+            python,
+            source_path,
+            source_root,
+            &globals,
+            &NoCancellation,
+        )
         .expect("Failed to build graph");
 }
 
@@ -45,13 +59,18 @@ fn can_support_injected_nodes() {
     "#;
     let python = "pass";
 
+    let file_name = "test.py";
+    let source_path = Path::new(file_name);
+    let source_root = Path::new("");
+
     let mut graph = StackGraph::new();
-    let file = graph.get_or_create_file("test.py");
+    let file = graph.get_or_create_file(file_name);
     let node_id = graph.new_node_id(file);
     let _preexisting_node = graph.add_scope_node(node_id, true).unwrap();
 
     let language = StackGraphLanguage::from_str(tree_sitter_python::language(), tsg).unwrap();
-    let mut builder = language.builder_into_stack_graph(&mut graph, file, python);
+    let mut builder =
+        language.builder_into_stack_graph(&mut graph, file, python, source_path, source_root);
 
     let mut globals = Variables::new();
     globals

--- a/tree-sitter-stack-graphs/tests/it/builder.rs
+++ b/tree-sitter-stack-graphs/tests/it/builder.rs
@@ -4,6 +4,7 @@
 // Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
+
 use stack_graphs::graph::StackGraph;
 use tree_sitter_graph::Variables;
 use tree_sitter_stack_graphs::NoCancellation;

--- a/tree-sitter-stack-graphs/tests/it/builder.rs
+++ b/tree-sitter-stack-graphs/tests/it/builder.rs
@@ -4,17 +4,14 @@
 // Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
-
-use std::path::Path;
-
 use stack_graphs::graph::StackGraph;
 use tree_sitter_graph::Variables;
 use tree_sitter_stack_graphs::NoCancellation;
 use tree_sitter_stack_graphs::StackGraphLanguage;
+use tree_sitter_stack_graphs::FILE_PATH_VAR;
 
 use crate::edges::check_stack_graph_edges;
 use crate::nodes::check_stack_graph_nodes;
-use crate::FILE_PATH_VAR;
 
 #[test]
 fn can_support_preexisting_nodes() {

--- a/tree-sitter-stack-graphs/tests/it/builder.rs
+++ b/tree-sitter-stack-graphs/tests/it/builder.rs
@@ -36,15 +36,7 @@ fn can_support_preexisting_nodes() {
     let globals = Variables::new();
     let language = StackGraphLanguage::from_str(tree_sitter_python::language(), tsg).unwrap();
     language
-        .build_stack_graph_into(
-            &mut graph,
-            file,
-            python,
-            source_path,
-            source_root,
-            &globals,
-            &NoCancellation,
-        )
+        .build_stack_graph_into(&mut graph, file, python, &globals, &NoCancellation)
         .expect("Failed to build graph");
 }
 
@@ -69,8 +61,7 @@ fn can_support_injected_nodes() {
     let _preexisting_node = graph.add_scope_node(node_id, true).unwrap();
 
     let language = StackGraphLanguage::from_str(tree_sitter_python::language(), tsg).unwrap();
-    let mut builder =
-        language.builder_into_stack_graph(&mut graph, file, python, source_path, source_root);
+    let mut builder = language.builder_into_stack_graph(&mut graph, file, python);
 
     let mut globals = Variables::new();
     globals

--- a/tree-sitter-stack-graphs/tests/it/main.rs
+++ b/tree-sitter-stack-graphs/tests/it/main.rs
@@ -5,6 +5,8 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+use std::path::Path;
+
 use stack_graphs::arena::Handle;
 use stack_graphs::graph::File;
 use stack_graphs::graph::StackGraph;
@@ -23,11 +25,22 @@ pub(self) fn build_stack_graph(
     python_source: &str,
     tsg_source: &str,
 ) -> Result<(StackGraph, Handle<File>), BuildError> {
+    let file_name = "test.py";
+    let source_path = Path::new(file_name);
+    let source_root = Path::new("");
     let language =
         StackGraphLanguage::from_str(tree_sitter_python::language(), tsg_source).unwrap();
     let mut graph = StackGraph::new();
-    let file = graph.get_or_create_file("test.py");
+    let file = graph.get_or_create_file(file_name);
     let globals = Variables::new();
-    language.build_stack_graph_into(&mut graph, file, python_source, &globals, &NoCancellation)?;
+    language.build_stack_graph_into(
+        &mut graph,
+        file,
+        python_source,
+        source_path,
+        source_root,
+        &globals,
+        &NoCancellation,
+    )?;
     Ok((graph, file))
 }

--- a/tree-sitter-stack-graphs/tests/it/main.rs
+++ b/tree-sitter-stack-graphs/tests/it/main.rs
@@ -14,8 +14,7 @@ use tree_sitter_graph::Variables;
 use tree_sitter_stack_graphs::BuildError;
 use tree_sitter_stack_graphs::NoCancellation;
 use tree_sitter_stack_graphs::StackGraphLanguage;
-
-static FILE_PATH_VAR: &'static str = "FILE_PATH";
+use tree_sitter_stack_graphs::FILE_PATH_VAR;
 
 mod builder;
 mod edges;
@@ -35,7 +34,6 @@ pub(self) fn build_stack_graph(
     let mut globals = Variables::new();
     let source_path = Path::new(file_name);
 
-    // The FILE_PATH_VAR is not accessible here
     globals
         .add(FILE_PATH_VAR.into(), source_path.to_str().unwrap().into())
         .expect("failed to add file path variable");

--- a/tree-sitter-stack-graphs/tests/it/test.rs
+++ b/tree-sitter-stack-graphs/tests/it/test.rs
@@ -68,12 +68,22 @@ fn build_stack_graph_into(
     graph: &mut StackGraph,
     file: Handle<File>,
     python_source: &str,
+    source_path: &Path,
+    source_root: &Path,
     tsg_source: &str,
     globals: &Variables,
 ) -> Result<(), BuildError> {
     let language =
         StackGraphLanguage::from_str(tree_sitter_python::language(), tsg_source).unwrap();
-    language.build_stack_graph_into(graph, file, python_source, globals, &NoCancellation)?;
+    language.build_stack_graph_into(
+        graph,
+        file,
+        python_source,
+        source_path,
+        source_root,
+        globals,
+        &NoCancellation,
+    )?;
     Ok(())
 }
 
@@ -102,6 +112,8 @@ fn check_test(
             &mut test.graph,
             fragments.file,
             &fragments.source,
+            &fragments.path,
+            &fragments.root_path,
             tsg_source,
             &globals,
         )

--- a/tree-sitter-stack-graphs/tests/it/test.rs
+++ b/tree-sitter-stack-graphs/tests/it/test.rs
@@ -68,22 +68,12 @@ fn build_stack_graph_into(
     graph: &mut StackGraph,
     file: Handle<File>,
     python_source: &str,
-    source_path: &Path,
-    source_root: &Path,
     tsg_source: &str,
     globals: &Variables,
 ) -> Result<(), BuildError> {
     let language =
         StackGraphLanguage::from_str(tree_sitter_python::language(), tsg_source).unwrap();
-    language.build_stack_graph_into(
-        graph,
-        file,
-        python_source,
-        source_path,
-        source_root,
-        globals,
-        &NoCancellation,
-    )?;
+    language.build_stack_graph_into(graph, file, python_source, globals, &NoCancellation)?;
     Ok(())
 }
 
@@ -112,8 +102,6 @@ fn check_test(
             &mut test.graph,
             fragments.file,
             &fragments.source,
-            &fragments.path,
-            &fragments.root_path,
             tsg_source,
             &globals,
         )

--- a/tree-sitter-stack-graphs/tests/it/test.rs
+++ b/tree-sitter-stack-graphs/tests/it/test.rs
@@ -100,14 +100,17 @@ fn check_test(
     for fragments in &test.fragments {
         globals.clear();
 
-        globals
-            .add(
-                FILE_PATH_VAR.into(),
-                fragments.path.to_str().unwrap().into(),
-            )
-            .expect("failed to add file path variable");
-
         fragments.add_globals_to(&mut globals);
+
+        if globals.get(&FILE_PATH_VAR.into()).is_none() {
+            globals
+                .add(
+                    FILE_PATH_VAR.into(),
+                    fragments.path.to_str().unwrap().into(),
+                )
+                .expect("failed to add file path variable");
+        }
+
         build_stack_graph_into(
             &mut test.graph,
             fragments.file,

--- a/tree-sitter-stack-graphs/tests/it/test.rs
+++ b/tree-sitter-stack-graphs/tests/it/test.rs
@@ -5,6 +5,7 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+use crate::FILE_PATH_VAR;
 use once_cell::sync::Lazy;
 use pretty_assertions::assert_eq;
 use stack_graphs::arena::Handle;
@@ -94,9 +95,18 @@ fn check_test(
         expected_successes + expected_failures,
         assertion_count,
     );
+
     let mut globals = Variables::new();
     for fragments in &test.fragments {
         globals.clear();
+
+        globals
+            .add(
+                FILE_PATH_VAR.into(),
+                fragments.path.to_str().unwrap().into(),
+            )
+            .expect("failed to add file path variable");
+
         fragments.add_globals_to(&mut globals);
         build_stack_graph_into(
             &mut test.graph,


### PR DESCRIPTION
Hello @hendrikvanantwerpen, this fixes #430.
This issue was that a symbol was poped for each part of the file path, but it was pushed (on import) only for each part of the import. (eg. it pushed Users, nohehf, module, foo and popped module, foo).
Languages like python needs knowledge about the "root path", as modules are resolved relative to the "input script" as stated here: https://docs.python.org/3/tutorial/modules.html#the-module-search-path

Here is my fix proposal, and I believe it could be useful for several other languages:
- introduces a `ROOT_PATH` global variable, that allows to compute the relative file path. This is particularly useful for interpreted languages like python that creates the modules paths relative to a base path.
- adds a test that reproduces the error as described in #430, it did fail before the changes and now passes
- FILE_PATH is now passed explicitly, rather than extracted from `stack_graph[self.file]` as it's stated in https://github.com/github/stack-graphs/blob/558d1da3c27dfe50a45cc9acbee66bc5d898d314/stack-graphs/src/graph.rs#L335-L337 that it is not necessarily the file path.

Let me know what you think.