### PR TITLE
Fix lambdas without params. in Python.

### DIFF
--- a/languages/tree-sitter-stack-graphs-python/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-python/src/stack-graphs.tsg
@@ -768,7 +768,7 @@ inherit .parent_module
     body: (_) @body
   ) @func
   (lambda
-    parameters: (_) @params
+    parameters: (_)? @params
     body: (_) @body
   )@func
 ] {
@@ -777,12 +777,16 @@ inherit .parent_module
   node drop_scope
 
   edge @func.call -> return_value
-  edge @body.before_scope -> @params.after_scope
+  if some @params {
+    edge @body.before_scope -> @params.after_scope
+  }
   edge @body.before_scope -> drop_scope
   edge drop_scope -> @func.bottom
   attr (drop_scope) type = "drop_scopes"
   attr (@func.call) pop_scoped_symbol = "()"
-  edge @params.before_scope -> JUMP_TO_SCOPE_NODE
+  if some @params {
+    edge @params.before_scope -> JUMP_TO_SCOPE_NODE
+  }
   attr (return_value) is_exported
   let @func.function_returns = return_value
 }

--- a/languages/tree-sitter-stack-graphs-python/test/lambdas.py
+++ b/languages/tree-sitter-stack-graphs-python/test/lambdas.py
@@ -1,2 +1,11 @@
 sorted([1, 2, 3], key=lambda x: x)
 #                               ^ defined: 1
+
+y = 42
+
+foo = lambda: print(y)
+#                   ^ defined: 4
+
+bar = lambda daz: print(y, daz)
+#                       ^ defined: 4
+#                          ^ defined: 9


### PR DESCRIPTION
A lambda without parameters does not have a syntax for the parameters, unlike a function without parameters (which does, containing just the `(` and `)` characters). The stanza for callables did not optionally match `@params`, causing it to miss lambdas without parameters entirely, which would then cause an error in a later stanza:

```plaintext
0: Error executing statement edge @lam.output -> @lam.call at (984, 3)
    src/stack-graphs.tsg:984:3:
    984 |   edge @lam.output -> @lam.call
        |   ^
    in stanza
    src/stack-graphs.tsg:975:1:
    975 | (lambda
        | ^
    matching (lambda) node
    test/lambdas.py:6:7:
    6 | foo = lambda: print(y)
        |       ^
1: Evaluating edge sink
2: Undefined scoped variable [syntax node lambda (6, 7)].call
```

The fragments of the parsed Tree-sitter tree for such lambda without and with parameters is:

```treesitter
(lambda [6, 7] - [6, 23])
  body: …)
(lambda [9, 7] - [9, 32])
  parameters: (lambda parameters …)
  body: …)
```

As of [v0.23.5 of the Python grammar](https://github.com/tree-sitter/tree-sitter-python/blob/v0.23.5/grammar.js#L835), `lambda` indeed declares an optional `parameters` field.

Making the `@params` capture optional and only emitting the edges if it’s there fixes the issue.