### PR TITLE
Fix superclass keyword arguments in Python.

### DIFF
--- a/languages/tree-sitter-stack-graphs-python/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-python/src/stack-graphs.tsg
@@ -933,7 +933,10 @@ inherit .parent_module
 
 (class_definition
   superclasses: (argument_list
-    (_) @superclass)) @class
+    [
+      (identifier)
+      (attribute)
+    ] @superclass)) @class
 {
   edge @class.super_scope -> @superclass.output
 }

--- a/languages/tree-sitter-stack-graphs-python/test/superclasses.py
+++ b/languages/tree-sitter-stack-graphs-python/test/superclasses.py
@@ -1,19 +1,22 @@
 class A:
+    def __init_subclass__(cls, foo):
+        pass
+
     def __init__(self):
         self.some_attr = 2
 
     def some_method(self):
         print self
 
-class B(A):
+class B(A, foo="Bar"):
     def method2(self):
         print self.some_attr, self.some_method()
-        #          ^ defined: 3
-        #                          ^ defined: 5, 14
+        #          ^ defined: 6
+        #                          ^ defined: 8, 17
 
     def some_method(self):
         pass
 
     def other(self):
         super().some_method()
-        #       ^ defined: 5
+        #       ^ defined: 8


### PR DESCRIPTION
Python supports keyword arguments in its `superclasses: (argument_list …)`, which somehow modify the superclass. The stanza capturing superclasses was erroneously capturing these keyword arguments as superclasses themselves as well, which would then cause an error upon emitting the edge:

```plaintext
0: Error executing statement edge @class.super_scope -> @superclass.output at (938, 3)
    src/stack-graphs.tsg:938:3:
    938 |   edge @class.super_scope -> @superclass.output
        |   ^
    in stanza
    src/stack-graphs.tsg:934:1:
    934 | (class_definition
        | ^
    matching (class_definition) node
    test/superclasses.py:11:1:
    11 | class B(A, foo="Bar"):
        | ^
1: Evaluating edge sink
2: Undefined scoped variable [syntax node keyword_argument (11, 12)].output
```

The fragment of the parsed Tree-sitter tree for such a superclass argument list with keyword arguments is:
```
superclasses: (argument_list
  (identifier)
  (keyword_argument …))
```

As of [v0.23.5 of the Python grammar](https://github.com/tree-sitter/tree-sitter-python/blob/v0.23.5/grammar.js#L474), the `superclasses` field is indeed an `argument_list` syntax node, which in turn can contain either an `expression` or a `keyword_argument` (among other things), and `expression` in turn can be a whole host of types of syntax nodes.

Explicitly capturing only `identifier` and `attribute` (which are dotted identifier chains like `foo.bar`) syntax nodes fixes the issue. This is possibly too strict, since technically any expression can be used here, but it likely captures the vast majority of cases out there.