### PR TITLE
Fix multiple Python TSG grammar scoping errors

### DIFF
--- a/languages/tree-sitter-stack-graphs-python/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-python/src/stack-graphs.tsg
@@ -960,7 +960,7 @@ inherit .parent_module
 
 (class_definition
   superclasses: (argument_list
-    (_) @superclass)) @class
+    (expression) @superclass)) @class
 {
   edge @class.super_scope -> @superclass.output
 }

--- a/languages/tree-sitter-stack-graphs-python/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-python/src/stack-graphs.tsg
@@ -881,7 +881,13 @@ inherit .parent_module
 
 [
   (parameter/typed_parameter
-    . (_) @name) @param
+    . (identifier) @name) @param
+  (parameter/typed_parameter
+    . (list_splat_pattern
+      (_) @name)) @param
+  (parameter/typed_parameter
+    . (dictionary_splat_pattern
+      (_) @name)) @param
   (parameter/list_splat_pattern
     (_) @name) @param
   (parameter/dictionary_splat_pattern

--- a/languages/tree-sitter-stack-graphs-python/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-python/src/stack-graphs.tsg
@@ -765,16 +765,10 @@ inherit .parent_module
 
 (with_clause) {}
 
-[
-  (function_definition
-    parameters: (_) @params
-    body: (_) @body
-  ) @func
-  (lambda
-    parameters: (_) @params
-    body: (_) @body
-  )@func
-] {
+(function_definition
+  parameters: (_) @params
+  body: (_) @body
+) @func {
   node @func.call
   node return_value
   node drop_scope
@@ -788,6 +782,30 @@ inherit .parent_module
   edge @params.before_scope -> JUMP_TO_SCOPE_NODE
   attr (return_value) is_exported
   let @func.function_returns = return_value
+}
+
+(lambda
+  body: (_) @body
+) @lam {
+  node @lam.call
+  node return_value
+  node @body.after_scope
+
+  edge @lam.call -> return_value
+  edge @body.before_scope -> @body.after_scope
+  edge @body.after_scope -> @lam.bottom
+  attr (@lam.call) pop_scoped_symbol = "()"
+  attr (return_value) is_exported
+  let @lam.function_returns = return_value
+}
+
+(lambda
+  parameters: (_) @params
+  body: (_) @body
+) {
+  edge @body.before_scope -> @params.after_scope
+  edge @params.before_scope -> JUMP_TO_SCOPE_NODE
+  edge @params.after_scope -> @body.after_scope
 }
 
 (function_definition

--- a/languages/tree-sitter-stack-graphs-python/src/stack-graphs.tsg
+++ b/languages/tree-sitter-stack-graphs-python/src/stack-graphs.tsg
@@ -195,6 +195,9 @@ attribute node_symbol = node            => symbol = (source-text node), source_n
   ; with item
   (with_item)
 
+  ; assignment
+  (assignment)
+
   ; pattern list
   (pattern_list)
 
@@ -1285,16 +1288,19 @@ inherit .parent_module
   edge @case.new_bindings -> @pattern.new_bindings
 }
 
-[
-  (assignment
-    left: (_) @pattern
-    right: (_) @value)
-  (with_item
-    value:
-      (as_pattern
-        (_) @value
-        alias: (as_pattern_target (_) @pattern)))
-]
+(assignment
+  left: (_) @pattern
+  right: (_) @value) @assignment
+{
+  edge @pattern.input -> @value.output
+  edge @assignment.output -> @value.output
+}
+
+(with_item
+  value:
+    (as_pattern
+      (_) @value
+      alias: (as_pattern_target (_) @pattern)))
 {
   edge @pattern.input -> @value.output
 }

--- a/languages/tree-sitter-stack-graphs-python/test/assignments.py
+++ b/languages/tree-sitter-stack-graphs-python/test/assignments.py
@@ -1,0 +1,12 @@
+exponent = exp = 3
+digits = decimals = abs(exp)
+                    #   ^ defined: 1
+
+print digits
+#     ^ defined: 2
+
+print decimals
+#     ^ defined: 2
+
+print exponent
+#     ^ defined: 1

--- a/languages/tree-sitter-stack-graphs-python/test/lambdas.py
+++ b/languages/tree-sitter-stack-graphs-python/test/lambdas.py
@@ -5,7 +5,8 @@ no_params = lambda: y
 
 sorted([1, 2, 3], key=lambda y: x + y)
                       #         ^ defined: 1
+                      #             ^ defined: 1, 6
 
 def uses_default(fn=lambda: 1):
     fn()
-#   ^ defined: 9
+#   ^ defined: 10

--- a/languages/tree-sitter-stack-graphs-python/test/lambdas.py
+++ b/languages/tree-sitter-stack-graphs-python/test/lambdas.py
@@ -1,2 +1,11 @@
-sorted([1, 2, 3], key=lambda x: x)
-#                               ^ defined: 1
+y = x = 1
+
+no_params = lambda: y
+            #       ^ defined: 1
+
+sorted([1, 2, 3], key=lambda y: x + y)
+                      #         ^ defined: 1
+
+def uses_default(fn=lambda: 1):
+    fn()
+#   ^ defined: 9

--- a/languages/tree-sitter-stack-graphs-python/test/superclasses.py
+++ b/languages/tree-sitter-stack-graphs-python/test/superclasses.py
@@ -17,3 +17,12 @@ class B(A):
     def other(self):
         super().some_method()
         #       ^ defined: 5
+
+    def __init_subclass__(cls, **kwargs):
+        cls._c = kwargs.pop("c", True)
+        super().__init_subclass__(**kwargs)
+
+class C(B, c=False):
+    def subclass(self):
+        self.some_method()
+        #    ^ defined: 5, 14

--- a/languages/tree-sitter-stack-graphs-python/test/typed_splat_params.py
+++ b/languages/tree-sitter-stack-graphs-python/test/typed_splat_params.py
@@ -1,0 +1,9 @@
+from typing import Any
+
+def build(*args: Any, some: str | None = None, **kwargs: Any):
+    print args
+    #     ^ defined: 3
+    print kwargs
+    #     ^ defined: 3
+    print some
+    #     ^ defined: 3


### PR DESCRIPTION
Address https://github.com/github/stack-graphs/issues/497

The changes enhance scope tracking, symbol resolution, and support for Python features such as typed splat parameters, subclass initialization with keyword parameters and lambdas.