### PR TITLE
Fix 'mismatched_lifetime_syntaxes' warnings on nightly

### DIFF
--- a/languages/tree-sitter-stack-graphs-java/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-java/rust/lib.rs
@@ -23,7 +23,7 @@ pub fn language_configuration(cancellation_flag: &dyn CancellationFlag) -> Langu
 
 pub fn try_language_configuration(
     cancellation_flag: &dyn CancellationFlag,
-) -> Result<LanguageConfiguration, LoadError> {
+) -> Result<LanguageConfiguration, LoadError<'_>> {
     LanguageConfiguration::from_sources(
         tree_sitter_java::LANGUAGE.into(),
         Some(String::from("source.java")),

--- a/languages/tree-sitter-stack-graphs-javascript/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-javascript/rust/lib.rs
@@ -35,7 +35,7 @@ pub fn language_configuration(cancellation_flag: &dyn CancellationFlag) -> Langu
 
 pub fn try_language_configuration(
     cancellation_flag: &dyn CancellationFlag,
-) -> Result<LanguageConfiguration, LoadError> {
+) -> Result<LanguageConfiguration, LoadError<'_>> {
     let mut lc = LanguageConfiguration::from_sources(
         tree_sitter_javascript::LANGUAGE.into(),
         Some(String::from("source.js")),

--- a/languages/tree-sitter-stack-graphs-python/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-python/rust/lib.rs
@@ -27,7 +27,7 @@ pub fn language_configuration(cancellation_flag: &dyn CancellationFlag) -> Langu
 
 pub fn try_language_configuration(
     cancellation_flag: &dyn CancellationFlag,
-) -> Result<LanguageConfiguration, LoadError> {
+) -> Result<LanguageConfiguration, LoadError<'_>> {
     LanguageConfiguration::from_sources(
         tree_sitter_python::LANGUAGE.into(),
         Some(String::from("source.py")),

--- a/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
+++ b/languages/tree-sitter-stack-graphs-typescript/rust/lib.rs
@@ -42,7 +42,7 @@ pub fn language_configuration_typescript(
 
 pub fn try_language_configuration_typescript(
     cancellation_flag: &dyn CancellationFlag,
-) -> Result<LanguageConfiguration, LoadError> {
+) -> Result<LanguageConfiguration, LoadError<'_>> {
     let mut lc = LanguageConfiguration::from_sources(
         tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
         Some(String::from("source.ts")),
@@ -72,7 +72,7 @@ pub fn language_configuration_tsx(
 
 pub fn try_language_configuration_tsx(
     cancellation_flag: &dyn CancellationFlag,
-) -> Result<LanguageConfiguration, LoadError> {
+) -> Result<LanguageConfiguration, LoadError<'_>> {
     let mut lc = LanguageConfiguration::from_sources(
         tree_sitter_typescript::LANGUAGE_TSX.into(),
         Some(String::from("source.tsx")),

--- a/stack-graphs/src/graph.rs
+++ b/stack-graphs/src/graph.rs
@@ -1391,7 +1391,7 @@ impl DebugInfo {
         self.entries.push(DebugEntry { key, value });
     }
 
-    pub fn iter(&self) -> std::slice::Iter<DebugEntry> {
+    pub fn iter(&self) -> std::slice::Iter<'_, DebugEntry> {
         self.entries.iter()
     }
 }

--- a/tree-sitter-stack-graphs/src/cli/init.rs
+++ b/tree-sitter-stack-graphs/src/cli/init.rs
@@ -776,7 +776,7 @@ impl ProjectSettings<'_> {
 
             pub fn try_language_configuration(
                 cancellation_flag: &dyn CancellationFlag,
-            ) -> Result<LanguageConfiguration, LoadError> {{
+            ) -> Result<LanguageConfiguration, LoadError<'_>> {{
                 LanguageConfiguration::from_sources(
                     {}::LANGUAGE.into(),
                     Some(String::from("source.{}")),

--- a/tree-sitter-stack-graphs/src/loader.rs
+++ b/tree-sitter-stack-graphs/src/loader.rs
@@ -665,7 +665,7 @@ impl PathLoader {
         language_path: &Path,
         file_path: &Path,
         file_content: &mut dyn ContentProvider,
-    ) -> Result<Option<&SupplementedLanguage>, LoadError> {
+    ) -> Result<Option<&SupplementedLanguage>, LoadError<'_>> {
         let scope = self.scope.as_deref();
         let languages = self.loader.languages_at_path(language_path, scope)?;
         if languages.is_empty() {
@@ -777,7 +777,7 @@ impl SupplementedTsLoader {
         &mut self,
         path: &Path,
         scope: Option<&str>,
-    ) -> Result<Vec<&SupplementedLanguage>, LoadError> {
+    ) -> Result<Vec<&SupplementedLanguage>, LoadError<'_>> {
         if !self.1.contains_key(path) {
             let languages = self
                 .0


### PR DESCRIPTION
Fixes these warnings on the nightly compiler, which will probably make it to the stable toolchain eventually.

Ref: rust-lang/rust/pull/138677 #138677 Add a new mismatched-lifetime-syntaxes lint

```
warning: lifetime flowing from input to output with different syntax can be confusing
    --> stack-graphs/src/graph.rs:1394:17
     |
1394 |     pub fn iter(&self) -> std::slice::Iter<DebugEntry> {
     |                 ^^^^^     ---------------------------- the lifetime gets resolved as `'_`
     |                 |
     |                 this lifetime flows to the output
     |
     = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
     |
1394 |     pub fn iter(&self) -> std::slice::Iter<'_, DebugEntry> {
     |                                            +++
   Compiling tree-sitter-stack-graphs v0.10.0 (stack-graphs/tree-sitter-stack-graphs)
warning: lifetime flowing from input to output with different syntax can be confusing
   --> tree-sitter-stack-graphs/src/loader.rs:664:9
    |
664 |         &mut self,
    |         ^^^^^^^^^ this lifetime flows to the output
...
668 |     ) -> Result<Option<&SupplementedLanguage>, LoadError> {
    |                        ---------------------   --------- the lifetimes get resolved as `'_`
    |                        |
    |                        the lifetimes get resolved as `'_`
    |
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
668 |     ) -> Result<Option<&SupplementedLanguage>, LoadError<'_>> {
    |                                                         ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> tree-sitter-stack-graphs/src/loader.rs:777:9
    |
777 |         &mut self,
    |         ^^^^^^^^^ this lifetime flows to the output
...
780 |     ) -> Result<Vec<&SupplementedLanguage>, LoadError> {
    |                     ---------------------   --------- the lifetimes get resolved as `'_`
    |                     |
    |                     the lifetimes get resolved as `'_`
    |
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
780 |     ) -> Result<Vec<&SupplementedLanguage>, LoadError<'_>> {
    |                                                      ++++

warning: `tree-sitter-stack-graphs` (lib) generated 2 warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.87s
```
