### PR TITLE
Update `tree-sitter-java` from `0.20.0` to `0.20.2`

### DIFF
--- a/languages/tree-sitter-stack-graphs-java/Cargo.toml
+++ b/languages/tree-sitter-stack-graphs-java/Cargo.toml
@@ -40,7 +40,7 @@ cli = ["anyhow", "clap", "tree-sitter-stack-graphs/cli"]
 [dependencies]
 anyhow = { version = "1.0", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
-tree-sitter-java = { version = "=0.20.0" }
+tree-sitter-java = { version = "=0.20.2" }
 tree-sitter-stack-graphs = { version = "0.8", path = "../../tree-sitter-stack-graphs" }
 
 [dev-dependencies]

--- a/languages/tree-sitter-stack-graphs-java/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-java/src/stack-graphs.tsg
@@ -1078,6 +1078,10 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
   edge @child.lexical_scope -> @expr.lexical_scope
 }
 
+(condition (_) @child) @expr {
+  edge @child.lexical_scope -> @expr.lexical_scope
+}
+
 ;; =============
 ;;  Expressions
 ;; =============
@@ -1107,6 +1111,7 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
   (this)
   ; (identifier)
   (parenthesized_expression)
+  (condition)
   (object_creation_expression)
   (field_access)
   (array_access)


### PR DESCRIPTION
Version `0.20.2` of `tree-sitter-java` introduces the `condition` expression in `if_statement`:
```
(if_statement
-   condition: (parenthesized_expression)
+   condition: (condition)
    consequence: (block)
    alternative: (block)
)
```

It seems to be the only breaking change, all tests pass with this update.
If merged, this PR would close https://github.com/github/stack-graphs/issues/441