### PR TITLE
Fix deep property access in TypeScript.

### DIFF
--- a/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
@@ -2361,12 +2361,17 @@ if none @is_async {
 }
 
 [
-  (nested_identifier object:(_)@mod)
-  (member_expression object:[(member_expression) (identifier)]@mod)
+  (nested_identifier object:(_))
+  (member_expression object:(_))
 ]@nested {
   node @nested.expr_def
   node @nested.type_def
+}
 
+[
+  (nested_identifier object:(_)@mod)
+  (member_expression object:[(member_expression) (identifier)]@mod)
+]@nested {
   edge @nested.expr_def -> @mod.expr_def
   edge @nested.type_def -> @mod.type_def
 }
@@ -5584,10 +5589,16 @@ if none @is_acc {
 }
 
 [
+  (nested_identifier object:(_))
+  (member_expression object:(_))
+]@nested {
+  node @nested.type_ref
+}
+
+[
   (nested_identifier object:(_)@mod)
   (member_expression object:[(member_expression) (identifier)]@mod)
 ]@nested {
-  node @nested.type_ref
   edge @mod.type_ref -> @nested.type_ref
 }
 

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/access-properties.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/access-properties.ts
@@ -1,0 +1,23 @@
+{
+    let x = { y: 42 };
+    x.y;
+//    ^ defined: 2
+}
+
+{ /// Deep
+    let x = { y: { z: 42 } };
+    x.y.z;
+//      ^ defined: 8
+}
+
+{ /// Deep with parenthesized expression
+    let x = { y: { z: 42 } };
+    (x).y.z;
+//        ^ defined: 14
+}
+
+{ /// Deep with subscript expression
+    let x = [{ y: { z: 42 } }];
+    x[0].y.z;
+//         ^ defined: 20
+}


### PR DESCRIPTION
A couple of stanzas were only matching `member_expression` syntax nodes that had as their `object:` field either another `member_expression` or an `identifier` syntax node. E.g.:

```plaintext
[
  (nested_identifier object:(_)@mod)
  (member_expression object:[(member_expression) (identifier)]@mod)
]@nested {
  node @nested.expr_def
  node @nested.type_def

  edge @nested.expr_def -> @mod.expr_def
  edge @nested.type_def -> @mod.type_def
}
```
However, if that object was itself a `member_expression` the stanzas would create edges to its `expr_[dr]ef` graph nodes indiscriminately, regardless of whether it would itself be matched and thus those nodes created. In a “deep” property access involving two nested `member_expression`s and a third non-matching inner syntax node, e.g. a `parenthesized_expression`, these stanzas would cause errors, e.g.:

```plaintext
0: Error executing statement edge @nested.expr_def -> @mod.expr_def at (2377, 3)
     src/stack-graphs.tsg:2377:3:
     2377 |   edge @nested.expr_def -> @mod.expr_def
          |   ^
     in stanza
     src/stack-graphs.tsg:2371:1:
     2371 | [
          | ^
     matching (member_expression) node
     test/expressions/access-properties.ts:15:5:
     15 |     (x).y.z;
        |     ^
1: Evaluating edge sink
2: Undefined scoped variable [syntax node member_expression (15, 5)].expr_def
```

The fragment of the parsed Tree-sitter tree for such a deep property access is:
```
(member_expression ; Matching fine, `expr_[dr]ef` graph nodes created, but edge creation would fail
  object: (member_expression; Not matching, so `expr_[dr]ef` graph nodes not created
    object: (parenthesized_expression …)
    …)
  …)
```

Separating graph nodes and edges creation fixes the issue. Copious testing (on our TS test suite and on all of [microsoft/vscode](https://github.com/microsoft/vscode)) reveals no negative side effects.