### PR TITLE
Fix not defaulting to `Builder::file` for `FILE_PATH`.

### DIFF
--- a/tree-sitter-stack-graphs/src/lib.rs
+++ b/tree-sitter-stack-graphs/src/lib.rs
@@ -653,6 +653,13 @@ impl<'a> Builder<'a> {
             .add(JUMP_TO_SCOPE_NODE_VAR.into(), jump_to_scope_node.into())
             .expect("Failed to set JUMP_TO_SCOPE_NODE");
 
+        if globals.get(&FILE_PATH_VAR.into()).is_none() {
+            let file_name = self.stack_graph[self.file].to_string();
+            globals
+                .add(FILE_PATH_VAR.into(), file_name.into())
+                .expect("Failed to set FILE_PATH");
+        }
+
         let mut config = ExecutionConfig::new(&self.sgl.functions, &globals)
             .lazy(true)
             .debug_attributes(


### PR DESCRIPTION
See also [this comment on #438](https://github.com/github/stack-graphs/pull/438#discussion_r1848966738).

The user is [already passing `file` to create the `Builder`](https://github.com/github/stack-graphs/blob/3090222200a9859619f7b5310b0773bc0d4161d7/tree-sitter-stack-graphs/src/lib.rs#L581); requiring that they additionally set `FILE_PATH` in `globals` is redundant and non-obvious.