### PR TITLE
Fix nested assignments in Python.

### DIFF
--- a/languages/tree-sitter-stack-graphs-python/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-python/src/stack-graphs.tsg
@@ -158,6 +158,7 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
   (generator_expression)
   (ellipsis)
   (list_splat)
+  (assignment)
 
   ; expression list
   (expression_list)

--- a/languages/tree-sitter-stack-graphs-python/test/assignments.py
+++ b/languages/tree-sitter-stack-graphs-python/test/assignments.py
@@ -1,0 +1,11 @@
+x = 42
+
+print(x)
+#     ^ defined: 1
+
+y = z = 1337
+
+print(x, y, z)
+#     ^ defined: 1
+#        ^ defined: 6
+#           ^ defined: 6


### PR DESCRIPTION
Python supports “nested” assignments like `x = y = 42`. In that particular context the nested `y = 42` assignment sort of acts like an expression, and the result is bound to the LHS of the first assignment: `x = <result>`. However, assignments are not generally considered expressions, and as such the TSSG definition does not create an `output` node for it, causing an error in the the stanza that deals with assignments:

```plaintext
0: Error executing statement edge @pattern.input -> @value.output at (1299, 3)
     src/stack-graphs.tsg:1299:3:
     1299 |   edge @pattern.input -> @value.output
          |   ^
     in stanza
     src/stack-graphs.tsg:1288:1:
     1288 | [
          | ^
     matching (assignment) node
     test/assignments.py:6:1:
     6 | y = z = 1337
       | ^
1: Evaluating edge sink
2: Undefined scoped variable [syntax node assignment (6, 5)].output
```

The fragment of the parsed Tree-sitter tree for such a nested assignment is:
```
(assignment
  left: (…)
  right: (assignment
    left: (…)
    right: (…)))
```

As of [v0.23.5 of the Python grammar](https://github.com/tree-sitter/tree-sitter-python/blob/v0.23.5/grammar.js#L850), the `right` field of an `assignment` indeed accepts another `assignment` (via `_right_hand_side`).

Simply creating an `output` node for an `assignment` fixes the issue. Copious testing reveals no negative side effects.