### PR TITLE
fix(grammar): The TSG grammar for Java does not handle the static_initializer node

### DIFF
--- a/languages/tree-sitter-stack-graphs-java/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-java/src/stack-graphs.tsg
@@ -227,6 +227,20 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
   edge @declaration.lexical_scope -> @class_body.lexical_scope
 }
 
+(class_body
+  (static_initializer) @static_init
+) @class_body
+{
+  node @static_init.defs
+  node @static_init.static_defs
+  node @static_init.lexical_scope
+  node @static_init.before_scope
+
+  edge @static_init.before_scope -> @class_body.lexical_scope
+  edge @static_init.lexical_scope -> @static_init.before_scope
+}
+
+
 (class_body (block) @block) {
   node @block.defs
   node @block.static_defs

--- a/languages/tree-sitter-stack-graphs-java/test/decl/static_initializer.java
+++ b/languages/tree-sitter-stack-graphs-java/test/decl/static_initializer.java
@@ -1,0 +1,9 @@
+class TestClass {
+  static {
+      System.out.println("Static initializer block executed!");
+  }
+
+  public void printMessage() {
+      System.out.println("Hello from TestClass!");
+  }
+}


### PR DESCRIPTION
- Add the static_initializer node for the Java grammar, this node may contain multiple statements, such as initializing variables or executing functions