### PR TITLE
Update `tree-sitter-javascript` from `0.20.3` to `0.20.4`

### DIFF
--- a/languages/tree-sitter-stack-graphs-javascript/Cargo.toml
+++ b/languages/tree-sitter-stack-graphs-javascript/Cargo.toml
@@ -32,7 +32,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 stack-graphs = { version = "0.13", path = "../../stack-graphs" }
 tree-sitter-graph = "0.11.2"
-tree-sitter-javascript = "=0.20.3"
+tree-sitter-javascript = "=0.20.4"
 tree-sitter-stack-graphs = { version = "0.8", path = "../../tree-sitter-stack-graphs" }
 
 [dev-dependencies]


### PR DESCRIPTION
All tests passed with the newer version, no changes were needed

This would close https://github.com/github/stack-graphs/issues/449