### PR TITLE
Fix literal subscript expressions in array patterns in TypeScript.

### DIFF
--- a/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-typescript/src/stack-graphs.tsg
@@ -4270,9 +4270,20 @@ if none @is_async {
 }
 
 (array_pattern
-  (_)@pat
+  [
+    (_)
+    (subscript_expression
+      index:(number)@subidx
+    )
+  ]@pat
 )@array_pat {
-  node @pat.comp_index
+  ; There’s a `(subscript_expression … index:(number)@…)` stanza above that also
+  ; creates the `comp_index` and its `push_symbol` attribute.
+  let is_number_subscript = (not (is-null @subidx))
+
+  if (not is_number_subscript) {
+    node @pat.comp_index
+  }
 
   ; propagate lexical scope
   edge @pat.lexical_scope -> @array_pat.lexical_scope
@@ -4280,7 +4291,9 @@ if none @is_async {
   ; propagate cotype components
   edge @pat.cotype -> @pat.comp_index
   ;
-  attr (@pat.comp_index) push_symbol = (named-child-index @pat)
+  if (not is_number_subscript) {
+    attr (@pat.comp_index) push_symbol = (named-child-index @pat)
+  }
   edge @pat.comp_index -> @array_pat.indexable
 
   ; propagate defs

--- a/languages/tree-sitter-stack-graphs-typescript/test/statements/array-pattern.ts
+++ b/languages/tree-sitter-stack-graphs-typescript/test/statements/array-pattern.ts
@@ -1,0 +1,2 @@
+const items = [13, 37];
+[items[0], items[1]] = [items[1], items[0]];


### PR DESCRIPTION
The Tree-sitter TypeScript grammar “overloads” the `subscript_expression` syntax node with use in LHS assignment patterns. This causes duplicate node & attribute creation in the stanza dealing with `array_pattern` syntax nodes, giving an error — e.g.:

```plaintext
0: Error executing statement node @pat.comp_index at (4275, 3)
   src/stack-graphs.tsg:4275:3:
   4275 |   node @pat.comp_index
        |   ^
   in stanza
   src/stack-graphs.tsg:4272:1:
   4272 | (array_pattern
        | ^
   matching (array_pattern) node
   test/statements/array-pattern.ts:2:1:
   2 | [items[0], items[1]] = [items[1], items[0]];
     | ^
 > and executing statement node @subscript_expr.comp_index at (3602, 3)
   src/stack-graphs.tsg:3602:3:
   3602 |   node @subscript_expr.comp_index
        |   ^
   in stanza
   src/stack-graphs.tsg:3598:1:
   3598 | (subscript_expression
        | ^
   matching (subscript_expression) node
   test/statements/array-pattern.ts:2:2:
   2 | [items[0], items[1]] = [items[1], items[0]];
     |  ^
1: Duplicate variable [syntax node subscript_expression (2, 2)].comp_index
```

A somewhat inelegant fix is to check whether the array pattern component is a `subscript_expression` with a `number` and if so avoid creating the node & attribute within the `array_pattern` stanza. Copious testing (on this repo’s TypeScript test suite and on all of [microsoft/vscode](https://github.com/microsoft/vscode)) reveals no negative side effects.