### PR TITLE
Fix JS optional-chained member expression.

### DIFF
--- a/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
@@ -3189,27 +3189,22 @@ inherit .containing_class_value
 ;; ##### Member Expressions
 
 (member_expression
-  .
-  (_)@object
-  (optional_chain)? ; '?.' operator
-  (_)@property
-  .
-)@member_expr
-{
-
-    node member_push
-    node property_push
+  object:(_)@object
+  property:(_)@property
+)@member_expr {
+  node member_push
+  node property_push
 
   ; scopes flow into object then back out
   edge @object.before_scope -> @member_expr.before_scope
   edge @member_expr.after_scope -> @object.after_scope
 
   ; value is a member projection on the value of the object ie. a push then push dot
-    attr (member_push) push_symbol = "GUARD:MEMBER"
-    attr (property_push) node_reference = @property
-    edge property_push -> member_push
-    edge @member_expr.value -> property_push
-    edge member_push -> @object.value
+  attr (member_push) push_symbol = "GUARD:MEMBER"
+  attr (property_push) node_reference = @property
+  edge property_push -> member_push
+  edge @member_expr.value -> property_push
+  edge member_push -> @object.value
 
   ; (member_expression) nodes can occur in patterns
   node @member_expr.covalue

--- a/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
@@ -3191,7 +3191,7 @@ inherit .containing_class_value
 (member_expression
   .
   (_)@object
-  (_)? ; '?.' `optional_chain` operator
+  (optional_chain)? ; '?.' operator
   (_)@property
   .
 )@member_expr

--- a/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-javascript/src/stack-graphs.tsg
@@ -3189,7 +3189,12 @@ inherit .containing_class_value
 ;; ##### Member Expressions
 
 (member_expression
-  (_)@object . (_)@property)@member_expr
+  .
+  (_)@object
+  (_)? ; '?.' `optional_chain` operator
+  (_)@property
+  .
+)@member_expr
 {
 
     node member_push

--- a/languages/tree-sitter-stack-graphs-javascript/test/expressions/member_expression.js
+++ b/languages/tree-sitter-stack-graphs-javascript/test/expressions/member_expression.js
@@ -16,3 +16,8 @@ let x = 1;
 
 /**/ x;
 //   ^ defined: 1
+
+// Optional chain
+
+/**/ x?.foo
+//   ^ defined: 1


### PR DESCRIPTION
`member_expression` can contain an additional `(optional_chain)` node between its _object_ and _property_, for example in `foo?.bar`:
```
(member_expression
  object: (identifier)
  optional_chain: (optional_chain)
  property: (property_identifier))
```