### PR TITLE
Fix dependencies to allow publish

### DIFF
--- a/.github/workflows/publish-tree-sitter-stack-graphs.yml
+++ b/.github/workflows/publish-tree-sitter-stack-graphs.yml
@@ -29,31 +29,6 @@ jobs:
         working-directory: ${{ env.CRATE_DIR }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-  publish-npm:
-    needs: publish-crate
-    runs-on: ubuntu-latest
-    env:
-      PACKAGE_DIR: './tree-sitter-stack-graphs/npm'
-    steps:
-      - name: Install Node environment
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
-          registry-url: 'https://registry.npmjs.org'
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      # TODO Verify the package version matches the tag
-      - name: Install dependencies
-        run: npm install
-        working-directory: ${{ env.PACKAGE_DIR }}
-      - name: Verify package
-        run: npm publish --dry-run
-        working-directory: ${{ env.PACKAGE_DIR }}
-      - name: Publish package
-        run: npm publish
-        working-directory: ${{ env.PACKAGE_DIR }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   create-release:
     needs: publish-crate
     runs-on: ubuntu-latest

--- a/languages/tree-sitter-stack-graphs-java/Cargo.toml
+++ b/languages/tree-sitter-stack-graphs-java/Cargo.toml
@@ -41,7 +41,7 @@ cli = ["anyhow", "clap", "tree-sitter-stack-graphs/cli"]
 anyhow = { version = "1.0", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 tree-sitter-java = { version = "=0.20.2" }
-tree-sitter-stack-graphs = { path = "../../tree-sitter-stack-graphs" }
+tree-sitter-stack-graphs = { version = "0.9", path = "../../tree-sitter-stack-graphs" } # explicit version is required to be able to publish crate
 
 [dev-dependencies]
 anyhow = { version = "1.0" }

--- a/languages/tree-sitter-stack-graphs-javascript/Cargo.toml
+++ b/languages/tree-sitter-stack-graphs-javascript/Cargo.toml
@@ -30,10 +30,10 @@ anyhow = { version = "1.0", optional = true }
 clap = { version = "4", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-stack-graphs = { path = "../../stack-graphs" }
+stack-graphs = { version = "0.14", path = "../../stack-graphs" } # explicit version is required to be able to publish crate
 tree-sitter-graph = "0.11.2"
 tree-sitter-javascript = "=0.20.4"
-tree-sitter-stack-graphs = { path = "../../tree-sitter-stack-graphs" }
+tree-sitter-stack-graphs = { version = "0.9", path = "../../tree-sitter-stack-graphs" } # explicit version is required to be able to publish crate
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/languages/tree-sitter-stack-graphs-python/Cargo.toml
+++ b/languages/tree-sitter-stack-graphs-python/Cargo.toml
@@ -30,7 +30,7 @@ cli = ["anyhow", "clap", "tree-sitter-stack-graphs/cli"]
 [dependencies]
 anyhow = { version = "1.0", optional = true }
 clap = { version = "4", optional = true, features = ["derive"] }
-tree-sitter-stack-graphs = { path = "../../tree-sitter-stack-graphs" }
+tree-sitter-stack-graphs = { version = "0.9", path = "../../tree-sitter-stack-graphs" } # explicit version is required to be able to publish crate
 tree-sitter-python = "=0.20.4"
 
 [dev-dependencies]

--- a/languages/tree-sitter-stack-graphs-typescript/Cargo.toml
+++ b/languages/tree-sitter-stack-graphs-typescript/Cargo.toml
@@ -32,8 +32,8 @@ clap = { version = "4", optional = true }
 glob = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-stack-graphs = { path = "../../stack-graphs" }
-tree-sitter-stack-graphs = { path = "../../tree-sitter-stack-graphs" }
+stack-graphs = { version = "0.14", path = "../../stack-graphs" } # explicit version is required to be able to publish crate
+tree-sitter-stack-graphs = { version = "0.9", path = "../../tree-sitter-stack-graphs" } # explicit version is required to be able to publish crate
 tree-sitter-typescript = "=0.20.2"
 tsconfig = "0.1.0"
 

--- a/stack-graphs/Cargo.toml
+++ b/stack-graphs/Cargo.toml
@@ -32,7 +32,7 @@ enumset = "1.1"
 fxhash = "0.2"
 itertools = "0.10.2"
 libc = "0.2"
-lsp-positions = { version = "0.3", path = "../lsp-positions" }
+lsp-positions = { version = "0.3", path = "../lsp-positions" } # explicit version is required to be able to publish crate
 rusqlite = { version = "0.28", optional = true, features = ["bundled", "functions"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }

--- a/tree-sitter-stack-graphs/Cargo.toml
+++ b/tree-sitter-stack-graphs/Cargo.toml
@@ -62,14 +62,14 @@ env_logger = { version = "0.9", optional = true }
 indoc = { version = "1.0", optional = true }
 itertools = "0.10"
 log = "0.4"
-lsp-positions = { version="0.3", path="../lsp-positions", features=["tree-sitter"] }
+lsp-positions = { version="0.3", path="../lsp-positions", features=["tree-sitter"] } # explicit version is required to be able to publish crate
 once_cell = "1"
 pathdiff = { version = "0.2.1", optional = true }
 regex = "1"
 rust-ini = "0.18"
 serde_json = { version="1.0", optional=true }
 sha1 = { version="0.10", optional=true }
-stack-graphs = { path="../stack-graphs" }
+stack-graphs = { version = "0.14", path="../stack-graphs" } # explicit version is required to be able to publish crate
 thiserror = "1.0"
 time = { version = "0.3", optional = true }
 tokio = { version = "1.26", optional = true, features = ["io-std", "rt", "rt-multi-thread"] }


### PR DESCRIPTION
The previous PR removed explicit versions for in-repo dependencies. I expected that `cargo publish` would just replace the `path` dependency with the current version, but instead it complains and aborts.

This PR restores the version numbers where required. (It seems not required for dev dependencies, which I verified using a local `cargo publish --dry-run`.)

I also removed the `publish-npm` workflow job, which would have failed since the NPM package has been removed.
