### PR TITLE
Fix template literal types in TypeScript.

### DIFF
--- a/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
@@ -5769,7 +5769,7 @@ if none @is_acc {
 
 ; (template_literal_type)
 
-(template_literal_type (_)@inner)@type {
+(template_literal_type (template_type)@inner)@type {
   ; propagate lexical scope
   edge @inner.lexical_scope -> @type.lexical_scope
 

--- a/languages/tree-sitter-stack-graphs-typescript/test/types/template-literal-type.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/types/template-literal-type.ts
@@ -1,0 +1,3 @@
+type World = "world";
+type Greeting = `Hello, ${World}!`;
+//                       ^TODO defined: 1


### PR DESCRIPTION
The stanza dealing `template_literal_type` syntax nodes is too liberal in its capturing of inner types, causing it to capture `string_fragment` syntax nodes and fail creating edges with an error like:

```
0: Error executing statement edge @inner.lexical_scope -> @type.lexical_scope at (5775, 3)
     src/stack-graphs.tsg:5775:3:
     5775 |   edge @inner.lexical_scope -> @type.lexical_scope
          |   ^
     in stanza
     src/stack-graphs.tsg:5773:1:
     5773 | (template_literal_type (_)@inner)@type {
          | ^
     matching (template_literal_type) node
     test/types/template-literal-type.ts:2:17:
     2 | type Greeting = `Hello, ${World}!`;
       |                 ^
1: Evaluating edge source
2: Undefined scoped variable [syntax node string_fragment (2, 18)].lexical_scope
```

Restricting the inner type capture to just `template_type` syntax node fixes the issue. As of [v0.23.2](https://github.com/tree-sitter/tree-sitter-typescript/blob/v0.23.2/common/define-grammar.js#L789) of the Tree-sitter TypeScript grammar the `template_literal_type` only allows `string_fragment` and `template_type` children, so this fix should be fine. Copious testing (on this repo’s TypeScript test suite and on all of [microsoft/vscode](https://github.com/microsoft/vscode)) reveals no negative side effects.

