### PR TITLE
Fix typed splat function parameters in Python.

### DIFF
--- a/languages/tree-sitter-stack-graphs-python/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-python/src/stack-graphs.tsg
@@ -860,7 +860,7 @@ inherit .parent_module
 
 [
   (parameter/typed_parameter
-    . (_) @name) @param
+    . (identifier) @name) @param
   (parameter/list_splat_pattern
     (_) @name) @param
   (parameter/dictionary_splat_pattern

--- a/languages/tree-sitter-stack-graphs-python/test/typed_splat_parameters.py
+++ b/languages/tree-sitter-stack-graphs-python/test/typed_splat_parameters.py
@@ -1,0 +1,10 @@
+from typing import Any
+
+def foo(*bar: Any):
+    #         ^defined: 1
+    pass
+
+def duux(**quux: Any):
+    #            ^defined: 1
+    pass
+


### PR DESCRIPTION
This addresses issue #476.

Eliding the `identifier` node type in the stanza query allows it to erroneously match `list_splat_pattern` or `dictionary_splat_pattern` when those appear within a `typed_parameter`. This causes the stack graph generation to fail with an error:

```plaintext
0: Error executing statement edge @name.def -> @param.param_name at (871, 3)
    src/stack-graphs.tsg:871:3:
    871 |   edge @name.def -> @param.param_name
        |   ^
    in stanza
    src/stack-graphs.tsg:861:1:
    861 | [
        | ^
    matching (typed_parameter) node
    test/typed_splat_parameters.py:3:9:
    5 | def foo(*bar: typing.Any):
        |         ^
1: Evaluating edge source
2: Undefined scoped variable [syntax node list_splat_pattern (3, 9)].def
```

The fragment of the parsed Tree-sitter tree for such a parameter is:
```plaintext
(typed_parameter [3, 9] - [3, 25])
  (list_splat_pattern [3, 9] - [3, 13])
    (identifier [3, 10] - [3, 13]))
  type: (…))
```

As of [v0.23.5 of the Python grammar](https://github.com/tree-sitter/tree-sitter-python/blob/v0.23.5/grammar.js#L935), `typed_parameter` may contain `identifier` or either of the `*_splat_pattern` node types. As such, making the `identifier` node type explicit fixes the issue precisely without introducing other problems.