### PR TITLE
Fix instantiation expr. args. in TypeScript.

### DIFF
--- a/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
@@ -2678,6 +2678,7 @@ if none @is_async {
   (ternary_expression)
   (this)
   (true)
+  (instantiation_expression)
 ; #dialect typescript
   (type_assertion)
 ; #end

--- a/languages/tree-sitter-stack-graphs-typescript/test/expressions/instantiation.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/expressions/instantiation.ts
@@ -1,0 +1,4 @@
+function foo<T extends new () => unknown>(x: T) {}
+class Bar<_T> {}
+foo(Bar<string>);
+//  ^TODO defined: 2


### PR DESCRIPTION
`instantiation_expression` syntax nodes were not included in the list of basic expressions, and thus the `@expr.lexical_scope` graph node was not being created for them. This caused an error in the stanza that deals with function arguments, e.g.:

```plaintext
0: Error executing statement edge @arg.lexical_scope -> @args.lexical_scope at (3515, 3)
     src/stack-graphs.tsg:3515:3:
     3515 |   edge @arg.lexical_scope -> @args.lexical_scope
          |   ^
     in stanza
     src/stack-graphs.tsg:3511:1:
     3511 | (arguments (_)@arg)@args {
          | ^
     matching (arguments) node
     test/test.ts:3:4:
     3 | foo(Bar<string>);
       |    ^
1: Evaluating edge source
2: Undefined scoped variable [syntax node instantiation_expression (3, 5)].lexical_scop
```

Simply including `instantiation_expression` syntax nodes in the list fixe the issue. Copious testing (on our TS test suite and on all of [microsoft/vscode](https://github.com/microsoft/vscode)) reveals no negative side effects.

Actually resolving a reference appearing in an instantiation expression as call argument does not work — I left a `TODO`.